### PR TITLE
Fix: add break to avoid infinite loop

### DIFF
--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -114,6 +114,8 @@ macro_rules! emit_tokens {
                         godot_error!("Unexpected: Model channel disconnected");
                     }
                 }
+            } else {
+                break;
             }
         }
     }};


### PR DESCRIPTION
Whoops...

This bug was already found (and fixed) on the embeddings branch, but not on `main`.

Let's just get this out there quick