### PR TITLE
Add support for rendering chat templates through `minijinja`

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -129,9 +129,9 @@ checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -268,12 +268,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "godot"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "godot-bindings"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "gdextension-api",
 ]
@@ -407,12 +407,12 @@ dependencies = [
 [[package]]
 name = "godot-cell"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 
 [[package]]
 name = "godot-codegen"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "godot-core"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "godot-ffi"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "gensym",
  "godot-bindings",
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "godot-macros"
 version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
+source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
 dependencies = [
  "godot-bindings",
  "proc-macro2",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -572,6 +572,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni-sys"
@@ -590,10 +596,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -628,15 +635,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -667,9 +674,8 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3de97289f2e60b779a241b029672faded0bf1b5524316cc36d4fba218982ce6"
+version = "0.1.86"
+source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#333683bc5b5d39c77a8e505738c5c6bd0c317bd0"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -679,9 +685,8 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6088e6d4577e6e0abb686c8359f6ca2ccde33fc1c8fd4438fee7fc48ce9a28"
+version = "0.1.86"
+source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#333683bc5b5d39c77a8e505738c5c6bd0c317bd0"
 dependencies = [
  "bindgen",
  "cc",
@@ -721,6 +726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +744,18 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c37e1b517d1dcd0e51dc36c4567b9d5a29262b3ec8da6cb5d35e27a8fb529b5"
+dependencies = [
+ "memo-map",
+ "self_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -793,9 +816,11 @@ dependencies = [
  "encoding_rs",
  "godot",
  "llama-cpp-2",
+ "minijinja",
  "rusqlite",
+ "serde",
  "sqlite-vec",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "wgpu",
 ]
 
@@ -995,10 +1020,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "shlex"
@@ -1047,9 +1116,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1076,11 +1145,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.4",
 ]
 
 [[package]]
@@ -1096,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1193,9 +1262,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1204,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1219,21 +1288,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1241,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1254,15 +1324,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1543,9 +1613,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
+checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "zerocopy"

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -11,11 +11,15 @@ encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
 ] }
-llama-cpp-2 = { version = "0.1.84" }
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 thiserror = "2.0.3"
+minijinja = { version = "2.5.0", features = ["builtins", "json", "loader"] }
+serde = { version = "1.0.215", features = ["derive"] }
 wgpu = "23.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { version = "0.1.84", features = ["vulkan"] }
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", features = [
+    "vulkan",
+] }

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -16,4 +16,3 @@ macos.release.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-
 [icons]
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
 NobodyWhoPromptChat =       "res://addons/nobodywho/icon.svg"
-NobodyWhoPromptCompletion = "res://addons/nobodywho/icon.svg"

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -55,11 +55,8 @@ impl ChatState {
         }
     }
 
-    pub fn add_message(&mut self, role: &str, content: &str) {
-        self.messages.push(Message {
-            role: role.to_string(),
-            content: content.to_string(),
-        });
+    pub fn add_message(&mut self, role: String, content: String) {
+        self.messages.push(Message { role, content });
     }
 
     fn render(&mut self) -> Result<String, minijinja::Error> {

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -32,7 +32,7 @@ pub struct ChatState {
 /// given a chat history where the first two messages are from system and user
 /// return a history where the first message is from user, and contains the system prompt as well.
 /// (this is what llama.cpp does for the gemma template too)
-fn concat_system_and_first_user_messages(messages: &Vec<Message>) -> Result<Vec<Message>, minijinja::Error> {
+fn concat_system_and_first_user_messages(messages: &[Message]) -> Result<Vec<Message>, minijinja::Error> {
     if messages.len() < 2 || messages[0].role != "system" || messages[1].role != "user" {
         // HACK: this should probably be a custom ChatStateError, and nont a minijinja error
         //       but this was quick and easy rn, and we "abuse" the minijinja errors for

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -74,9 +74,14 @@ impl ChatState {
             Ok(rendered) => Ok(rendered),
             Err(err) => match err.kind() {
                 minijinja::ErrorKind::InvalidOperation => {
-                    // concat the first two messages and try again
-                    self.messages = concat_system_and_first_user_messages(&self.messages);
-                    self.render()
+                    if err.to_string().contains("System role not supported") {
+                        // this is the error message we get when rendering the gemma2
+                        // concat the first two messages and try again
+                        self.messages = concat_system_and_first_user_messages(&self.messages);
+                        self.render()
+                    } else {
+                        Err(err)
+                    }
                 },
                 _ => Err(err)
             },

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -5,9 +5,15 @@ use serde::{self, Serialize};
 
 static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| {
     let mut env = Environment::new();
-    env.add_function("raise_exception", |msg: String| -> Result<(), minijinja::Error> {
-        Err(minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, msg))
-    });
+    env.add_function(
+        "raise_exception",
+        |msg: String| -> Result<(), minijinja::Error> {
+            Err(minijinja::Error::new(
+                minijinja::ErrorKind::InvalidOperation,
+                msg,
+            ))
+        },
+    );
     env
 });
 
@@ -39,7 +45,7 @@ impl ChatState {
         });
     }
 
-    pub fn render_chat(&self) -> Result<String, minijinja::Error> {
+    pub fn render_diff(&mut self) -> Result<String, minijinja::Error> {
         let tmpl = MINIJINJA_ENV.template_from_str(&self.chat_template)?;
 
         let ctx = context! {
@@ -49,6 +55,10 @@ impl ChatState {
 
         let text = tmpl.render(ctx)?;
 
-        Ok(text)
+        let diff = text[self.length..].to_string();
+
+        self.length = text.len();
+
+        Ok(diff)
     }
 }

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -3,7 +3,13 @@ use std::sync::LazyLock;
 use minijinja::{context, Environment};
 use serde::{self, Serialize};
 
-static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| Environment::new());
+static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| {
+    let mut env = Environment::new();
+    env.add_function("raise_exception", |msg: String| -> Result<(), minijinja::Error> {
+        Err(minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, msg))
+    });
+    env
+});
 
 #[derive(Serialize)]
 pub struct Message {

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -33,18 +33,16 @@ impl ChatState {
         });
     }
 
-    pub fn render_chat(&self) -> String {
-        let tmpl = MINIJINJA_ENV
-            .template_from_str(&self.chat_template)
-            .unwrap();
+    pub fn render_chat(&self) -> Result<String, minijinja::Error> {
+        let tmpl = MINIJINJA_ENV.template_from_str(&self.chat_template)?;
 
         let ctx = context! {
             messages => &self.messages,
             add_generation_prompt => true,
         };
 
-        let text = tmpl.render(ctx).unwrap();
+        let text = tmpl.render(ctx)?;
 
-        text
+        Ok(text)
     }
 }

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -1,0 +1,50 @@
+use std::sync::LazyLock;
+
+use minijinja::{context, Environment};
+use serde::{self, Serialize};
+
+static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| Environment::new());
+
+#[derive(Serialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+pub struct ChatState {
+    messages: Vec<Message>,
+    chat_template: String,
+    length: usize,
+}
+
+impl ChatState {
+    pub fn new(chat_template: String) -> Self {
+        Self {
+            messages: Vec::new(),
+            chat_template,
+            length: 0,
+        }
+    }
+
+    pub fn add_message(&mut self, role: &str, content: &str) {
+        self.messages.push(Message {
+            role: role.to_string(),
+            content: content.to_string(),
+        });
+    }
+
+    pub fn render_chat(&self) -> String {
+        let tmpl = MINIJINJA_ENV
+            .template_from_str(&self.chat_template)
+            .unwrap();
+
+        let ctx = context! {
+            messages => &self.messages,
+            add_generation_prompt => true,
+        };
+
+        let text = tmpl.render(ctx).unwrap();
+
+        text
+    }
+}

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -240,9 +240,9 @@ impl NobodyWhoPromptChat {
         }
     }
 
-    fn send_message(&mut self, role: String, content: String) {
+    fn send_message(&mut self, content: String) {
         if let Some(tx) = self.prompt_tx.as_ref() {
-            tx.send((role, content)).unwrap();
+            tx.send(content).unwrap();
         } else {
             godot_error!("Model not initialized. Call `run` first");
         }
@@ -250,7 +250,7 @@ impl NobodyWhoPromptChat {
 
     #[func]
     fn say(&mut self, message: String) {
-        self.send_message("user".into(), message);
+        self.send_message(message);
     }
 
     #[signal]

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -142,7 +142,7 @@ struct NobodyWhoPromptChat {
     #[export]
     context_length: u32,
 
-    prompt_tx: Option<Sender<(String, String)>>,
+    prompt_tx: Option<Sender<String>>,
     completion_rx: Option<Receiver<llm::LLMOutput>>,
 
     base: Base<Node>,

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -1,9 +1,10 @@
+mod chat_state;
 mod db;
 mod llm;
 
 use godot::classes::{INode, ProjectSettings};
 use godot::prelude::*;
-use llm::run_worker;
+use llm::{run_worker, SamplerConfig};
 use std::sync::mpsc::{Receiver, Sender};
 
 struct NobodyWhoExtension;
@@ -125,145 +126,6 @@ impl NobodyWhoModel {
     }
 }
 
-macro_rules! run_model {
-    ($self:ident) => {{
-        // simple closure that loads the model and returns a result
-        // TODO: why does run_result need to be mutable?
-        let mut run_result = || -> Result<(), String> {
-            // get NobodyWhoModel
-            let gd_model_node = $self.model_node.as_mut().ok_or("Model node is not set.")?;
-            let mut nobody_model = gd_model_node.bind_mut();
-            let model: llm::Model = nobody_model.get_model().map_err(|e| e.to_string())?;
-
-            // get NobodyWhoSampler
-            let sampler_config: llm::SamplerConfig =
-                if let Some(gd_sampler) = $self.sampler.as_mut() {
-                    let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
-                    nobody_sampler.get_sampler_config()
-                } else {
-                    llm::DEFAULT_SAMPLER_CONFIG
-                };
-
-            // make and store channels for communicating with the llm worker thread
-            let (prompt_tx, prompt_rx) = std::sync::mpsc::channel::<String>();
-            let (completion_tx, completion_rx) = std::sync::mpsc::channel::<llm::LLMOutput>();
-            $self.prompt_tx = Some(prompt_tx);
-            $self.completion_rx = Some(completion_rx);
-
-            // start the llm worker
-            let n_ctx = $self.context_length;
-            std::thread::spawn(move || {
-                run_worker(model, prompt_rx, completion_tx, sampler_config, n_ctx);
-            });
-
-            Ok(())
-        };
-
-        // run it and show error in godot if it fails
-        if let Err(msg) = run_result() {
-            godot_error!("Error running model: {}", msg);
-        }
-    }};
-}
-
-macro_rules! send_text {
-    ($self:ident, $text:expr) => {
-        if let Some(tx) = $self.prompt_tx.as_ref() {
-            tx.send($text).unwrap();
-        } else {
-            godot_error!("Model not initialized. Call `run` first");
-        }
-    };
-}
-
-macro_rules! emit_tokens {
-    ($self:ident) => {{
-        loop {
-            if let Some(rx) = $self.completion_rx.as_ref() {
-                match rx.try_recv() {
-                    Ok(llm::LLMOutput::Token(token)) => {
-                        $self
-                            .base_mut()
-                            .emit_signal("completion_updated", &[Variant::from(token)]);
-                    }
-                    Ok(llm::LLMOutput::Done) => {
-                        $self.base_mut().emit_signal("completion_finished", &[]);
-                    }
-                    Ok(llm::LLMOutput::FatalErr(msg)) => {
-                        godot_error!("Model worker crashed: {msg}");
-                    }
-                    Err(std::sync::mpsc::TryRecvError::Empty) => {
-                        break;
-                    }
-                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                        godot_error!("Model output channel died. Did the LLM worker crash?");
-                        // set hanging channel to None
-                        // this prevents repeating the dead channel error message foreve
-                        $self.completion_rx = None;
-                    }
-                }
-            } else {
-                break;
-            }
-        }
-    }};
-}
-
-#[derive(GodotClass)]
-#[class(base=Node)]
-struct NobodyWhoPromptCompletion {
-    #[export]
-    model_node: Option<Gd<NobodyWhoModel>>,
-
-    #[export]
-    sampler: Option<Gd<NobodyWhoSampler>>,
-
-    #[export]
-    context_length: u32,
-
-    completion_rx: Option<Receiver<llm::LLMOutput>>,
-    prompt_tx: Option<Sender<String>>,
-
-    base: Base<Node>,
-}
-
-#[godot_api]
-impl INode for NobodyWhoPromptCompletion {
-    fn init(base: Base<Node>) -> Self {
-        Self {
-            model_node: None,
-            sampler: None,
-            context_length: 4096,
-            completion_rx: None,
-            prompt_tx: None,
-            base,
-        }
-    }
-
-    fn physics_process(&mut self, _delta: f64) {
-        emit_tokens!(self)
-    }
-}
-
-#[godot_api]
-impl NobodyWhoPromptCompletion {
-    #[func]
-    fn run(&mut self) {
-        run_model!(self)
-    }
-
-    #[func]
-    fn prompt(&mut self, prompt: String) {
-        send_text!(self, prompt)
-    }
-
-    #[signal]
-    fn completion_updated();
-
-    #[signal]
-    fn completion_finished();
-}
-
 #[derive(GodotClass)]
 #[class(base=Node)]
 struct NobodyWhoPromptChat {
@@ -276,12 +138,11 @@ struct NobodyWhoPromptChat {
     #[export]
     #[var(hint = MULTILINE_TEXT)]
     prompt: GString,
-    sent_prompt: bool,
 
     #[export]
     context_length: u32,
 
-    prompt_tx: Option<Sender<String>>,
+    prompt_tx: Option<Sender<(String, String)>>,
     completion_rx: Option<Receiver<llm::LLMOutput>>,
 
     base: Base<Node>,
@@ -294,7 +155,6 @@ impl INode for NobodyWhoPromptChat {
             model_node: None,
             sampler: None,
             prompt: "".into(),
-            sent_prompt: false,
             context_length: 4096,
             prompt_tx: None,
             completion_rx: None,
@@ -303,47 +163,96 @@ impl INode for NobodyWhoPromptChat {
     }
 
     fn physics_process(&mut self, _delta: f64) {
-        emit_tokens!(self)
+        loop {
+            if let Some(rx) = self.completion_rx.as_ref() {
+                match rx.try_recv() {
+                    Ok(llm::LLMOutput::Token(token)) => {
+                        self.base_mut()
+                            .emit_signal("completion_updated", &[Variant::from(token)]);
+                    }
+                    Ok(llm::LLMOutput::Done) => {
+                        self.base_mut().emit_signal("completion_finished", &[]);
+                    }
+                    Ok(llm::LLMOutput::FatalErr(msg)) => {
+                        godot_error!("Model worker crashed: {msg}");
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {
+                        break;
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        godot_error!("Model output channel died. Did the LLM worker crash?");
+                        // set hanging channel to None
+                        // this prevents repeating the dead channel error message foreve
+                        self.completion_rx = None;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
     }
 }
 
 #[godot_api]
 impl NobodyWhoPromptChat {
+    fn get_model(&mut self) -> Option<llm::Model> {
+        let gd_model_node = self.model_node.as_mut()?;
+        let mut nobody_model = gd_model_node.bind_mut();
+        let model: llm::Model = nobody_model.get_model().ok()?;
+
+        Some(model)
+    }
+
+    fn get_sampler_config(&mut self) -> SamplerConfig {
+        if let Some(gd_sampler) = self.sampler.as_mut() {
+            let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
+            nobody_sampler.get_sampler_config()
+        } else {
+            llm::DEFAULT_SAMPLER_CONFIG
+        }
+    }
+
     #[func]
     fn run(&mut self) {
-        run_model!(self)
+        let mut result = || -> Result<(), String> {
+            let model = self.get_model().ok_or("Model not loaded")?;
+            let sampler_config = self.get_sampler_config();
+
+            // make and store channels for communicating with the llm worker thread
+            let (prompt_tx, prompt_rx) = std::sync::mpsc::channel();
+            let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+            self.prompt_tx = Some(prompt_tx);
+            self.completion_rx = Some(completion_rx);
+
+            // start the llm worker
+            let n_ctx = self.context_length;
+            std::thread::spawn(move || {
+                run_worker(model, prompt_rx, completion_tx, sampler_config, n_ctx);
+            });
+
+            // Send the system prompt to the worker
+            self.send_message("system".into(), self.prompt.to_string());
+
+            Ok(())
+        };
+
+        // run it and show error in godot if it fails
+        if let Err(msg) = result() {
+            godot_error!("Error running model: {}", msg);
+        }
+    }
+
+    fn send_message(&mut self, role: String, content: String) {
+        if let Some(tx) = self.prompt_tx.as_ref() {
+            tx.send((role, content)).unwrap();
+        } else {
+            godot_error!("Model not initialized. Call `run` first");
+        }
     }
 
     #[func]
     fn say(&mut self, message: String) {
-        // simple closure that returns Err(String) if something fails
-        let say_result = || -> Result<(), String> {
-            // get the model instance
-            let gd_model_node = self.model_node.as_mut().ok_or(
-                "No model node provided. Remember to set a model node on NobodyWhoPromptChat.",
-            )?;
-            let nobody_model: GdRef<NobodyWhoModel> = gd_model_node.bind();
-            let model: llm::Model = nobody_model
-                .model
-                .clone()
-                .ok_or("Could not access LlamaModel from model node.".to_string())?;
-
-            // make a chat string
-            let mut messages: Vec<(String, String)> = vec![];
-            if !self.sent_prompt {
-                messages.push(("system".into(), (&self.prompt).into()));
-                self.sent_prompt = true;
-            }
-            messages.push(("user".to_string(), message));
-            let text: String = llm::apply_chat_template(model, messages)?;
-            send_text!(self, text);
-            Ok::<(), String>(())
-        };
-
-        // run it and show the error in godot if it fails
-        if let Err(msg) = say_result() {
-            godot_error!("Error sending chat message to model worker: {msg}");
-        }
+        self.send_message("user".into(), message);
     }
 
     #[signal]

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -226,12 +226,10 @@ impl NobodyWhoPromptChat {
 
             // start the llm worker
             let n_ctx = self.context_length;
+            let system_prompt = self.prompt.to_string();
             std::thread::spawn(move || {
-                run_worker(model, prompt_rx, completion_tx, sampler_config, n_ctx);
+                run_worker(model, prompt_rx, completion_tx, sampler_config, n_ctx, system_prompt);
             });
-
-            // Send the system prompt to the worker
-            self.send_message("system".into(), self.prompt.to_string());
 
             Ok(())
         };

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -170,8 +170,8 @@ impl INode for NobodyWhoPromptChat {
                         self.base_mut()
                             .emit_signal("completion_updated", &[Variant::from(token)]);
                     }
-                    Ok(llm::LLMOutput::Done) => {
-                        self.base_mut().emit_signal("completion_finished", &[]);
+                    Ok(llm::LLMOutput::Done(response)) => {
+                        self.base_mut().emit_signal("completion_finished", &[Variant::from(response)]);
                     }
                     Ok(llm::LLMOutput::FatalErr(msg)) => {
                         godot_error!("Model worker crashed: {msg}");

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -188,7 +188,7 @@ fn run_worker_result(
     // according to llama.cpp source code, the longest known template is about 1200bytes
     let chat_template = model.get_chat_template(4_000)?;
     let mut chat_state = chat_state::ChatState::new(chat_template);
-    chat_state.add_message("system".to_string(), &system_prompt);
+    chat_state.add_message("system".to_string(), system_prompt);
 
     let n_threads = std::thread::available_parallelism()?.get() as i32;
     let n_ctx: u32 = std::cmp::min(n_ctx, model.n_ctx_train());
@@ -204,7 +204,7 @@ fn run_worker_result(
     let mut sampler = make_sampler(&model, sampler_config)?;
 
     while let Ok(content) = message_rx.recv() {
-        chat_state.add_message("user".to_string(), &content);
+        chat_state.add_message("user".to_string(), content);
 
         let diff = chat_state.render_diff()?;
 
@@ -249,7 +249,7 @@ fn run_worker_result(
                     chat_state.add_message("assistant".to_string(), response.clone());
 
                     completion_tx
-                        .send(LLMOutput::Done(response))
+                        .send(LLMOutput::Done(response.clone()))
                         .map_err(|_| WorkerError::SendError)?;
 
                     response.clear();

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -202,7 +202,7 @@ fn run_worker_result(
     while let Ok((role, content)) = message_rx.recv() {
         chat_state.add_message(&role, &content);
 
-        let diff = chat_state.render_chat()?;
+        let diff = chat_state.render_diff()?;
 
         let tokens_list = ctx.model.str_to_token(&diff, AddBos::Always)?;
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -66,8 +66,8 @@ pub fn get_model(
         LlamaModel::load_from_file(&LLAMA_BACKEND, model_path, &model_params).map_err(|e| {
             LoadModelError::InvalidModel(format!(
                 "Bad model path: {} - Llama.cpp error: {}",
-                model_path.to_string(),
-                e.to_string()
+                model_path,
+                e
             ))
         })?;
     Ok(Arc::new(model))

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -183,6 +183,7 @@ fn run_worker_result(
     sampler_config: SamplerConfig,
     n_ctx: u32,
 ) -> Result<(), WorkerError> {
+    // according to llama.cpp source code, the longest known template is about 1200bytes
     let chat_template = model.get_chat_template(4_000)?;
     let mut chat_state = chat_state::ChatState::new(chat_template);
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -19,7 +19,7 @@ static LLAMA_BACKEND: LazyLock<LlamaBackend> =
 pub enum LLMOutput {
     Token(String),
     FatalErr(WorkerError),
-    Done,
+    Done(String),
 }
 
 pub type Model = Arc<LlamaModel>;
@@ -245,7 +245,7 @@ fn run_worker_result(
                     chat_state.add_message("assistant", &response);
 
                     completion_tx
-                        .send(LLMOutput::Done)
+                        .send(LLMOutput::Done(response))
                         .map_err(|_| WorkerError::SendError)?;
                     break;
                 }

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -188,7 +188,7 @@ fn run_worker_result(
     // according to llama.cpp source code, the longest known template is about 1200bytes
     let chat_template = model.get_chat_template(4_000)?;
     let mut chat_state = chat_state::ChatState::new(chat_template);
-    chat_state.add_message("system", &system_prompt);
+    chat_state.add_message("system".to_string(), &system_prompt);
 
     let n_threads = std::thread::available_parallelism()?.get() as i32;
     let n_ctx: u32 = std::cmp::min(n_ctx, model.n_ctx_train());
@@ -204,7 +204,7 @@ fn run_worker_result(
     let mut sampler = make_sampler(&model, sampler_config)?;
 
     while let Ok(content) = message_rx.recv() {
-        chat_state.add_message("user", &content);
+        chat_state.add_message("user".to_string(), &content);
 
         let diff = chat_state.render_diff()?;
 
@@ -246,11 +246,12 @@ fn run_worker_result(
                     batch.clear();
                     batch.add(new_token_id, n_cur, &[0], true)?;
 
-                    chat_state.add_message("assistant", &response);
+                    chat_state.add_message("assistant".to_string(), response.clone());
 
                     completion_tx
                         .send(LLMOutput::Done(response))
                         .map_err(|_| WorkerError::SendError)?;
+
                     break;
                 }
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -287,24 +287,22 @@ fn run_worker_result(
     unreachable!();
 }
 
-macro_rules! test_model_path {
-    () => {
-        std::env::var("TEST_MODEL")
-            .unwrap_or("model.gguf".to_string())
-            .as_str()
-    };
-}
-
 #[cfg(test)]
 mod tests {
-    use llama_cpp_2::model::LlamaChatMessage;
-
     use super::*;
+
+    macro_rules! test_model_path {
+        () => {
+            std::env::var("TEST_MODEL")
+                .unwrap_or("model.gguf".to_string())
+                .as_str()
+        };
+    }
+
 
     #[test]
     fn test_chat_completion() {
         let model = get_model(test_model_path!(), true).unwrap();
-        let model_copy = model.clone();
 
         let (prompt_tx, prompt_rx) = std::sync::mpsc::channel();
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
@@ -314,7 +312,7 @@ mod tests {
 
         prompt_tx.send("What is the capital of Denmark?".to_string()).unwrap();
 
-        let mut result: String = "".to_string();
+        let result: String;
         loop {
             match completion_rx.recv() {
                 Ok(LLMOutput::Token(_)) => {},
@@ -325,9 +323,13 @@ mod tests {
                 _ => unreachable!(),
             }
         }
+        assert!(
+            result.contains("Copenhagen"),
+            "Expected completion to contain 'Copenhagen', got: {result}"
+        );
 
         prompt_tx.send("What language to they speak there?".to_string()).unwrap();
-        let mut result: String = "".to_string();
+        let result: String;
         loop {
             match completion_rx.recv() {
                 Ok(LLMOutput::Token(_)) => {},

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -252,6 +252,7 @@ fn run_worker_result(
                         .send(LLMOutput::Done(response))
                         .map_err(|_| WorkerError::SendError)?;
 
+                    response.clear();
                     break;
                 }
 


### PR DESCRIPTION
This PR introduces rendering chats with model (or user specified) chat templates in `jinja2` format.

While `llama.cpp` supports rudimentary chat template support, most models take tool calling into account through the chat template, through the `tools` and `tool_calls` properties, which are not supported by `llama.cpp`.

This is part of the larger goal, which is abstracting tool calling across local models.

The PR introduces as breaking change, as the `NobodyWhoCompletionNode` is removed.
