### PR TITLE
Rename a bunch of stuff

### DIFF
--- a/example-game/nobody_who_prompt_chat.gd
+++ b/example-game/nobody_who_prompt_chat.gd
@@ -1,11 +1,11 @@
-extends NobodyWhoPromptChat
+extends NobodyWhoChat
 
 func _ready() -> void:
 	say("Hi there! Who are you?")
 
-func _on_completion_updated(text) -> void:
+func _on_response_updated(text: String) -> void:
 	print(text)
 
-func _on_completion_finished() -> void:
+func _on_response_finished(response: String) -> void:
 	print("MODEL FINISHED")
 	say("Interesting... Tell me more.")

--- a/example-game/player.tscn
+++ b/example-game/player.tscn
@@ -5,12 +5,12 @@
 
 [sub_resource type="NobodyWhoSampler" id="NobodyWhoSampler_djbpq"]
 
-[node name="NobodyWhoPromptCompletion" type="Node2D"]
+[node name="World" type="Node2D"]
 
 [node name="NobodyWhoModel" type="NobodyWhoModel" parent="."]
 model_path = "res://model.gguf"
 
-[node name="NobodyWhoPromptChat" type="NobodyWhoPromptChat" parent="." node_paths=PackedStringArray("model_node")]
+[node name="NobodyWhoChat" type="NobodyWhoChat" parent="." node_paths=PackedStringArray("model_node")]
 model_node = NodePath("../NobodyWhoModel")
 sampler = SubResource("NobodyWhoSampler_djbpq")
 prompt = "You are a powerful wizard who always tries to cast spells to turn people into frogs.
@@ -21,5 +21,5 @@ script = ExtResource("2_r1dk7")
 [node name="NobodyWhoDB" type="NobodyWhoDB" parent="."]
 script = ExtResource("2_qeomc")
 
-[connection signal="completion_finished" from="NobodyWhoPromptChat" to="NobodyWhoPromptChat" method="_on_completion_finished"]
-[connection signal="completion_updated" from="NobodyWhoPromptChat" to="NobodyWhoPromptChat" method="_on_completion_updated"]
+[connection signal="response_finished" from="NobodyWhoChat" to="NobodyWhoChat" method="_on_response_finished"]
+[connection signal="response_updated" from="NobodyWhoChat" to="NobodyWhoChat" method="_on_response_updated"]

--- a/nobodywho/nobody.gdextension
+++ b/nobodywho/nobody.gdextension
@@ -1,0 +1,14 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.1
+reloadable = true
+
+[libraries]
+linux.debug.x86_64 =     "res://../nobody/target/debug/libnobody.so"
+linux.release.x86_64 =   "res://../nobody/target/release/libnobody.so"
+windows.debug.x86_64 =   "res://../nobody/target/debug/nobody.dll"
+windows.release.x86_64 = "res://../nobody/target/release/nobody.dll"
+macos.debug =            "res://../nobody/target/debug/libnobody.dylib"
+macos.release =          "res://../nobody/target/release/libnobody.dylib"
+macos.debug.arm64 =      "res://../nobody/target/debug/libnobody.dylib"
+macos.release.arm64 =    "res://../nobody/target/release/libnobody.dylib"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -15,4 +15,4 @@ macos.release.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-
 
 [icons]
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
-NobodyWhoPromptChat =       "res://addons/nobodywho/icon.svg"
+NobodyWhoChat =             "res://addons/nobodywho/icon.svg"

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -137,7 +137,7 @@ struct NobodyWhoChat {
 
     #[export]
     #[var(hint = MULTILINE_TEXT)]
-    prompt: GString,
+    system_prompt: GString,
 
     #[export]
     context_length: u32,
@@ -154,7 +154,7 @@ impl INode for NobodyWhoChat {
         Self {
             model_node: None,
             sampler: None,
-            prompt: "".into(),
+            system_prompt: "".into(),
             context_length: 4096,
             prompt_tx: None,
             completion_rx: None,
@@ -223,7 +223,7 @@ impl NobodyWhoChat {
 
             // start the llm worker
             let n_ctx = self.context_length;
-            let system_prompt = self.prompt.to_string();
+            let system_prompt = self.system_prompt.to_string();
             std::thread::spawn(move || {
                 run_worker(
                     model,

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -128,7 +128,7 @@ impl NobodyWhoModel {
 
 #[derive(GodotClass)]
 #[class(base=Node)]
-struct NobodyWhoPromptChat {
+struct NobodyWhoChat {
     #[export]
     model_node: Option<Gd<NobodyWhoModel>>,
 
@@ -149,7 +149,7 @@ struct NobodyWhoPromptChat {
 }
 
 #[godot_api]
-impl INode for NobodyWhoPromptChat {
+impl INode for NobodyWhoChat {
     fn init(base: Base<Node>) -> Self {
         Self {
             model_node: None,
@@ -167,11 +167,11 @@ impl INode for NobodyWhoPromptChat {
             match rx.try_recv() {
                 Ok(llm::LLMOutput::Token(token)) => {
                     self.base_mut()
-                        .emit_signal("completion_updated", &[Variant::from(token)]);
+                        .emit_signal("response_updated", &[Variant::from(token)]);
                 }
                 Ok(llm::LLMOutput::Done(response)) => {
                     self.base_mut()
-                        .emit_signal("completion_finished", &[Variant::from(response)]);
+                        .emit_signal("response_finished", &[Variant::from(response)]);
                 }
                 Ok(llm::LLMOutput::FatalErr(msg)) => {
                     godot_error!("Model worker crashed: {msg}");
@@ -191,7 +191,7 @@ impl INode for NobodyWhoPromptChat {
 }
 
 #[godot_api]
-impl NobodyWhoPromptChat {
+impl NobodyWhoChat {
     fn get_model(&mut self) -> Result<llm::Model, String> {
         let gd_model_node = self.model_node.as_mut().ok_or("Model node was not set")?;
         let mut nobody_model = gd_model_node.bind_mut();
@@ -260,8 +260,8 @@ impl NobodyWhoPromptChat {
     }
 
     #[signal]
-    fn completion_updated();
+    fn response_updated(new_token: String);
 
     #[signal]
-    fn completion_finished();
+    fn response_finished(response: String);
 }


### PR DESCRIPTION
Since we're already releasing some breaking changes with #54 and #39, I figure this is a good time to do some naming improvements.

In #54, "run()" was renamed to "start_worker()"

I suggest the following renames:

"NobodyWhoPromptChat" becomes "NobodyWhoChat"

"completion_finished" becomes "response_finished"

"completion_updated" becomes "response_updated"

"prompt" becomes "system_prompt"