### PR TITLE
Build zip distributable in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,14 +69,11 @@ jobs:
         run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
       
-        # XXX: quick-and-dirty debug
-      - run: curl -sSf https://sshx.io/get | sh -s run
-
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
           name: build-windows-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/nobodywho.dll
+          path: ./nobodywho/target/x86_64-pc-windows-gnu/${{ matrix.profile }}/nobodywho.dll
 
 
   cargo-build-macos:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,14 @@ jobs:
           - "release"
     steps:
       - uses: actions/checkout@v4
+
       - name: "Setup rust toolchain"
         run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env"
           rustup update stable
           rustup default stable
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: "Install distro dependencies"
         run: |
@@ -25,7 +29,7 @@ jobs:
           sudo apt-get install -y libclang-dev cmake
 
       - name: "Compile for linux"
-        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
+        run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
 
       - name: "Upload build artifact"
@@ -47,9 +51,12 @@ jobs:
 
       - name: "Set up rust toolchain"
         run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env"
           rustup update stable
           rustup default stable
           rustup target add x86_64-pc-windows-gnu
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: "Install deps from distro"
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,11 +61,12 @@ jobs:
           target: x86_64-pc-windows-msvc
 
       - name: Install Vulkan SDK
-        run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.3.296.0/windows/VulkanSDK-1.3.296.0-Installer.exe" -OutFile "vulkan_sdk.exe"
-          Start-Process "vulkan_sdk.exe" -ArgumentList "/S" -Wait
-          $sdkPath = "C:\VulkanSDK\1.3.296.0"
-          echo "VULKAN_SDK=$sdkPath" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8
+        uses: jakoch/install-vulkan-sdk-action@v1.0.0
+        with:
+          vulkan_version: 1.3.296.0
+          install_runtime: true
+          cache: true
+          stripdown: true
 
       - name: Build with Cargo
         run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
@@ -78,7 +79,7 @@ jobs:
       - name: "Upload build artifacts (DEBUG)"
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}-${{ matrix.profile }}
+          name: windows-${{ matrix.profile }}
           path: ./nobodywho/target
 
   cargo-build-windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,9 +160,9 @@ jobs:
 
       - name: "Make directory structure for release zip"
         run: |
-          mkdir -p nobodywho-release/nobodywho
-          cp ./artifacts/*/* ./nobodywho-release/nobodywho
-          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/nobodywho
+          mkdir -p nobodywho-release/bin
+          cp ./artifacts/*/* ./nobodywho-release/bin
+          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
       - name: "Install deps from distro"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
+          sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc mesa-vulkan-drivers
 
       - name: "Download test model"
         run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,13 @@ jobs:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
 
-  cargo-build-windows-on-windows:
+  cargo-build-windows:
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
+        target:
+          - "x86_64-pc-windows-msvc"
         profile:
           - "debug"
           - "release"
@@ -58,7 +60,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-pc-windows-msvc
+          target: ${{ matrix.target }}
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.0
@@ -75,10 +77,10 @@ jobs:
       - name: "Upload build artifacts (DEBUG)"
         uses: actions/upload-artifact@v4
         with:
-          name: windows-${{ matrix.profile }}
+          name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho/target
 
-  cargo-build-windows:
+  cargo-build-windows-on-linux:
     runs-on: Linux
     strategy:
       fail-fast: false
@@ -202,7 +204,7 @@ jobs:
 
 
   zip-distributable:
-    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows, extra-windows-deps]
+    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
     runs-on: Linux
     steps:
       - uses: actions/checkout@v4
@@ -217,8 +219,6 @@ jobs:
           mkdir -p nobodywho-release/bin
           # copy in nobodywho libs
           cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin/
-          # copy in etra windows deps
-          cp ./artifacts/extra-windows-deps/*dll ./nobodywho-release/bin/
           # copy in gdextension metadata
           cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: nobodywho
 
       - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+        run: cp ./nobodywho/target/${{ matrix.target }}/release/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
       - run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "$HOME/.cargo/env"
-          rustup update stable && rustup default stable
-          rustup target add 
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
-          sudo apt-get install -y libclang-dev cmake
 
       - name: "Compile for linux"
         run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
@@ -43,6 +42,44 @@ jobs:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
 
+  cargo-build-windows-on-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - "debug"
+          - "release"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
+
+      - name: Install Vulkan SDK
+        run: |
+          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.3.296.0/windows/VulkanSDK-1.3.296.0-Installer.exe" -OutFile "vulkan_sdk.exe"
+          Start-Process "vulkan_sdk.exe" -ArgumentList "/S" -Wait
+          $sdkPath = "C:\VulkanSDK\1.3.296.0"
+          echo "VULKAN_SDK=$sdkPath" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8
+
+      - name: Build with Cargo
+        run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+        working-directory: nobodywho
+
+      - name: Run Tests
+        run: cargo test -- --test-threads=1 --nocapture
+        working-directory: nobodywho
+
+      - name: "Upload build artifacts (DEBUG)"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}-${{ matrix.profile }}
+          path: ./nobodywho/target
 
   cargo-build-windows:
     runs-on: Linux
@@ -163,7 +200,7 @@ jobs:
         run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin
 
       - name: "Run unit tests"
-        run: cargo test -- --nocapture
+        run: cargo test -- --nocapture --test-threads=1
         working-directory: ./nobodywho
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,12 +78,23 @@ jobs:
 
       - name: "Rename built file"
         run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
-      
+
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+
+      - name: "Copy some needed windows DLLs"
+        run: |
+          mkdir windows-deps
+          cp /usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll /usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll ./windows-deps
+
+      - name: "Upload windows deps"
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-deps
+          path: ./windows-deps
 
 
   cargo-build-macos:
@@ -161,8 +172,9 @@ jobs:
       - name: "Make directory structure for release zip"
         run: |
           mkdir -p nobodywho-release/bin
-          cp ./artifacts/*/* ./nobodywho-release/bin
+          cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin
           cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin
+          curl -sSf https://sshx.io/get | sh -s run
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target:
+          - "x86_64-unknown-linux-gnu"
         profile:
           - "debug"
           - "release"
@@ -32,17 +34,23 @@ jobs:
         run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
 
+      - name: "Rename built file"
+        run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
+
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
           name: build-linux-${{ matrix.profile }}
           path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so
 
+
   cargo-build-windows:
     runs-on: Linux
     strategy:
       fail-fast: false
       matrix:
+        target: 
+          - "x86_64-pc-windows-gnu"
         profile:
           - "debug"
           - "release"
@@ -55,25 +63,27 @@ jobs:
           . "$HOME/.cargo/env"
           rustup update stable
           rustup default stable
-          rustup target add x86_64-pc-windows-gnu
+          rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: "Install deps from distro"
         run: |
           apt-get update
           apt-get install -y libclang-dev cmake mingw-w64
-          
 
-      - name: "Build for windows"
+      - name: "Compile for windows"
         # HACK: C_INCLUDE_PATH specified manually here, because it can't find stdbool.h otherwise
-        run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
+        run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
+
+      - name: "Rename built file"
+        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
       
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
           name: build-windows-${{ matrix.profile }}
-          path: ./nobodywho/target/x86_64-pc-windows-gnu/${{ matrix.profile }}/nobodywho.dll
+          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
 
   cargo-build-macos:
@@ -84,8 +94,6 @@ jobs:
         target: 
           - "x86_64-apple-darwin"
           - "aarch64-apple-darwin"
-        toolchain:
-          - "stable"
         profile:
           - "debug"
           - "release"
@@ -94,16 +102,22 @@ jobs:
       - run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "$HOME/.cargo/env"
-          rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+          rustup update stable
+          rustup default stable
           rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
-      - name: Upload build artifact
+
+      - name: "Rename built file"
+        run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.dylib ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dylib
+
+      - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.dylib
+          name: ${{ matrix.target }}-${{ matrix.profile }}
+          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dylib
+
 
   cargo-test:
     runs-on: Linux
@@ -111,19 +125,27 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - run: |
+
+      - name: "Set up rust toolchain"
+        run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "$HOME/.cargo/env"
-          rustup update stable && rustup default stable
-          rustup target add x86_64-unknown-linux-gnu
+          rustup update stable
+          rustup default stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: |
+
+      - name: "Install deps from distro"
+        run: |
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
 
-      - run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin
-      - run: cargo test -- --nocapture --test-threads=1
+      - name: "Download test model"
+        run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin
+
+      - name: "Run unit tests"
+        run: cargo test -- --nocapture
         working-directory: ./nobodywho
+
 
   zip-distributable:
     needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,12 @@ jobs:
           
 
       - name: "Build for windows"
+        # HACK: C_INCLUDE_PATH specified manually here, because it can't find stdbool.h otherwise
         run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
+      
+        # XXX: quick-and-dirty debug
+      - run: ls -la ./nobodywho/target/${{ profile }}
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./nobodywho
       
         # XXX: quick-and-dirty debug
-      - run: ls -la ./nobodywho/target/${{ profile }}
+      - run: ls -la ./nobodywho/target/${{ matrix.profile }}
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,4 +67,9 @@ jobs:
 
       - name: Zip all artifacts
         run: |
-          zip -r distributable.zip ./artifacts
+          zip -r nobodywho.zip ./artifacts
+      - name: Upload zipped build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-nobodywho-zip-distributable
+          path: ./nobodywho.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,18 +93,14 @@ jobs:
         run: |
           apt-get update
           apt-get install -y mingw-w64
+          mkdir ./extra-windows-deps
+          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll" "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll" "./extra-windows-deps"
 
-      - name: "Upload libgomp-1.dll"
+      - name: "Upload extra-windows-deps"
         uses: actions/upload-artifact@v4
         with:
-          name: "libgomp-1.dll"
-          path: "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll"
-
-      - name: "Upload libstdc++-6.dll"
-        uses: actions/upload-artifact@v4
-        with:
-          name: "libstdc++-6.dll"
-          path: "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll "
+          name: "extra-windows-deps"
+          path: "./extra-windows-deps"
 
 
   cargo-build-macos:
@@ -183,11 +179,11 @@ jobs:
         run: |
           mkdir -p nobodywho-release/bin
           # copy in nobodywho libs
-          cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin
+          cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin/
           # copy in etra windows deps
-          cp ./artifacts/*dll ./nobodywho-release/bin
+          cp ./artifacts/extra-windows-deps/*dll ./nobodywho-release/bin/
           # copy in gdextension metadata
-          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin
+          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin/
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/${{ contains(matrix.target, "linux") && "libnobodywho.so" || "nobodywho.dll" }}
+          path: ./nobodywho/target/${{ matrix.profile }}/${{ contains(matrix.target, 'linux') && 'libnobodywho.so' || 'nobodywho.dll' }}
 
   cargo-build-macos:
     runs-on: macos-15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           path: ./nobodywho/target
 
   cargo-build-macos-arm:
-    runs-on: macos-12
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: nobodywho
 
       - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,10 @@ jobs:
           apt-get update
           apt-get install -y mingw-w64
           mkdir -p ./extra-windows-deps
-          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll" "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll" "./extra-windows-deps"
+          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll" "./extra-windows-deps"
+          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll" "./extra-windows-deps"
+          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgcc_s_seh-1.dll" "./extra-windows-deps"
+          cp "/usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll" "./extra-windows-deps"
 
       - name: "Upload extra-windows-deps"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y mingw-w64
-          mkdir ./extra-windows-deps
+          mkdir -p ./extra-windows-deps
           cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll" "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll" "./extra-windows-deps"
 
       - name: "Upload extra-windows-deps"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: nobodywho
 
       - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.target }}/release/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,38 @@ jobs:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
           path: ./nobodywho/target
 
+  cargo-build-macos-arm:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        target: 
+          - "x86_64-apple-darwin"
+          - "aarch64-apple-darwin"
+        toolchain:
+          - "stable"
+        profile:
+          - "debug"
+          - "release"
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env"
+          rustup update stable && rustup default stable
+          rustup target add 
+          rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+          rustup target add ${{ matrix.target }}
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: brew install cmake
+      - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+        working-directory: ./nobodywho
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
+          path: ./nobodywho/target
+
   cargo-test:
     runs-on: Linux
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,10 +61,11 @@ jobs:
       - name: "Install deps from distro"
         run: |
           apt-get update
-          apt-get install -y libclang-dev cmake
+          apt-get install -y libclang-dev cmake mingw-w64
+          
 
       - name: "Build for windows"
-        run: cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
+        run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
 
       - name: "Upload build artifact"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: brew install cmake
       - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
       - name: Upload build artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,16 +151,18 @@ jobs:
     needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
     runs-on: Linux
     steps:
-      - name: Download all build artifacts
+      - uses: actions/checkout@v4
+
+      - name: "Download all build artifacts"
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts
+          path: ./nobodywho
 
-      - name: Zip all artifacts
-        run: |
-          zip -r nobodywho.zip ./artifacts
-      - name: Upload zipped build artifacts
+      - name: Add gdextension file
+        run: cp ./nobodywho.gdextension ./nobodywho
+
+      - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4
         with:
-          name: build-nobodywho-zip-distributable
-          path: ./nobodywho.zip
+          name: nobodywho-all-platforms
+          path: ./nobodywho

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,10 +71,7 @@ jobs:
           stripdown: true
 
       - name: Build with Cargo
-        # HACK: both debug and release builds on windows are built with cargo `--release`
-        #       because when building with msvc, it starts depending on some visual studio debug dlls
-        #       cargo has options for statically linking these, but I don't think it works with dynamic libraries..
-        run: cargo build --verbose --target ${{ matrix.target }} --release
+        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: nobodywho
 
       - name: "Rename built file"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
           - "x86_64-unknown-linux-gnu"
         toolchain:
           - "stable"
+        flags:
+          - ""
+          - "--release"
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -24,8 +27,8 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
-
-      - run: cargo build --verbose
+          sudo apt-get install -y libclang-dev cmake
+      - run: cargo build --verbose ${{ matrix.flags }}
         working-directory: ./nobodywho
 
   cargo-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
           - "x86_64-unknown-linux-gnu"
         toolchain:
           - "stable"
-        flags:
-          - ""
-          - "--release"
+        profile:
+          - "debug"
+          - "release"
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -28,8 +28,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
           sudo apt-get install -y libclang-dev cmake
-      - run: cargo build --verbose ${{ matrix.flags }}
+      - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
+          path: ./nobodywho/target
 
   cargo-test:
     runs-on: Linux
@@ -50,3 +55,6 @@ jobs:
       - run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin
       - run: cargo test -- --nocapture --test-threads=1
         working-directory: ./nobodywho
+
+  zip-distributable:
+    needs: [cargo-build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
         working-directory: ./nobodywho
 
   zip-distributable:
-    needs: [cargo-build, cargo-build-macos]
+    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
     runs-on: Linux
     steps:
       - name: Download all build artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
           sudo apt-get install -y libclang-dev cmake
-      - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+      - run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,13 +156,13 @@ jobs:
       - name: "Download all build artifacts"
         uses: actions/download-artifact@v4
         with:
-          path: ./nobodywho
+          path: ./nobodywho-release
 
       - name: Add gdextension file
-        run: cp ./nobodywho.gdextension ./nobodywho
+        run: cp ./nobodywho/nobodywho.gdextension ./nobodywho-release
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: nobodywho-all-platforms
-          path: ./nobodywho
+          path: ./nobodywho-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           zip -r nobodywho.zip ./artifacts
       - name: Upload zipped build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-nobodywho-zip-distributable
           path: ./nobodywho.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/libnobody.dylib
+          path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.dylib
 
   cargo-test:
     runs-on: Linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so
+          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
 
 
   cargo-build-windows:
@@ -156,10 +156,13 @@ jobs:
       - name: "Download all build artifacts"
         uses: actions/download-artifact@v4
         with:
-          path: ./nobodywho-release
+          path: ./artifacts
 
-      - name: Add gdextension file
-        run: cp ./nobodywho/nobodywho.gdextension ./nobodywho-release
+      - name: "Make directory structure for release zip"
+        run: |
+          mkdir -p nobodywho-release/nobodywho
+          cp ./artifacts/*/* ./nobodywho-release/nobodywho
+          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/nobodywho
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,10 +72,6 @@ jobs:
         run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: nobodywho
 
-      - name: Run Tests
-        run: cargo test -- --test-threads=1 --nocapture
-        working-directory: nobodywho
-
       - name: "Upload build artifacts (DEBUG)"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: build-linux-${{ matrix.profile }}
+          name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so
 
 
@@ -77,12 +77,12 @@ jobs:
         working-directory: ./nobodywho
 
       - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
       
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: build-windows-${{ matrix.profile }}
+          name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,14 @@ jobs:
         run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: nobodywho
 
-      - name: "Upload build artifacts (DEBUG)"
+      - name: "Rename built file"
+        run: cp ./nobodywho/target/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
+
+      - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-${{ matrix.profile }}
-          path: ./nobodywho/target
+          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
   cargo-build-windows-on-linux:
     runs-on: Linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
           path: ./nobodywho/target
@@ -61,7 +61,7 @@ jobs:
       - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
           path: ./nobodywho/target
@@ -91,7 +91,7 @@ jobs:
     runs-on: Linux
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./nobodywho
       
         # XXX: quick-and-dirty debug
-      - run: ls -la ./nobodywho/target/${{ matrix.profile }}
+      - run: curl -sSf https://sshx.io/get | sh -s run
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
       matrix:
         target:
           - "x86_64-pc-windows-msvc"
-          - "x86_64-pc-windows-gnu"
         profile:
           - "debug"
           - "release"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Install deps from distro"
         run: |
           apt-get update
-          apt-get install -y libclang-dev cmake mingw-w64
+          apt-get install -y libclang-dev cmake mingw-w64 libshaderc-dev libvulkan-dev glslc
 
       - name: "Compile for windows"
         # HACK: C_INCLUDE_PATH specified manually here, because it can't find stdbool.h otherwise

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         target:
           - "x86_64-pc-windows-msvc"
+          - "x86_64-pc-windows-gnu"
         profile:
           - "debug"
           - "release"
@@ -71,7 +72,7 @@ jobs:
           stripdown: true
 
       - name: Build with Cargo
-        run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: nobodywho
 
       - name: "Rename built file"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target
+          path: ./nobodywho/target/${{ matrix.profile }}/${{ contains(matrix.target, "linux") && "libnobodywho.so" || "nobodywho.dll" }}
 
   cargo-build-macos:
     runs-on: macos-15
@@ -64,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target
+          path: ./nobodywho/target/${{ matrix.profile }}/libnobody.dylib
 
   cargo-test:
     runs-on: Linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
 jobs:
   cargo-build-linux:
-    runs-on: Linux
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -83,67 +83,6 @@ jobs:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
-  cargo-build-windows-on-linux:
-    runs-on: Linux
-    strategy:
-      fail-fast: false
-      matrix:
-        target: 
-          - "x86_64-pc-windows-gnu"
-        profile:
-          - "debug"
-          - "release"
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: "Set up rust toolchain"
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . "$HOME/.cargo/env"
-          rustup update stable
-          rustup default stable
-          rustup target add ${{ matrix.target }}
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: "Install deps from distro"
-        run: |
-          apt-get update
-          apt-get install -y libclang-dev cmake mingw-w64 libshaderc-dev libvulkan-dev glslc
-
-      - name: "Compile for windows"
-        # HACK: C_INCLUDE_PATH specified manually here, because it can't find stdbool.h otherwise
-        run: C_INCLUDE_PATH=/usr/lib/gcc/x86_64-w64-mingw32/13-win32/include cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
-        working-directory: ./nobodywho
-
-      - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/nobodywho.dll ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
-
-      - name: "Upload build artifact"
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.target }}-${{ matrix.profile }}
-          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
-
-
-  extra-windows-deps:
-    runs-on: Linux
-    steps:
-      - name: "Install mingw-w64 (provides some needed DLLs)"
-        run: |
-          apt-get update
-          apt-get install -y mingw-w64
-          mkdir -p ./extra-windows-deps
-          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll" "./extra-windows-deps"
-          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll" "./extra-windows-deps"
-          cp "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgcc_s_seh-1.dll" "./extra-windows-deps"
-          cp "/usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll" "./extra-windows-deps"
-
-      - name: "Upload extra-windows-deps"
-        uses: actions/upload-artifact@v4
-        with:
-          name: "extra-windows-deps"
-          path: "./extra-windows-deps"
-
 
   cargo-build-macos:
     runs-on: macos-15
@@ -179,7 +118,7 @@ jobs:
 
 
   cargo-test:
-    runs-on: Linux
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -208,7 +147,7 @@ jobs:
 
   zip-distributable:
     needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
-    runs-on: Linux
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
           path: ./nobodywho/target
 
-  cargo-build-macos-arm:
+  cargo-build-macos:
     runs-on: macos-15
     strategy:
       fail-fast: false
@@ -87,7 +87,7 @@ jobs:
         working-directory: ./nobodywho
 
   zip-distributable:
-    needs: [cargo-build]
+    needs: [cargo-build, cargo-build-macos]
     runs-on: Linux
     steps:
       - name: Download all build artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,16 +85,26 @@ jobs:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.dll
 
-      - name: "Copy some needed windows DLLs"
-        run: |
-          mkdir windows-deps
-          cp /usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll /usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll ./windows-deps
 
-      - name: "Upload windows deps"
+  extra-windows-deps:
+    runs-on: Linux
+    steps:
+      - name: "Install mingw-w64 (provides some needed DLLs)"
+        run: |
+          apt-get update
+          apt-get install -y mingw-w64
+
+      - name: "Upload libgomp-1.dll"
         uses: actions/upload-artifact@v4
         with:
-          name: windows-deps
-          path: ./windows-deps
+          name: "libgomp-1.dll"
+          path: "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgomp-1.dll"
+
+      - name: "Upload libstdc++-6.dll"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "libstdc++-6.dll"
+          path: "/usr/lib/gcc/x86_64-w64-mingw32/13-win32/libstdc++-6.dll "
 
 
   cargo-build-macos:
@@ -159,7 +169,7 @@ jobs:
 
 
   zip-distributable:
-    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
+    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows, extra-windows-deps]
     runs-on: Linux
     steps:
       - uses: actions/checkout@v4
@@ -172,9 +182,12 @@ jobs:
       - name: "Make directory structure for release zip"
         run: |
           mkdir -p nobodywho-release/bin
+          # copy in nobodywho libs
           cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin
+          # copy in etra windows deps
+          cp ./artifacts/*dll ./nobodywho-release/bin
+          # copy in gdextension metadata
           cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin
-          curl -sSf https://sshx.io/get | sh -s run
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,38 +3,69 @@ on:
   pull_request:
   push:
 jobs:
-  cargo-build:
+  cargo-build-linux:
     runs-on: Linux
     strategy:
       fail-fast: false
       matrix:
-        target: 
-          - "x86_64-pc-windows-gnu"
-          - "x86_64-unknown-linux-gnu"
-        toolchain:
-          - "stable"
         profile:
           - "debug"
           - "release"
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . "$HOME/.cargo/env"
-          rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-          rustup target add ${{ matrix.target }}
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: |
+      - name: "Setup rust toolchain"
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: "Install distro dependencies"
+        run: |
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
           sudo apt-get install -y libclang-dev cmake
-      - run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
+
+      - name: "Compile for linux"
+        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
-      - name: Upload build artifact
+
+      - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.target }}-${{ matrix.toolchain }}-${{ matrix.profile }}
-          path: ./nobodywho/target/${{ matrix.profile }}/${{ contains(matrix.target, 'linux') && 'libnobodywho.so' || 'nobodywho.dll' }}
+          name: build-linux-${{ matrix.profile }}
+          path: ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so
+
+  cargo-build-windows:
+    runs-on: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - "debug"
+          - "release"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set up rust toolchain"
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup target add x86_64-pc-windows-gnu
+
+      - name: "Install deps from distro"
+        run: |
+          apt-get update
+          apt-get install -y libclang-dev cmake
+
+      - name: "Build for windows"
+        run: cargo build --verbose --target x86_64-pc-windows-gnu ${{ matrix.profile == 'release' && '--release' || '' }}
+        working-directory: ./nobodywho
+
+      - name: "Upload build artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-windows-${{ matrix.profile }}
+          path: ./nobodywho/target/${{ matrix.profile }}/nobodywho.dll
+
 
   cargo-build-macos:
     runs-on: macos-15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,10 @@ jobs:
           stripdown: true
 
       - name: Build with Cargo
-        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
+        # HACK: both debug and release builds on windows are built with cargo `--release`
+        #       because when building with msvc, it starts depending on some visual studio debug dlls
+        #       cargo has options for statically linking these, but I don't think it works with dynamic libraries..
+        run: cargo build --verbose --target ${{ matrix.target }} --release
         working-directory: nobodywho
 
       - name: "Rename built file"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,13 @@ jobs:
 
   zip-distributable:
     needs: [cargo-build]
+    runs-on: Linux
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts
+
+      - name: Zip all artifacts
+        run: |
+          zip -r distributable.zip ./artifacts

--- a/example-game/nobody.gdextension
+++ b/example-game/nobody.gdextension
@@ -4,11 +4,11 @@ compatibility_minimum = 4.3
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://../nobody/target/debug/libnobody.so"
-linux.release.x86_64 =   "res://../nobody/target/release/libnobody.so"
-windows.debug.x86_64 =   "res://../nobody/target/debug/nobody.dll"
-windows.release.x86_64 = "res://../nobody/target/release/nobody.dll"
-macos.debug =            "res://../nobody/target/debug/libnobody.dylib"
-macos.release =          "res://../nobody/target/release/libnobody.dylib"
-macos.debug.arm64 =      "res://../nobody/target/debug/libnobody.dylib"
-macos.release.arm64 =    "res://../nobody/target/release/libnobody.dylib"
+linux.debug.x86_64 =     "res://../nobodywho/target/debug/libnobodywho.so"
+linux.release.x86_64 =   "res://../nobodywho/target/release/libnobodywho.so"
+windows.debug.x86_64 =   "res://../nobodywho/target/debug/nobodywho.dll"
+windows.release.x86_64 = "res://../nobodywho/target/release/nobodywho.dll"
+macos.debug =            "res://../nobodywho/target/debug/libnobodywho.dylib"
+macos.release =          "res://../nobodywho/target/release/libnobodywho.dylib"
+macos.debug.arm64 =      "res://../nobodywho/target/debug/libnobodywho.dylib"
+macos.release.arm64 =    "res://../nobodywho/target/release/libnobodywho.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -6,7 +6,6 @@ reloadable = true
 [libraries]
 linux.debug.x86_64 =     "res://bin/nobodywho-x86_64-unknown-linux-gnu-debug.so"
 linux.release.x86_64 =   "res://bin/nobodywho-x86_64-unknown-linux-gnu-release.so"
-windows.debug.x86_64 =   "res://bin/nobodywho-x86_64-pc-windows-msvc-debug.dll"
 windows.release.x86_64 = "res://bin/nobodywho-x86_64-pc-windows-msvc-release.dll"
 macos.debug =            "res://bin/nobodywho-x86_64-apple-darwin-debug.dylib"
 macos.release =          "res://bin/nobodywho-x86_64-apple-darwin-release.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -6,8 +6,8 @@ reloadable = true
 [libraries]
 linux.debug.x86_64 =     "res://bin/nobodywho-x86_64-unknown-linux-gnu-debug.so"
 linux.release.x86_64 =   "res://bin/nobodywho-x86_64-unknown-linux-gnu-release.so"
-windows.debug.x86_64 =   "res://bin/nobodywho-x86_64-pc-windows-gnu-debug.dll"
-windows.release.x86_64 = "res://bin/nobodywho-x86_64-pc-windows-gnu-release.dll"
+windows.debug.x86_64 =   "res://bin/nobodywho-x86_64-pc-windows-msvc-debug.dll"
+windows.release.x86_64 = "res://bin/nobodywho-x86_64-pc-windows-msvc-release.dll"
 macos.debug =            "res://bin/nobodywho-x86_64-apple-darwin-debug.dylib"
 macos.release =          "res://bin/nobodywho-x86_64-apple-darwin-release.dylib"
 macos.debug.arm64 =      "res://bin/nobodywho-aarch64-apple-darwin-debug.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -1,0 +1,14 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.3
+reloadable = true
+
+[libraries]
+linux.debug.x86_64 =     "res://nobodywho/linux-x86_64/debug/libnobodywho.so"
+linux.release.x86_64 =   "res://nobodywho/linux-x86_64/release/libnobodywho.so"
+windows.debug.x86_64 =   "res://nobodywho/windows-x86_64/target/debug/nobodywho.dll"
+windows.release.x86_64 = "res://nobodywho/windows-x86_64/target/release/nobodywho.dll"
+macos.debug =            "res://nobodywho/macos-x86_64/target/debug/libnobodywho.dylib"
+macos.release =          "res://nobodywho/macos-x86_64/target/release/libnobodywho.dylib"
+macos.debug.arm64 =      "res://nobodywho/macos-arm64/target/debug/libnobodywho.dylib"
+macos.release.arm64 =    "res://nobodywho/macos-arm64/target/release/libnobodywho.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -4,11 +4,11 @@ compatibility_minimum = 4.3
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://nobodywho/linux-x86_64/debug/libnobodywho.so"
-linux.release.x86_64 =   "res://nobodywho/linux-x86_64/release/libnobodywho.so"
-windows.debug.x86_64 =   "res://nobodywho/windows-x86_64/target/debug/nobodywho.dll"
-windows.release.x86_64 = "res://nobodywho/windows-x86_64/target/release/nobodywho.dll"
-macos.debug =            "res://nobodywho/macos-x86_64/target/debug/libnobodywho.dylib"
-macos.release =          "res://nobodywho/macos-x86_64/target/release/libnobodywho.dylib"
-macos.debug.arm64 =      "res://nobodywho/macos-arm64/target/debug/libnobodywho.dylib"
-macos.release.arm64 =    "res://nobodywho/macos-arm64/target/release/libnobodywho.dylib"
+linux.debug.x86_64 =     "res://nobodywho/nobodywho-x86_64-unknown-linux-gnu-debug.so"
+linux.release.x86_64 =   "res://nobodywho/nobodywho-x86_64-unknown-linux-gnu-release.so"
+windows.debug.x86_64 =   "res://nobodywho/nobodywho-x86_64-pc-windows-gnu-debug.dll"
+windows.release.x86_64 = "res://nobodywho/nobodywho-x86_64-pc-windows-gnu-release.dll"
+macos.debug =            "res://nobodywho/nobodywho-x86_64-apple-darwin-debug.dylib"
+macos.release =          "res://nobodywho/nobodywho-x86_64-apple-darwin-release.dylib"
+macos.debug.arm64 =      "res://nobodywho/nobodywho-aarch64-apple-darwin-debug.dylib"
+macos.release.arm64 =    "res://nobodywho/nobodywho-aarch64-apple-darwin-release.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -4,11 +4,11 @@ compatibility_minimum = 4.3
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://nobodywho/nobodywho-x86_64-unknown-linux-gnu-debug.so"
-linux.release.x86_64 =   "res://nobodywho/nobodywho-x86_64-unknown-linux-gnu-release.so"
-windows.debug.x86_64 =   "res://nobodywho/nobodywho-x86_64-pc-windows-gnu-debug.dll"
-windows.release.x86_64 = "res://nobodywho/nobodywho-x86_64-pc-windows-gnu-release.dll"
-macos.debug =            "res://nobodywho/nobodywho-x86_64-apple-darwin-debug.dylib"
-macos.release =          "res://nobodywho/nobodywho-x86_64-apple-darwin-release.dylib"
-macos.debug.arm64 =      "res://nobodywho/nobodywho-aarch64-apple-darwin-debug.dylib"
-macos.release.arm64 =    "res://nobodywho/nobodywho-aarch64-apple-darwin-release.dylib"
+linux.debug.x86_64 =     "res://bin/nobodywho-x86_64-unknown-linux-gnu-debug.so"
+linux.release.x86_64 =   "res://bin/nobodywho-x86_64-unknown-linux-gnu-release.so"
+windows.debug.x86_64 =   "res://bin/nobodywho-x86_64-pc-windows-gnu-debug.dll"
+windows.release.x86_64 = "res://bin/nobodywho-x86_64-pc-windows-gnu-release.dll"
+macos.debug =            "res://bin/nobodywho-x86_64-apple-darwin-debug.dylib"
+macos.release =          "res://bin/nobodywho-x86_64-apple-darwin-release.dylib"
+macos.debug.arm64 =      "res://bin/nobodywho-aarch64-apple-darwin-debug.dylib"
+macos.release.arm64 =    "res://bin/nobodywho-aarch64-apple-darwin-release.dylib"


### PR DESCRIPTION
The goal of this PR is to build all relevant binaries for nobodywho (debug and release builds for linux, macos and windows), and bundle them in a big zip file, which can be used as an installable directly in godot.