### PR TITLE
refactor: #28 build output folder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,12 +197,12 @@ jobs:
 
       - name: "Make directory structure for release zip"
         run: |
-          mkdir -p nobodywho-release/bin
+          mkdir -p nobodywho-release/bin/addons/nobodywho
           # copy in nobodywho libs
-          cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin/
+          cp ./artifacts/*/*nobodywho* ./nobodywho-release/bin/addons/nobodywho/
           # copy in gdextension metadata
-          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin/
-          cp ./assets/icon.svg ./nobodywho-release/bin/
+          cp ./nobodywho/nobodywho.gdextension ./nobodywho-release/bin/addons/nobodywho/
+          cp ./assets/icon.svg ./nobodywho-release/bin/addons/nobodywho/
 
       - name: "Upload zipped build artifacts"
         uses: actions/upload-artifact@v4

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -4,16 +4,16 @@ compatibility_minimum = 4.3
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://bin/nobodywho-x86_64-unknown-linux-gnu-debug.so"
-linux.release.x86_64 =   "res://bin/nobodywho-x86_64-unknown-linux-gnu-release.so"
-windows.debug.x86_64 =   "res://bin/nobodywho-x86_64-pc-windows-msvc-release.dll"
-windows.release.x86_64 = "res://bin/nobodywho-x86_64-pc-windows-msvc-release.dll"
-macos.debug =            "res://bin/nobodywho-x86_64-apple-darwin-debug.dylib"
-macos.release =          "res://bin/nobodywho-x86_64-apple-darwin-release.dylib"
-macos.debug.arm64 =      "res://bin/nobodywho-aarch64-apple-darwin-debug.dylib"
-macos.release.arm64 =    "res://bin/nobodywho-aarch64-apple-darwin-release.dylib"
+linux.debug.x86_64 =     "res://addons/nobodywho/nobodywho-x86_64-unknown-linux-gnu-debug.so"
+linux.release.x86_64 =   "res://addons/nobodywho/nobodywho-x86_64-unknown-linux-gnu-release.so"
+windows.debug.x86_64 =   "res://addons/nobodywho/nobodywho-x86_64-pc-windows-msvc-release.dll"
+windows.release.x86_64 = "res://addons/nobodywho/nobodywho-x86_64-pc-windows-msvc-release.dll"
+macos.debug =            "res://addons/nobodywho/nobodywho-x86_64-apple-darwin-debug.dylib"
+macos.release =          "res://addons/nobodywho/nobodywho-x86_64-apple-darwin-release.dylib"
+macos.debug.arm64 =      "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-debug.dylib"
+macos.release.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-release.dylib"
 
 [icons]
-NobodyWhoModel =            "res://bin/icon.svg"
-NobodyWhoPromptChat =       "res://bin/icon.svg"
-NobodyWhoPromptCompletion = "res://bin/icon.svg"
+NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
+NobodyWhoPromptChat =       "res://addons/nobodywho/icon.svg"
+NobodyWhoPromptCompletion = "res://addons/nobodywho/icon.svg"


### PR DESCRIPTION
- Follows the convention of putting plugins in the Godot /addons folder
- The files are not added to the root directory when using Godot default plugin installation

Closes #28 