### PR TITLE
Configurable context length

### DIFF
--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -147,8 +147,9 @@ macro_rules! run_model {
             $self.completion_rx = Some(completion_rx);
 
             // start the llm worker
+            let n_ctx = $self.context_length;
             std::thread::spawn(move || {
-                run_worker(model, prompt_rx, completion_tx, sampler_config);
+                run_worker(model, prompt_rx, completion_tx, sampler_config, n_ctx);
             });
 
             Ok(())
@@ -213,6 +214,9 @@ struct NobodyWhoPromptCompletion {
     #[export]
     sampler: Option<Gd<NobodyWhoSampler>>,
 
+    #[export]
+    context_length: u32,
+
     completion_rx: Option<Receiver<llm::LLMOutput>>,
     prompt_tx: Option<Sender<String>>,
 
@@ -225,6 +229,7 @@ impl INode for NobodyWhoPromptCompletion {
         Self {
             model_node: None,
             sampler: None,
+            context_length: 4096,
             completion_rx: None,
             prompt_tx: None,
             base,
@@ -269,6 +274,9 @@ struct NobodyWhoPromptChat {
     prompt: GString,
     sent_prompt: bool,
 
+    #[export]
+    context_length: u32,
+
     prompt_tx: Option<Sender<String>>,
     completion_rx: Option<Receiver<llm::LLMOutput>>,
 
@@ -283,6 +291,7 @@ impl INode for NobodyWhoPromptChat {
             sampler: None,
             prompt: "".into(),
             sent_prompt: false,
+            context_length: 4096,
             prompt_tx: None,
             completion_rx: None,
             base,

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -168,9 +168,10 @@ pub fn run_worker(
     prompt_rx: Receiver<String>,
     completion_tx: Sender<LLMOutput>,
     sampler_config: SamplerConfig,
+    n_ctx: u32,
 ) {
     // this function is a pretty thin wrapper to send back an `Err` if we get it
-    if let Err(msg) = run_worker_result(model, prompt_rx, &completion_tx, sampler_config) {
+    if let Err(msg) = run_worker_result(model, prompt_rx, &completion_tx, sampler_config, n_ctx) {
         completion_tx
             .send(LLMOutput::FatalErr(msg))
             .expect("Could not send llm worker fatal error back to consumer.");
@@ -182,9 +183,10 @@ fn run_worker_result(
     prompt_rx: Receiver<String>,
     completion_tx: &Sender<LLMOutput>,
     sampler_config: SamplerConfig,
+    n_ctx: u32,
 ) -> Result<(), WorkerError> {
     let n_threads = std::thread::available_parallelism()?.get() as i32;
-    let n_ctx: u32 = model.n_ctx_train();
+    let n_ctx: u32 = std::cmp::min(n_ctx, model.n_ctx_train());
     let ctx_params = LlamaContextParams::default()
         .with_n_ctx(std::num::NonZero::new(n_ctx))
         .with_n_threads(n_threads)

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -291,7 +291,13 @@ mod tests {
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            run_worker(model, prompt_rx, completion_tx, DEFAULT_SAMPLER_CONFIG)
+            run_worker(
+                model,
+                prompt_rx,
+                completion_tx,
+                DEFAULT_SAMPLER_CONFIG,
+                4096,
+            )
         });
 
         prompt_tx.send("Count to five: 1, 2, ".to_string()).unwrap();
@@ -323,7 +329,15 @@ mod tests {
         let (prompt_tx, prompt_rx) = std::sync::mpsc::channel();
         let (completion_tx, completion_rx) = std::sync::mpsc::channel();
 
-        std::thread::spawn(|| run_worker(model, prompt_rx, completion_tx, DEFAULT_SAMPLER_CONFIG));
+        std::thread::spawn(|| {
+            run_worker(
+                model,
+                prompt_rx,
+                completion_tx,
+                DEFAULT_SAMPLER_CONFIG,
+                4096,
+            )
+        });
 
         let chat: Vec<LlamaChatMessage> = vec![
             LlamaChatMessage::new(


### PR DESCRIPTION
Previous to this, context lengths were just set by `n_ctx_train()`, which is whatever context length the model supports.

Many models (e.g. Llama3.2) have really large context lengths (e.g. 128k tokens). Trying to create a `LlamaContext` that supports the full context length often results in trying to allocate more VRAM than the GPU has left. This crashes the worker. No fun. Not good.

Setting this to 4096 tokens by default should leave enough space on *most gpus*, and be enough context for *most use cases*.

The context length is adjustable from godot, so if someone has a use case that needs longer contexts, it can be increased, or if it needs to run on a smaller gpu, it can be decreased.

It annoys me a bit (a lot), that this means that developers might have to decide on an appropriate context length for the GPU that it's running on, which is difficult- but this solves the problem for now.

An alternative solution is #47, which starts off trying the maximum supported context lengths, and halves it until the allocation succeeds.