### PR TITLE
Bag of minor fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc mesa-vulkan-drivers
 
       - name: "Download test model"
-        run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.bin
+        run: wget "https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q5_K_M.gguf" -O ./nobodywho/model.gguf
 
       - name: "Run unit tests"
         run: cargo test -- --nocapture --test-threads=1

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "nobodywho"
-version = "0.1.0"
+version = "2.0.1"
 dependencies = [
  "encoding_rs",
  "godot",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -540,12 +540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,7 +793,6 @@ dependencies = [
  "encoding_rs",
  "godot",
  "llama-cpp-2",
- "num_cpus",
  "rusqlite",
  "sqlite-vec",
  "wgpu",
@@ -813,16 +806,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -12,7 +12,6 @@ godot = { git = "https://github.com/godot-rust/gdext", branch = "master", featur
     "experimental-threads",
 ] }
 llama-cpp-2 = { version = "0.1.83" }
-num_cpus = "1.16.0"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 wgpu = "23.0.0"

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -36,7 +36,13 @@ pub fn get_model(model_path: &str) -> Arc<LlamaModel> {
     // HACK: only offload anything to the gpu if we can find a dedicated GPU
     //       there seems to be a bug which results in garbage tokens if we over-allocate an integrated GPU
     //       while using the vulkan backend. See: https://github.com/nobodywho-ooo/nobodywho-rs/pull/14
-    let model_params = LlamaModelParams::default().with_n_gpu_layers(if has_discrete_gpu() || cfg!(target_os = "macos") { 1000000 } else { 0 });
+    let model_params = LlamaModelParams::default().with_n_gpu_layers(
+        if has_discrete_gpu() || cfg!(target_os = "macos") {
+            1000000
+        } else {
+            0
+        },
+    );
     let model_params = pin!(model_params);
     Arc::new(LlamaModel::load_from_file(&LLAMA_BACKEND, model_path, &model_params).unwrap())
 }
@@ -46,7 +52,9 @@ pub fn apply_chat_template(model: Model, chat: Vec<(String, String)>) -> Result<
         .into_iter()
         .map(|t| LlamaChatMessage::new(t.0, t.1).map_err(|e| e.to_string()))
         .collect();
-    let chat_string = model.apply_chat_template(None, chat_result?, true).map_err(|e| e.to_string())?;
+    let chat_string = model
+        .apply_chat_template(None, chat_result?, true)
+        .map_err(|e| e.to_string())?;
     Ok(chat_string)
 }
 
@@ -135,8 +143,10 @@ pub fn run_worker(
 
 macro_rules! test_model_path {
     () => {
-        std::env::var("TEST_MODEL").unwrap_or("model.bin".to_string()).as_str()
-    }
+        std::env::var("TEST_MODEL")
+            .unwrap_or("model.bin".to_string())
+            .as_str()
+    };
 }
 
 #[cfg(test)]

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -144,7 +144,7 @@ pub fn run_worker(
 macro_rules! test_model_path {
     () => {
         std::env::var("TEST_MODEL")
-            .unwrap_or("model.bin".to_string())
+            .unwrap_or("model.gguf".to_string())
             .as_str()
     };
 }

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -64,7 +64,7 @@ pub fn run_worker(
     completion_tx: Sender<LLMOutput>,
     seed: u32,
 ) {
-    let n_threads = num_cpus::get() as i32;
+    let n_threads = std::thread::available_parallelism().unwrap().get() as i32;
     let ctx_params = LlamaContextParams::default()
         .with_seed(seed)
         .with_n_threads(n_threads)


### PR DESCRIPTION
- update lockfile with the new 2.0.1 version number
- remove `num_cpus` dependency
- call the test model "model.gguf", not "model.bin"
- run `cargo fmt`

FWIW, clippy still warns two errors:

1. the `test_model_path` macro is "unused. That is- it is only used in the unit tests.
2.  `transmute` is used without annotations in db.rs (I really don't understand any of this)