### PR TITLE
get rid of run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,16 @@ Also in the inspector, you can provide a prompt, which gives the LLM instruction
 Now you can add a script to the `NobodyWhoPromptChat` node, to provide your chat interaction.
 
 `NobodyWhoPromptChat` uses this programming interface:
-    - `run()`: a function that starts the LLM worker. Must be called before doing anything else.
     - `say(text)`: a function that can be used to send text from the user to the LLM.
     - `completion_updated(text)`: a signal with a string parameter, that is emitted every time the LLM produces more text. Contains roughly one word per invocation.
     - `completion_finished()`: a signal which indicates that the LLM is done speaking.
+    - `start_worker()`: a function that starts the LLM worker. The LLM needs a few seconds to get ready before chatting, so you may want to call this ahead of time.
 
 
 ## Example `NobodyWhoPromptChat` script
 
 ```gdscript
 extends NobodyWhoPromptChat
-
-func _ready():
-    # initializes the LLM worker
-    run()
 
 func user_sent_some_text(text):
     # call this function whenever the user submits some new text

--- a/example-game/nobody_who_prompt_chat.gd
+++ b/example-game/nobody_who_prompt_chat.gd
@@ -1,7 +1,6 @@
 extends NobodyWhoPromptChat
 
 func _ready() -> void:
-	run()
 	say("Hi there! Who are you?")
 
 func _on_completion_updated(text) -> void:

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -192,12 +192,12 @@ impl INode for NobodyWhoPromptChat {
 
 #[godot_api]
 impl NobodyWhoPromptChat {
-    fn get_model(&mut self) -> Option<llm::Model> {
-        let gd_model_node = self.model_node.as_mut()?;
+    fn get_model(&mut self) -> Result<llm::Model, String> {
+        let gd_model_node = self.model_node.as_mut().ok_or("Model node was not set")?;
         let mut nobody_model = gd_model_node.bind_mut();
-        let model: llm::Model = nobody_model.get_model().ok()?;
+        let model: llm::Model = nobody_model.get_model().map_err(|e| e.to_string())?;
 
-        Some(model)
+        Ok(model)
     }
 
     fn get_sampler_config(&mut self) -> SamplerConfig {
@@ -212,7 +212,7 @@ impl NobodyWhoPromptChat {
     #[func]
     fn start_worker(&mut self) {
         let mut result = || -> Result<(), String> {
-            let model = self.get_model().ok_or("Model not loaded")?;
+            let model = self.get_model()?;
             let sampler_config = self.get_sampler_config();
 
             // make and store channels for communicating with the llm worker thread


### PR DESCRIPTION
Okay soooo

Now it calls `run_model!` inside `set_text!` if it hasn't been called yet.

This means that it's no longer required to call `run()`. The plugin will call it for you if you haven't yet.

I left run around, but renamed it `start_model_worker()`, which I think is a better name anyway.

The idea of still having it around is that a gamedev could choose to call it ahead of time, e.g. if they want to make sure that the model is loaded once the player reaches a certain character, then they could start it when the player enters a new area.

This is a *breaking change* since it renames `run` to `start_model_worker`

I'm open to suggestions, if anyone has a better name.

Closes #52 