### PR TITLE
Update sampler to new api from llama-cpp-rs

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -675,7 +675,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.86"
-source = "git+https://github.com/utilityai/llama-cpp-rs?rev=333683b#333683bc5b5d39c77a8e505738c5c6bd0c317bd0"
+source = "git+https://github.com/utilityai/llama-cpp-rs?rev=4d1df04#4d1df04fb28b247494849d018d55a7fcf42c0ee1"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.86"
-source = "git+https://github.com/utilityai/llama-cpp-rs?rev=333683b#333683bc5b5d39c77a8e505738c5c6bd0c317bd0"
+source = "git+https://github.com/utilityai/llama-cpp-rs?rev=4d1df04#4d1df04fb28b247494849d018d55a7fcf42c0ee1"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -11,7 +11,7 @@ encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
 ] }
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "333683b" }
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 thiserror = "2.0.3"
@@ -20,4 +20,4 @@ serde = { version = "1.0.215", features = ["derive"] }
 wgpu = "23.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "333683b", features = [ "vulkan" ] }
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }


### PR DESCRIPTION
A neat thing about the new sampler thing in llama-cpp-rs is that creating a sampler chain no longer returns a `Result`