### PR TITLE
Custom sampler resource

### DIFF
--- a/example-game/player.tscn
+++ b/example-game/player.tscn
@@ -1,15 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://breb76ad7m6xn"]
+[gd_scene load_steps=4 format=3 uid="uid://breb76ad7m6xn"]
 
 [ext_resource type="Script" path="res://nobody_who_db.gd" id="2_qeomc"]
 [ext_resource type="Script" path="res://nobody_who_prompt_chat.gd" id="2_r1dk7"]
 
+[sub_resource type="NobodyWhoSampler" id="NobodyWhoSampler_djbpq"]
+
 [node name="NobodyWhoPromptCompletion" type="Node2D"]
 
 [node name="NobodyWhoModel" type="NobodyWhoModel" parent="."]
-model_path = "res://Llama-3.2-1B-Instruct-f16.gguf"
+model_path = "res://model.gguf"
 
 [node name="NobodyWhoPromptChat" type="NobodyWhoPromptChat" parent="." node_paths=PackedStringArray("model_node")]
 model_node = NodePath("../NobodyWhoModel")
+sampler = SubResource("NobodyWhoSampler_djbpq")
 prompt = "You are a powerful wizard who always tries to cast spells to turn people into frogs.
 You are speaking to bob, the adventurer.
 Bob the Adventurer's full name is \"Robert Mortimer Vanderfuck\""

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
@@ -123,15 +123,15 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
@@ -233,9 +233,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -273,7 +273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -317,8 +317,8 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "gdextension-api"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/godot4-prebuilt?branch=releases#6d902e8a6060007f4ab94cd78882247ae2558d96"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/godot4-prebuilt?branch=releases#53fa4a856d93ac01d87deb8f57c6851179dfacec"
 
 [[package]]
 name = "gensym"
@@ -389,8 +389,8 @@ dependencies = [
 
 [[package]]
 name = "godot"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -398,21 +398,21 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 
 [[package]]
 name = "godot-codegen"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -424,8 +424,8 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -436,8 +436,8 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "gensym",
  "godot-bindings",
@@ -448,8 +448,8 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.1.3"
-source = "git+https://github.com/godot-rust/gdext?branch=master#7634fe769d1fcb66209586f0b6c06aac40978253"
+version = "0.2.0"
+source = "git+https://github.com/godot-rust/gdext?branch=master#c6b8b0e12414a69eb29ec512a313b4f5817e37de"
 dependencies = [
  "godot-bindings",
  "proc-macro2",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -551,7 +551,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -628,9 +628,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "libloading"
@@ -667,9 +667,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a21c5168551f726d59cb1df662dd6d7d16ee5e446da905def553917e00a74b"
+checksum = "f3de97289f2e60b779a241b029672faded0bf1b5524316cc36d4fba218982ce6"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31178fb25c234956728ba47c6b102bc65b1c1c68f1e14b4add58e2335aa4474"
+checksum = "ad6088e6d4577e6e0abb686c8359f6ca2ccde33fc1c8fd4438fee7fc48ce9a28"
 dependencies = [
  "bindgen",
  "cc",
@@ -854,9 +854,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pkg-config"
@@ -872,9 +872,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -982,15 +982,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-vec"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40a932995c21f9b64f49d338ca0b34355c378178c7c52e362e13969757fc604"
+checksum = "4ec77b84fb8dd5f0f8def127226db83b5d1152c5bf367f09af03998b76ba554a"
 dependencies = [
  "cc",
 ]
@@ -1046,9 +1046,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1108,18 +1108,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-width"
@@ -1135,9 +1135,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ab52f2d3d18b70d5ab8dd270a1cff3ebe6dbe4a7d13c1cc2557138a9777fdc"
+checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
 dependencies = [
  "arrayvec",
  "cfg_aliases",
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c68e7b6322a03ee5b83fcd92caeac5c2a932f6457818179f4652ad2a9c065"
+checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6e7266b869de56c7e3ed72a954899f71d14fec6cc81c102b7530b92947601b"
+checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1371,7 +1371,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1443,6 +1443,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -11,10 +11,10 @@ encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
 ] }
-llama-cpp-2 = { version = "0.1.83", features = ["sampler"]}
+llama-cpp-2 = { version = "0.1.84", features = ["sampler"]}
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 wgpu = "23.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { version = "0.1.83", features = ["vulkan" , "sampler"] }
+llama-cpp-2 = { version = "0.1.84", features = ["vulkan" , "sampler"] }

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -11,10 +11,10 @@ encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
 ] }
-llama-cpp-2 = { version = "0.1.84", features = ["sampler"]}
+llama-cpp-2 = { version = "0.1.84" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 wgpu = "23.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { version = "0.1.84", features = ["vulkan" , "sampler"] }
+llama-cpp-2 = { version = "0.1.84", features = ["vulkan"] }

--- a/nobodywho/src/db.rs
+++ b/nobodywho/src/db.rs
@@ -118,10 +118,10 @@ impl NobodyWhoDB {
                     Value::Text(s) => s.to_variant(),
                     Value::Blob(b) => PackedByteArray::from(b).to_variant(),
                 };
-                row_data.push(value);
+                row_data.push(&value);
             }
 
-            result.push(row_data.to_variant());
+            result.push(&row_data.to_variant());
         }
 
         result

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -195,6 +195,7 @@ macro_rules! emit_tokens {
                     }
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                         godot_error!("Unexpected: Model channel disconnected");
+                        panic!();
                     }
                 }
             } else {

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -148,13 +148,7 @@ macro_rules! run_model {
 
             // start the llm worker
             std::thread::spawn(move || {
-                run_worker(
-                    model,
-                    prompt_rx,
-                    completion_tx,
-                    // TODO: find a way to move a sampler (or sampler config) into this thread
-                    sampler_config,
-                );
+                run_worker(model, prompt_rx, completion_tx, sampler_config);
             });
 
             Ok(())

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -17,7 +17,25 @@ struct NobodyWhoSampler {
     base: Base<Resource>,
 
     #[export]
+    seed: u32,
+    #[export]
     temperature: f32,
+    #[export]
+    penalty_last_n: i32,
+    #[export]
+    penalty_repeat: f32,
+    #[export]
+    penalty_freq: f32,
+    #[export]
+    penalty_present: f32,
+    #[export]
+    penalize_nl: bool,
+    #[export]
+    ignore_eos: bool,
+    #[export]
+    mirostat_tau: f32,
+    #[export]
+    mirostat_eta: f32,
 }
 
 #[godot_api]
@@ -25,14 +43,34 @@ impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
         Self {
             base,
-            temperature: 0.5,
+            seed: llm::DEFAULT_SAMPLER_CONFIG.seed,
+            temperature: llm::DEFAULT_SAMPLER_CONFIG.temperature,
+            penalty_last_n: llm::DEFAULT_SAMPLER_CONFIG.penalty_last_n,
+            penalty_repeat: llm::DEFAULT_SAMPLER_CONFIG.penalty_repeat,
+            penalty_freq: llm::DEFAULT_SAMPLER_CONFIG.penalty_freq,
+            penalty_present: llm::DEFAULT_SAMPLER_CONFIG.penalty_present,
+            penalize_nl: llm::DEFAULT_SAMPLER_CONFIG.penalize_nl,
+            ignore_eos: llm::DEFAULT_SAMPLER_CONFIG.ignore_eos,
+            mirostat_tau: llm::DEFAULT_SAMPLER_CONFIG.mirostat_tau,
+            mirostat_eta: llm::DEFAULT_SAMPLER_CONFIG.mirostat_eta,
         }
     }
 }
 
-impl<'a> NobodyWhoSampler {
+impl NobodyWhoSampler {
     pub fn get_sampler_config(&self) -> llm::SamplerConfig {
-        llm::DEFAULT_SAMPLER_CONFIG
+        llm::SamplerConfig {
+            seed: self.seed,
+            temperature: self.temperature,
+            penalty_last_n: self.penalty_last_n,
+            penalty_repeat: self.penalty_repeat,
+            penalty_freq: self.penalty_freq,
+            penalty_present: self.penalty_present,
+            penalize_nl: self.penalize_nl,
+            ignore_eos: self.ignore_eos,
+            mirostat_tau: self.mirostat_tau,
+            mirostat_eta: self.mirostat_eta,
+        }
     }
 }
 

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -31,8 +31,8 @@ impl IResource for NobodyWhoSampler {
 }
 
 impl<'a> NobodyWhoSampler {
-    pub fn get_sampler(&self) -> llm::Sampler<'a> {
-        llm::default_sampler()
+    pub fn get_sampler_config(&self) -> llm::SamplerConfig {
+        llm::DEFAULT_SAMPLER_CONFIG
     }
 }
 
@@ -41,9 +41,6 @@ impl<'a> NobodyWhoSampler {
 struct NobodyWhoModel {
     #[export(file = "*.gguf")]
     model_path: GString,
-
-    #[export]
-    seed: u32,
 
     model: Option<llm::Model>,
 }
@@ -54,12 +51,9 @@ impl INode for NobodyWhoModel {
         // default values to show in godot editor
         let model_path: String = "model.gguf".into();
 
-        let seed = 1234;
-
         Self {
             model_path: model_path.into(),
             model: None,
-            seed,
         }
     }
 }
@@ -73,7 +67,7 @@ impl NobodyWhoModel {
 
         let project_settings = ProjectSettings::singleton();
         let model_path_string: String = project_settings
-            .globalize_path(self.model_path.clone())
+            .globalize_path(&self.model_path.clone())
             .into();
 
         match llm::get_model(model_path_string.as_str()) {
@@ -100,12 +94,13 @@ macro_rules! run_model {
             let model: llm::Model = nobody_model.get_model()?;
 
             // get NobodyWhoSampler
-            let sampler: llm::Sampler = if let Some(gd_sampler) = $self.sampler.as_mut() {
-                let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
-                nobody_sampler.get_sampler()
-            } else {
-                llm::default_sampler()
-            };
+            let sampler_config: llm::SamplerConfig =
+                if let Some(gd_sampler) = $self.sampler.as_mut() {
+                    let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
+                    nobody_sampler.get_sampler_config()
+                } else {
+                    llm::DEFAULT_SAMPLER_CONFIG
+                };
 
             // make and store channels for communicating with the llm worker thread
             let (prompt_tx, prompt_rx) = std::sync::mpsc::channel::<String>();
@@ -114,15 +109,13 @@ macro_rules! run_model {
             $self.completion_rx = Some(completion_rx);
 
             // start the llm worker
-            let seed = nobody_model.seed;
             std::thread::spawn(move || {
                 run_worker(
                     model,
                     prompt_rx,
                     completion_tx,
-                    seed,
                     // TODO: find a way to move a sampler (or sampler config) into this thread
-                    &mut llm::default_sampler(),
+                    sampler_config,
                 );
             });
 
@@ -154,12 +147,10 @@ macro_rules! emit_tokens {
                     Ok(llm::LLMOutput::Token(token)) => {
                         $self
                             .base_mut()
-                            .emit_signal("completion_updated".into(), &[Variant::from(token)]);
+                            .emit_signal("completion_updated", &[Variant::from(token)]);
                     }
                     Ok(llm::LLMOutput::Done) => {
-                        $self
-                            .base_mut()
-                            .emit_signal("completion_finished".into(), &[]);
+                        $self.base_mut().emit_signal("completion_finished", &[]);
                     }
                     Err(std::sync::mpsc::TryRecvError::Empty) => {
                         break;

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -12,6 +12,7 @@ use llama_cpp_2::model::{AddBos, Special};
 use llama_cpp_2::sampling::params::LlamaSamplerChainParams;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
+use llama_cpp_2::LlamaSamplerError;
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
@@ -95,6 +96,29 @@ pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig {
     mirostat_eta: 0.1,
 };
 
+fn make_sampler(
+    model: &LlamaModel,
+    config: SamplerConfig,
+) -> Result<LlamaSampler, LlamaSamplerError> {
+    // init mirostat sampler
+    let sampler_params = LlamaSamplerChainParams::default();
+    let sampler = LlamaSampler::new(sampler_params)?
+        .add_penalties(
+            model.n_vocab(),
+            model.token_eos().0,
+            model.token_nl().0,
+            config.penalty_last_n,
+            config.penalty_repeat,
+            config.penalty_freq,
+            config.penalty_present,
+            config.penalize_nl,
+            config.ignore_eos,
+        )
+        .add_temp(config.temperature)
+        .add_mirostat_v2(config.seed, config.mirostat_tau, config.mirostat_eta);
+    Ok(sampler)
+}
+
 pub fn run_worker<'a>(
     model: Arc<LlamaModel>,
     prompt_rx: Receiver<String>,
@@ -110,6 +134,9 @@ pub fn run_worker<'a>(
     let mut ctx = model.new_context(&LLAMA_BACKEND, ctx_params).unwrap();
 
     let mut n_cur = 0;
+
+    let mut sampler = make_sampler(&model, sampler_config)
+        .expect("Llama.cpp returned a null pointer when initializing sampler.");
 
     while let Ok(prompt) = prompt_rx.recv() {
         let tokens_list = ctx.model.str_to_token(&prompt, AddBos::Always).unwrap();
@@ -132,29 +159,6 @@ pub fn run_worker<'a>(
 
         // The `Decoder`
         let mut utf8decoder = encoding_rs::UTF_8.new_decoder();
-
-        // init mirostat sampler
-        let sampler_params = LlamaSamplerChainParams::default();
-        let mut sampler = LlamaSampler::new(sampler_params)
-            .expect("Llama.cpp returned a null pointer when initializing sampler.")
-            // .add_logit_bias(model.n_vocab())
-            .add_penalties(
-                model.n_vocab(),
-                model.token_eos().0,
-                model.token_nl().0,
-                sampler_config.penalty_last_n,
-                sampler_config.penalty_repeat,
-                sampler_config.penalty_freq,
-                sampler_config.penalty_present,
-                sampler_config.penalize_nl,
-                sampler_config.ignore_eos,
-            )
-            .add_temp(sampler_config.temperature)
-            .add_mirostat_v2(
-                sampler_config.seed,
-                sampler_config.mirostat_tau,
-                sampler_config.mirostat_eta,
-            );
 
         loop {
             // sample the next token
@@ -312,5 +316,12 @@ mod tests {
             result.contains("Danish"),
             "Expected completion to contain 'Danish', got: {result}"
         );
+    }
+
+    #[test]
+    fn test_initialize_default_sampler() {
+        let model = get_model(test_model_path!()).expect("Failed loading model");
+        let sampler = make_sampler(&model, DEFAULT_SAMPLER_CONFIG);
+        assert!(sampler.is_ok(), "make_sampler returned an Err");
     }
 }

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -69,16 +69,16 @@ pub fn apply_chat_template(model: Model, chat: Vec<(String, String)>) -> Result<
 }
 
 pub struct SamplerConfig {
-    seed: u32,
-    temperature: f32,
-    penalty_last_n: i32,
-    penalty_repeat: f32,
-    penalty_freq: f32,
-    penalty_present: f32,
-    penalize_nl: bool,
-    ignore_eos: bool,
-    mirostat_tau: f32,
-    mirostat_eta: f32,
+    pub seed: u32,
+    pub temperature: f32,
+    pub penalty_last_n: i32,
+    pub penalty_repeat: f32,
+    pub penalty_freq: f32,
+    pub penalty_present: f32,
+    pub penalize_nl: bool,
+    pub ignore_eos: bool,
+    pub mirostat_tau: f32,
+    pub mirostat_eta: f32,
 }
 
 // defaults here match the defaults read from `llama-cli --help`

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -3,14 +3,14 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, LazyLock};
 
 use llama_cpp_2::context::params::LlamaContextParams;
-use llama_cpp_2::context::sample::sampler;
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaChatMessage;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::model::{AddBos, Special};
-use llama_cpp_2::token::data_array::LlamaTokenDataArray;
+use llama_cpp_2::sampling::params::LlamaSamplerChainParams;
+use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
@@ -55,32 +55,6 @@ pub fn get_model(model_path: &str) -> Result<Arc<LlamaModel>, String> {
     Ok(Arc::new(model))
 }
 
-pub type Sampler<'a> = sampler::Sampler<'a, Vec<LlamaToken>>;
-
-pub fn default_sampler<'a>() -> Sampler<'a> {
-    // default llama.cpp sampler
-    // taken from https://docs.rs/llama-cpp-2/latest/llama_cpp_2/context/sample/sampler/index.html
-
-    // Sample a token greedily and add to the history.
-    let finalizer = &|mut canidates: LlamaTokenDataArray, history: &mut Vec<LlamaToken>| {
-        canidates.sample_softmax(None);
-        let token = canidates.data[0];
-        history.push(token.id());
-        vec![token]
-    };
-
-    let mut sampler = sampler::Sampler::new(finalizer);
-
-    sampler.push_step(&|c, history| c.sample_repetition_penalty(None, history, 64, 1.1, 0.0, 0.0));
-    sampler.push_step(&|c, _| c.sample_top_k(None, 40, 1));
-    sampler.push_step(&|c, _| c.sample_tail_free(None, 1.0, 1));
-    sampler.push_step(&|c, _| c.sample_typical(None, 1.0, 1));
-    sampler.push_step(&|c, _| c.sample_top_p(None, 0.95, 1));
-    sampler.push_step(&|c, _| c.sample_min_p(None, 0.05, 1));
-    sampler.push_step(&|c, _| c.sample_temp(None, 0.5));
-    sampler
-}
-
 // random candidates
 
 pub fn apply_chat_template(model: Model, chat: Vec<(String, String)>) -> Result<String, String> {
@@ -94,16 +68,41 @@ pub fn apply_chat_template(model: Model, chat: Vec<(String, String)>) -> Result<
     Ok(chat_string)
 }
 
+pub struct SamplerConfig {
+    seed: u32,
+    temperature: f32,
+    penalty_last_n: i32,
+    penalty_repeat: f32,
+    penalty_freq: f32,
+    penalty_present: f32,
+    penalize_nl: bool,
+    ignore_eos: bool,
+    mirostat_tau: f32,
+    mirostat_eta: f32,
+}
+
+// defaults here match the defaults read from `llama-cli --help`
+pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig {
+    seed: 1234,
+    temperature: 0.8,
+    penalty_last_n: -1,
+    penalty_repeat: 0.0,
+    penalty_freq: 0.0,
+    penalty_present: 0.0,
+    penalize_nl: false,
+    ignore_eos: false,
+    mirostat_tau: 5.0,
+    mirostat_eta: 0.1,
+};
+
 pub fn run_worker<'a>(
     model: Arc<LlamaModel>,
     prompt_rx: Receiver<String>,
     completion_tx: Sender<LLMOutput>,
-    seed: u32,
-    sampler: &mut Sampler,
+    sampler_config: SamplerConfig,
 ) {
     let n_threads = std::thread::available_parallelism().unwrap().get() as i32;
     let ctx_params = LlamaContextParams::default()
-        .with_seed(seed)
         .with_n_ctx(std::num::NonZero::new(model.n_ctx_train()))
         .with_n_threads(n_threads)
         .with_n_threads_batch(n_threads);
@@ -134,18 +133,35 @@ pub fn run_worker<'a>(
         // The `Decoder`
         let mut utf8decoder = encoding_rs::UTF_8.new_decoder();
 
-        let mut history = vec![];
+        // init mirostat sampler
+        let sampler_params = LlamaSamplerChainParams::default();
+        let mut sampler = LlamaSampler::new(sampler_params)
+            .expect("Llama.cpp returned a null pointer when initializing sampler.")
+            // .add_logit_bias(model.n_vocab())
+            .add_penalties(
+                model.n_vocab(),
+                model.token_eos().0,
+                model.token_nl().0,
+                sampler_config.penalty_last_n,
+                sampler_config.penalty_repeat,
+                sampler_config.penalty_freq,
+                sampler_config.penalty_present,
+                sampler_config.penalize_nl,
+                sampler_config.ignore_eos,
+            )
+            .add_temp(sampler_config.temperature)
+            .add_mirostat_v2(
+                sampler_config.seed,
+                sampler_config.mirostat_tau,
+                sampler_config.mirostat_eta,
+            );
+
         loop {
             // sample the next token
             {
-                let candidates = ctx.candidates_ith(batch.n_tokens() - 1);
-
-                let candidates_p = LlamaTokenDataArray::from_iter(candidates, false);
-
-                // sample the most likely token
-                let tokens = sampler.sample(&mut history, candidates_p);
-                assert_eq!(tokens.len(), 1);
-                let new_token_id: LlamaToken = tokens[0].id();
+                // sample the next token
+                let new_token_id: LlamaToken = sampler.sample(&ctx, batch.n_tokens() - 1);
+                sampler.accept(new_token_id);
 
                 // is it an end of stream?
                 if new_token_id == ctx.model.token_eos() {
@@ -203,13 +219,7 @@ mod tests {
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            run_worker(
-                model,
-                prompt_rx,
-                completion_tx,
-                1234,
-                &mut default_sampler(),
-            )
+            run_worker(model, prompt_rx, completion_tx, DEFAULT_SAMPLER_CONFIG)
         });
 
         prompt_tx.send("Count to five: 1, 2, ".to_string()).unwrap();
@@ -241,15 +251,7 @@ mod tests {
         let (prompt_tx, prompt_rx) = std::sync::mpsc::channel();
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
 
-        std::thread::spawn(|| {
-            run_worker(
-                model,
-                prompt_rx,
-                completion_tx,
-                1234,
-                &mut default_sampler(),
-            )
-        });
+        std::thread::spawn(|| run_worker(model, prompt_rx, completion_tx, DEFAULT_SAMPLER_CONFIG));
 
         let chat: Vec<LlamaChatMessage> = vec![
             LlamaChatMessage::new(


### PR DESCRIPTION
Created a `NobodyWhoSampler` resource, which is supposed to be attached to nodes like `NobodyWhoPromptChat` and `NobodyWhoPromptCompletion`

It uses a sampler chain that is very similar to the one used by the `main.cpp` example from llama.cpp, when mirostat_v2 is used. The defaults where taken from `llama-cli --help`. I'm hoping/assuming that they're pretty sane.

All of the penalty values are set to 0 by default. This is probably not optimal? Maybe? Hmm.

If no resource is supplied to the node, it just uses the default sampler.

This is a breaking change, since it moves the `seed` field from the model node to the sampler config resource.

It will also generate different, better, responses by default, since we moved to using a much better sampler.

Closes #24 