### PR TITLE
Handle all `.unwrap()`s in run_worker, showing errors in godot when it fails

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -484,7 +484,7 @@ checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "windows",
 ]
 
@@ -673,7 +673,7 @@ checksum = "f3de97289f2e60b779a241b029672faded0bf1b5524316cc36d4fba218982ce6"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -758,7 +758,7 @@ dependencies = [
  "rustc-hash",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -795,6 +795,7 @@ dependencies = [
  "llama-cpp-2",
  "rusqlite",
  "sqlite-vec",
+ "thiserror 2.0.3",
  "wgpu",
 ]
 
@@ -1070,7 +1071,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -1078,6 +1088,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1292,7 +1313,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -1334,7 +1355,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -14,6 +14,7 @@ godot = { git = "https://github.com/godot-rust/gdext", branch = "master", featur
 llama-cpp-2 = { version = "0.1.84" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
+thiserror = "2.0.3"
 wgpu = "23.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -188,8 +188,10 @@ macro_rules! emit_tokens {
                         break;
                     }
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                        godot_error!("Unexpected: Model channel disconnected");
-                        panic!();
+                        godot_error!("Model output channel died. Did the LLM worker crash?");
+                        // set hanging channel to None
+                        // this prevents repeating the dead channel error message foreve
+                        $self.completion_rx = None;
                     }
                 }
             } else {

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -98,7 +98,7 @@ impl INode for NobodyWhoModel {
 
 impl NobodyWhoModel {
     // memoized model loader
-    fn get_model(&mut self) -> Result<llm::Model, String> {
+    fn get_model(&mut self) -> Result<llm::Model, llm::LoadModelError> {
         if let Some(model) = &self.model {
             return Ok(model.clone());
         }
@@ -113,9 +113,9 @@ impl NobodyWhoModel {
                 self.model = Some(model.clone());
                 Ok(model.clone())
             }
-            Err(msg) => {
-                godot_error!("Could not load model: {msg}");
-                Err(msg)
+            Err(err) => {
+                godot_error!("Could not load model: {:?}", err.to_string());
+                Err(err)
             }
         }
     }
@@ -129,7 +129,7 @@ macro_rules! run_model {
             // get NobodyWhoModel
             let gd_model_node = $self.model_node.as_mut().ok_or("Model node is not set.")?;
             let mut nobody_model = gd_model_node.bind_mut();
-            let model: llm::Model = nobody_model.get_model()?;
+            let model: llm::Model = nobody_model.get_model().map_err(|e| e.to_string())?;
 
             // get NobodyWhoSampler
             let sampler_config: llm::SamplerConfig =

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -184,7 +184,7 @@ macro_rules! emit_tokens {
                     Ok(llm::LLMOutput::Done) => {
                         $self.base_mut().emit_signal("completion_finished", &[]);
                     }
-                    Ok(llm::LLMOutput::Err(msg)) => {
+                    Ok(llm::LLMOutput::FatalErr(msg)) => {
                         godot_error!("Model worker crashed: {msg}");
                     }
                     Err(std::sync::mpsc::TryRecvError::Empty) => {

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -184,6 +184,9 @@ macro_rules! emit_tokens {
                     Ok(llm::LLMOutput::Done) => {
                         $self.base_mut().emit_signal("completion_finished", &[]);
                     }
+                    Ok(llm::LLMOutput::Err(msg)) => {
+                        godot_error!("Model worker crashed: {msg}");
+                    }
                     Err(std::sync::mpsc::TryRecvError::Empty) => {
                         break;
                     }

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -1,10 +1,10 @@
 use std::pin::pin;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender, SendError};
 use std::sync::{Arc, LazyLock};
 
 use llama_cpp_2::context::params::LlamaContextParams;
 use llama_cpp_2::llama_backend::LlamaBackend;
-use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::llama_batch::{LlamaBatch, BatchAddError};
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaChatMessage;
 use llama_cpp_2::model::LlamaModel;
@@ -12,14 +12,14 @@ use llama_cpp_2::model::{AddBos, Special};
 use llama_cpp_2::sampling::params::LlamaSamplerChainParams;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
-use llama_cpp_2::LlamaSamplerError;
+use llama_cpp_2::{LlamaSamplerError, LlamaContextLoadError, StringToTokenError, TokenToStringError, DecodeError};
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
 
 pub enum LLMOutput {
     Token(String),
-    Err(String),
+    Err(WorkerError),
     Done,
 }
 
@@ -36,12 +36,21 @@ pub fn has_discrete_gpu() -> bool {
         .any(|a| a.get_info().device_type == wgpu::DeviceType::DiscreteGpu)
 }
 
-pub fn get_model(model_path: &str) -> Result<Arc<LlamaModel>, String> {
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadModelError {
+    #[error("Model not found: {0}")]
+    ModelNotFound(String),
+    #[error("Invalid or unsupported GGUF model: {0}")]
+    InvalidModel(String),
+}
+
+pub fn get_model(model_path: &str) -> Result<Arc<LlamaModel>, LoadModelError> {
     // HACK: only offload anything to the gpu if we can find a dedicated GPU
     //       there seems to be a bug which results in garbage tokens if we over-allocate an integrated GPU
     //       while using the vulkan backend. See: https://github.com/nobodywho-ooo/nobodywho-rs/pull/14
     if !std::path::Path::new(model_path).exists() {
-        return Err(format!("{model_path} does not exist."));
+        return Err(LoadModelError::ModelNotFound(model_path.into()));
     }
 
     let model_params = LlamaModelParams::default().with_n_gpu_layers(
@@ -53,7 +62,7 @@ pub fn get_model(model_path: &str) -> Result<Arc<LlamaModel>, String> {
     );
     let model_params = pin!(model_params);
     let model = LlamaModel::load_from_file(&LLAMA_BACKEND, model_path, &model_params)
-        .map_err(|_| format!("Looks like {model_path} is not a valid or supported GGUF model."))?;
+        .map_err(|e| LoadModelError::InvalidModel(format!("Bad model path: {} - Llama.cpp error: {}", model_path.to_string(), e.to_string())))?;
     Ok(Arc::new(model))
 }
 
@@ -120,6 +129,36 @@ fn make_sampler(
     Ok(sampler)
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum WorkerError {
+    #[error("Could not determine number of threads available: {0}")]
+    ThreadCountError(#[from] std::io::Error),
+
+    #[error("Could not create context: {0}")]
+    CreateContextError(#[from] LlamaContextLoadError),
+
+    #[error("Could not create sampler: {0}")]
+    CreateSamplerError(#[from] LlamaSamplerError),
+
+    #[error("Could not tokenize string: {0}")]
+    TokenizerError(#[from] StringToTokenError),
+
+    #[error("Could not detokenize string: {0}")]
+    Detokenize(#[from] TokenToStringError),
+
+    #[error("Could not add token to batch: {0}")]
+    BatchAddError(#[from] BatchAddError),
+
+    #[error("Context exceeded maximum length")]
+    ContextLengthExceededError,
+
+    #[error("Could not send newly generated token out to the game engine.")]
+    SendError, // this is actually a SendError<LLMOutput>, but that becomes recursive and weord.
+
+    #[error("Llama.cpp failed decoding: {0}")]
+    DecodeError(#[from] DecodeError)
+}
+
 pub fn run_worker(
     model: Arc<LlamaModel>,
     prompt_rx: Receiver<String>,
@@ -137,9 +176,8 @@ fn run_worker_result(
     prompt_rx: Receiver<String>,
     completion_tx: &Sender<LLMOutput>,
     sampler_config: SamplerConfig,
-) -> Result<(), String> {
-    let n_threads = std::thread::available_parallelism()
-        .map_err(|_| "Could not determine number of available threads in system.")?
+) -> Result<(), WorkerError> {
+    let n_threads = std::thread::available_parallelism()?
         .get() as i32;
     let n_ctx: u32 = model.n_ctx_train();
     let ctx_params = LlamaContextParams::default()
@@ -147,20 +185,14 @@ fn run_worker_result(
         .with_n_threads(n_threads)
         .with_n_threads_batch(n_threads);
 
-    let mut ctx = model
-        .new_context(&LLAMA_BACKEND, ctx_params)
-        .map_err(|_| "Failed creating new context.")?;
+    let mut ctx = model.new_context(&LLAMA_BACKEND, ctx_params)?;
 
     let mut n_cur = 0;
 
-    let mut sampler = make_sampler(&model, sampler_config)
-        .map_err(|_| "Llama.cpp returned a null pointer when initializing sampler.")?;
+    let mut sampler = make_sampler(&model, sampler_config)?;
 
     while let Ok(prompt) = prompt_rx.recv() {
-        let tokens_list = ctx
-            .model
-            .str_to_token(&prompt, AddBos::Always)
-            .map_err(|_| "Failed tokenizing user-provided text. Does it contain weird characters?")?;
+        let tokens_list = ctx.model.str_to_token(&prompt, AddBos::Always)?;
 
         let mut batch = LlamaBatch::new(ctx.n_ctx() as usize, 1);
 
@@ -170,15 +202,15 @@ fn run_worker_result(
         for (i, token) in (0..).zip(tokens_list.into_iter()) {
             // llama_decode will output logits only for the last token of the prompt
             let is_last = i == last_index;
-            batch.add(token, n_cur + i, &[0], is_last).map_err(|_| "Failed adding user-provided text to batch. Was the text longer than the maximum context?")?;
+            batch.add(token, n_cur + i, &[0], is_last)?;
         }
 
-        ctx.decode(&mut batch).map_err(|_| "Llama.cpp failed decoding batch.")?;
+        ctx.decode(&mut batch)?;
 
         // main loop
         n_cur += batch.n_tokens();
-        if n_ctx <= n_cur.try_into().map_err(|_| "n_cur does not fit in u32")? {
-            return Err("Maximum context length exceeded".to_string());
+        if n_ctx as i64 <= n_cur as i64 {
+            return Err(WorkerError::ContextLengthExceededError);
         }
 
         // The `Decoder`
@@ -194,17 +226,12 @@ fn run_worker_result(
                 // is it an end of stream?
                 if new_token_id == ctx.model.token_eos() {
                     batch.clear();
-                    batch
-                        .add(new_token_id, n_cur, &[0], true)
-                        .map_err(|_| "Failed adding EOS token to batch.")?;
-                    completion_tx.send(LLMOutput::Done).map_err(|_| "Failed sending newly generated token out. Was the game engine node removed?")?;
+                    batch.add(new_token_id, n_cur, &[0], true)?;
+                    completion_tx.send(LLMOutput::Done).map_err(|_| WorkerError::SendError)?;
                     break;
                 }
 
-                let output_bytes = ctx
-                    .model
-                    .token_to_bytes(new_token_id, Special::Tokenize)
-                    .map_err(|_| "Could not de-tokenize newly generated token.")?;
+                let output_bytes = ctx.model.token_to_bytes(new_token_id, Special::Tokenize)?;
 
                 // use `Decoder.decode_to_string()` to avoid the intermediate buffer
                 let mut output_string = String::with_capacity(32);
@@ -212,25 +239,20 @@ fn run_worker_result(
                     utf8decoder.decode_to_string(&output_bytes, &mut output_string, false);
 
                 // send new token string back to user
-                completion_tx.send(LLMOutput::Token(output_string)).map_err(|_|
-                    "Failed sending newly generated token out. Was the game engine node removed?",
-                )?;
+                completion_tx.send(LLMOutput::Token(output_string)).map_err(|_| WorkerError::SendError)?;
 
                 // prepare batch or the next decode
                 batch.clear();
 
-                batch
-                    .add(new_token_id, n_cur, &[0], true)
-                    .map_err(|_| "Failed adding newly generated token to batch")?;
+                batch.add(new_token_id, n_cur, &[0], true)?;
             }
 
             n_cur += 1;
-            if n_ctx <= n_cur.try_into().map_err(|_| "n_cur does not fit in u32")? {
-                return Err("Maximum context length exceeded".to_string());
+            if n_ctx <= n_cur.try_into().expect("n_cur does not fit in u32") {
+                return Err(WorkerError::ContextLengthExceededError);
             }
 
-            ctx.decode(&mut batch)
-                .map_err(|_| "Llama.cpp failed decoding batch.")?;
+            ctx.decode(&mut batch)?;
         }
     }
     unreachable!();


### PR DESCRIPTION
I came here to remove `.unwrap()`s and chew gum. ... and I'm all out of gum. :sunglasses: 

I do a lot of `.map_err("uh-oh")?;`, but at least now we can catch the errors and show them in godot.

I still have some uncertainty about the mpsc channels. If I send a message in the channel, and drop the sender before the message is read by the receiver, can the message still be read?

If a successfully sent message can always be read, even after the sender is dropped, then we're good. Otherwise we have a race condition that could cause an error message to not show.