### PR TITLE
Sampler variants

### DIFF
--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -1,176 +1,19 @@
 mod chat_state;
 mod db;
 mod llm;
+mod sampler_config;
+mod sampler_resource;
 
 use godot::classes::{INode, ProjectSettings};
 use godot::prelude::*;
-use llm::{run_completion_worker, run_embedding_worker, SamplerConfig};
+use llm::{run_completion_worker, run_embedding_worker};
+use sampler_resource::NobodyWhoSampler;
 use std::sync::mpsc::{Receiver, Sender};
 
 struct NobodyWhoExtension;
 
 #[gdextension]
 unsafe impl ExtensionLibrary for NobodyWhoExtension {}
-
-#[derive(GodotConvert, Var, Export, Debug, Clone, Copy)]
-#[godot(via=GString)]
-enum SamplerMethodName {
-    Greedy,
-    Temperature,
-    MirostatV2,
-    TopK,
-}
-
-#[derive(GodotClass)]
-#[class(tool, base=Resource)]
-/// Sampler configuration for the LLM.
-/// This will decide how the LLM selects the next token from the logit probabilities.
-struct NobodyWhoSampler {
-    base: Base<Resource>,
-
-    #[export]
-    method: SamplerMethodName,
-    sampler_config: llm::SamplerConfig
-}
-
-#[godot_api]
-impl IResource for NobodyWhoSampler {
-    fn init(base: Base<Resource>) -> Self {
-        let methodname = match llm::SamplerConfig::default().method {
-            llm::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
-            llm::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
-            llm::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
-            llm::SamplerMethod::Greedy => SamplerMethodName::Greedy,
-        };
-        Self {
-            method: methodname,
-            sampler_config: llm::SamplerConfig::default(),
-            base,
-        }
-    }
-
-    fn get_property_list(&mut self) -> Vec<godot::meta::PropertyInfo> {
-        let base_properties = vec![
-        ];
-        let penalty_properties = vec![
-            godot::meta::PropertyInfo::new_export::<i32>("penalty_last_n"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_repeat"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_freq"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_present"),
-            godot::meta::PropertyInfo::new_export::<bool>("penalize_nl"),
-            godot::meta::PropertyInfo::new_export::<bool>("ignore_eos"),
-        ];
-        let method_properties = match self.method {
-            SamplerMethodName::Greedy => vec![],
-            SamplerMethodName::Temperature => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
-            ],
-            SamplerMethodName::MirostatV2 => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
-                godot::meta::PropertyInfo::new_export::<f32>("tau"),
-                godot::meta::PropertyInfo::new_export::<f32>("eta")
-            ],
-            SamplerMethodName::TopK => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<i32>("top_k"),
-            ],
-        };
-        base_properties.into_iter().chain(penalty_properties).chain(method_properties).collect()
-    }
-
-    fn get_property(&self, property: StringName) -> Option<Variant> {
-        match (&self.sampler_config.method, property.to_string().as_str()) {
-            (_, "method") => Some(Variant::from(self.method)),
-            (_, "penalty_last_n") => Some(Variant::from(self.sampler_config.penalty_last_n)),
-            (_, "penalty_repeat") => Some(Variant::from(self.sampler_config.penalty_repeat)),
-            (_, "penalty_freq") => Some(Variant::from(self.sampler_config.penalty_freq)),
-            (_, "penalty_present") => Some(Variant::from(self.sampler_config.penalty_present)),
-            (_, "penalize_nl") => Some(Variant::from(self.sampler_config.penalize_nl)),
-            (_, "ignore_eos") => Some(Variant::from(self.sampler_config.ignore_eos)),
-            (llm::SamplerMethod::Temperature(conf), "temperature") => Some(Variant::from(conf.temperature)),
-            (llm::SamplerMethod::Temperature(conf), "seed") => Some(Variant::from(conf.seed)),
-            (llm::SamplerMethod::MirostatV2(conf), "eta") => Some(Variant::from(conf.eta)),
-            (llm::SamplerMethod::MirostatV2(conf), "tau") => Some(Variant::from(conf.tau)),
-            (llm::SamplerMethod::MirostatV2(conf), "temperature") => Some(Variant::from(conf.temperature)),
-            (llm::SamplerMethod::MirostatV2(conf), "seed") => Some(Variant::from(conf.seed)),
-            (llm::SamplerMethod::TopK(conf), "top_k") => Some(Variant::from(conf.top_k)),
-            (llm::SamplerMethod::TopK(conf), "seed") => Some(Variant::from(conf.seed)),
-            _ => {
-                // self.base.to_gd().get_property()
-                None
-            }
-            //panic!("Unexpected get property: {:?}", property)
-        }
-    }
-
-    fn set_property(&mut self, property: StringName, value: Variant) -> bool {
-        match (&mut self.sampler_config.method, property.to_string().as_str()) {
-            (_, "method") => {
-                let new_method = SamplerMethodName::try_from_variant(&value).expect("Unexpected: Got invalid sampler method"); 
-                self.method = new_method;
-                self.sampler_config.method = match new_method {
-                    SamplerMethodName::Temperature => llm::SamplerMethod::Temperature(llm::TemperatureConfig::default()),
-                    SamplerMethodName::MirostatV2 => llm::SamplerMethod::MirostatV2(llm::MirostatV2Config::default()),
-                    SamplerMethodName::TopK => llm::SamplerMethod::TopK(llm::TopKConfig::default()),
-                    SamplerMethodName::Greedy => llm::SamplerMethod::Greedy,
-                };
-                self.base.to_gd().upcast::<Object>().notify_property_list_changed();
-                return true;
-            }
-            (_, "penalty_last_n") => {
-                self.sampler_config.penalty_last_n = i32::try_from_variant(&value).expect("Unexpected type for penalty_last_n");
-            }
-            (_, "penalty_repeat") => {
-                self.sampler_config.penalty_repeat = f32::try_from_variant(&value).expect("Unexpected type for penalty_repeat");
-            }
-            (_, "penalty_freq") => {
-                self.sampler_config.penalty_freq = f32::try_from_variant(&value).expect("Unexpected type for penalty_freq");
-            }
-            (_, "penalty_present") => {
-                self.sampler_config.penalty_present = f32::try_from_variant(&value).expect("Unexpected type for penalty_present");
-            }
-            (_, "penalize_nl") => {
-                self.sampler_config.penalize_nl = bool::try_from_variant(&value).expect("Unexpected type for penalize_nl");
-            }
-            (_, "ignore_eos") => {
-                self.sampler_config.ignore_eos = bool::try_from_variant(&value).expect("Unexpected type for ignore_eos");
-            }
-
-            (llm::SamplerMethod::Temperature(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-            (llm::SamplerMethod::Temperature(conf), "temperature") => {
-                conf.temperature = f32::try_from_variant(&value).expect("Unexpected type for temperature");
-            }
-
-            (llm::SamplerMethod::MirostatV2(conf), "tau") => {
-                conf.tau = f32::try_from_variant(&value).expect("Unexpected type for tau");
-            }
-            (llm::SamplerMethod::MirostatV2(conf), "eta") => {
-                conf.eta = f32::try_from_variant(&value).expect("Unexpected type for eta");
-            }
-            (llm::SamplerMethod::MirostatV2(conf), "temperature") => {
-                conf.temperature = f32::try_from_variant(&value).expect("Unexpected type for temperature");
-            }
-            (llm::SamplerMethod::MirostatV2(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-
-            (llm::SamplerMethod::TopK(conf), "top_k") => {
-                conf.top_k = i32::try_from_variant(&value).expect("Unexpected type for top_k");
-            }
-            (llm::SamplerMethod::TopK(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-            _ => godot_warn!("Set unexpected property name: {:?}", property)
-        }
-        true
-
-    }
-}
-
 
 #[derive(GodotClass)]
 #[class(base=Node)]
@@ -332,12 +175,12 @@ impl NobodyWhoChat {
         Ok(model)
     }
 
-    fn get_sampler_config(&mut self) -> SamplerConfig {
+    fn get_sampler_config(&mut self) -> sampler_config::SamplerConfig {
         if let Some(gd_sampler) = self.sampler.as_mut() {
             let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
             nobody_sampler.sampler_config.clone()
         } else {
-            llm::SamplerConfig::default()
+            sampler_config::SamplerConfig::default()
         }
     }
 

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -12,6 +12,14 @@ struct NobodyWhoExtension;
 #[gdextension]
 unsafe impl ExtensionLibrary for NobodyWhoExtension {}
 
+#[derive(GodotConvert, Var, Export, Debug, Clone, Copy)]
+#[godot(via=GString)]
+enum SamplerMethod {
+    Greedy,
+    Temperature,
+    MirostatV2
+}
+
 #[derive(GodotClass)]
 #[class(tool, base=Resource)]
 /// Sampler configuration for the LLM.
@@ -20,72 +28,70 @@ struct NobodyWhoSampler {
     base: Base<Resource>,
 
     #[export]
-    /// The seed to use for the LLM.
-    seed: u32,
-    #[export]
-    /// The temperature for the LLM. This controls the randomness of the LLM. A high temperature
-    /// will make the LLM "creative" with its responses, while a low score will make it more deterministic.
-    temperature: f32,
-    #[export]
-    /// The repeat-last-n option controls the number of tokens in the history to consider for penalizing repetition. A larger value will look further back in the generated text to prevent repetitions, while a smaller value will only consider recent tokens. A value of 0 disables the penalty,
-    penalty_last_n: i32,
-    #[export]
-    /// The repeat-penalty option helps prevent the model from generating repetitive or monotonous text. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient. The default value is 1.
-    penalty_repeat: f32,
-    #[export]
-    /// Decreases the likelihood of repeating tokens based on how often they appear.
-    penalty_freq: f32,
-    #[export]
-    /// Binary penalty if the token has apeared before.
-    penalty_present: f32,
-    #[export]
-    /// Penalizes newlines.
-    penalize_nl: bool,
-    #[export]
-    /// Ignores end of sentence tokens.
-    ignore_eos: bool,
-    #[export]
-    /// Sets the Mirostat target entropy (tau), which represents the desired perplexity value for the generated text. Adjusting the target entropy allows you to control the balance between coherence and diversity in the generated text. A lower value will result in more focused and coherent text, while a higher value will lead to more diverse and potentially less coherent text. The default value is 5.0.
-    mirostat_tau: f32,
-    #[export]
-    /// Sets the Mirostat learning rate (eta). The learning rate influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. The default value is 0.1.
-    mirostat_eta: f32,
+    method: SamplerMethod,
+    sampler_config: llm::SamplerConfig
 }
 
 #[godot_api]
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
-        let sampler_config = SamplerConfig::default();
-        Self {
-            base,
-            seed: sampler_config.seed,
-            temperature: sampler_config.temperature,
-            penalty_last_n: sampler_config.penalty_last_n,
-            penalty_repeat: sampler_config.penalty_repeat,
-            penalty_freq: sampler_config.penalty_freq,
-            penalty_present: sampler_config.penalty_present,
-            penalize_nl: sampler_config.penalize_nl,
-            ignore_eos: sampler_config.ignore_eos,
-            mirostat_tau: sampler_config.mirostat_tau,
-            mirostat_eta: sampler_config.mirostat_eta,
+        match llm::DEFAULT_SAMPLER_CONFIG {
+            llm::SamplerConfig::MirostatV2(config) => {
+                Self {
+                    method: SamplerMethod::MirostatV2,
+                    sampler_config: llm::DEFAULT_SAMPLER_CONFIG,
+                    base,
+                }
+            }
         }
+    }
+
+    fn get_property_list(&mut self) -> Vec<godot::meta::PropertyInfo> {
+        let base_properties = vec![
+        ];
+        let penalty_properties = vec![
+            godot::meta::PropertyInfo::new_export::<i32>("penalty_last_n"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_repeat"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_freq"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_present"),
+            godot::meta::PropertyInfo::new_export::<bool>("penalize_nl"),
+            godot::meta::PropertyInfo::new_export::<bool>("ignore_eos"),
+        ];
+        let method_properties = match self.method {
+            SamplerMethod::Greedy => vec![],
+            SamplerMethod::Temperature => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<f32>("temperature")
+            ],
+            SamplerMethod::MirostatV2 => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<f32>("tau"),
+                godot::meta::PropertyInfo::new_export::<f32>("eta")
+            ]
+        };
+        base_properties.into_iter().chain(penalty_properties).chain(method_properties).collect()
+    }
+
+    // fn get_property() {
+    // }
+
+    fn set_property(&mut self, property: StringName, value: Variant) -> bool {
+        // let mut obj: Gd<Object> = self.base.to_gd().upcast::<Object>();
+        // // this line doesn't work:
+        // self.base.notify_property_list_changed();
+        if property == "method".into() {
+            let new_method = SamplerMethod::try_from_variant(&value).expect("Unexpected: Got invalid sampler method"); 
+            self.method = new_method;
+            self.base.to_gd().upcast::<Object>().notify_property_list_changed();
+            return true;
+        }
+        true
     }
 }
 
 impl NobodyWhoSampler {
     pub fn get_sampler_config(&self) -> llm::SamplerConfig {
-        llm::SamplerConfig {
-            seed: self.seed,
-            temperature: self.temperature,
-            penalty_last_n: self.penalty_last_n,
-            penalty_repeat: self.penalty_repeat,
-            penalty_freq: self.penalty_freq,
-            penalty_present: self.penalty_present,
-            penalize_nl: self.penalize_nl,
-            ignore_eos: self.ignore_eos,
-            mirostat_tau: self.mirostat_tau,
-            mirostat_eta: self.mirostat_eta,
-        }
+        llm::DEFAULT_SAMPLER_CONFIG
     }
 }
 

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -35,14 +35,14 @@ struct NobodyWhoSampler {
 #[godot_api]
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
-        let methodname = match llm::DEFAULT_SAMPLER_CONFIG.method {
+        let methodname = match llm::SamplerConfig::default().method {
             llm::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
             llm::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
             llm::SamplerMethod::Greedy => SamplerMethodName::Greedy,
         };
         Self {
             method: methodname,
-            sampler_config: llm::DEFAULT_SAMPLER_CONFIG,
+            sampler_config: llm::SamplerConfig::default(),
             base,
         }
     }
@@ -89,7 +89,11 @@ impl IResource for NobodyWhoSampler {
             (llm::SamplerMethod::MirostatV2(conf), "tau") => Some(Variant::from(conf.tau)),
             (llm::SamplerMethod::MirostatV2(conf), "temperature") => Some(Variant::from(conf.temperature)),
             (llm::SamplerMethod::MirostatV2(conf), "seed") => Some(Variant::from(conf.seed)),
-            _ => panic!("Unexpected get property: {:?}", property)
+            _ => {
+                // self.base.to_gd().get_property()
+                None
+            }
+            //panic!("Unexpected get property: {:?}", property)
         }
     }
 
@@ -98,6 +102,11 @@ impl IResource for NobodyWhoSampler {
             (_, "method") => {
                 let new_method = SamplerMethodName::try_from_variant(&value).expect("Unexpected: Got invalid sampler method"); 
                 self.method = new_method;
+                self.sampler_config.method = match new_method {
+                    SamplerMethodName::Temperature => llm::SamplerMethod::Temperature(llm::TemperatureConfig::default()),
+                    SamplerMethodName::MirostatV2 => llm::SamplerMethod::MirostatV2(llm::MirostatV2Config::default()),
+                    SamplerMethodName::Greedy => llm::SamplerMethod::Greedy,
+                };
                 self.base.to_gd().upcast::<Object>().notify_property_list_changed();
                 return true;
             }
@@ -139,7 +148,7 @@ impl IResource for NobodyWhoSampler {
             (llm::SamplerMethod::MirostatV2(conf), "seed") => {
                 conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
             }
-            _ => panic!("Unexpected property name: {:?}", property)
+            _ => godot_warn!("Set unexpected property name: {:?}", property)
         }
         true
 
@@ -312,7 +321,7 @@ impl NobodyWhoChat {
             let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
             nobody_sampler.sampler_config.clone()
         } else {
-            SamplerConfig::default()
+            llm::SamplerConfig::default()
         }
     }
 

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -14,7 +14,7 @@ unsafe impl ExtensionLibrary for NobodyWhoExtension {}
 
 #[derive(GodotConvert, Var, Export, Debug, Clone, Copy)]
 #[godot(via=GString)]
-enum SamplerMethod {
+enum SamplerMethodName {
     Greedy,
     Temperature,
     MirostatV2
@@ -28,21 +28,22 @@ struct NobodyWhoSampler {
     base: Base<Resource>,
 
     #[export]
-    method: SamplerMethod,
+    method: SamplerMethodName,
     sampler_config: llm::SamplerConfig
 }
 
 #[godot_api]
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
-        match llm::DEFAULT_SAMPLER_CONFIG {
-            llm::SamplerConfig::MirostatV2(config) => {
-                Self {
-                    method: SamplerMethod::MirostatV2,
-                    sampler_config: llm::DEFAULT_SAMPLER_CONFIG,
-                    base,
-                }
-            }
+        let methodname = match llm::DEFAULT_SAMPLER_CONFIG.method {
+            llm::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
+            llm::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
+            llm::SamplerMethod::Greedy => SamplerMethodName::Greedy,
+        };
+        Self {
+            method: methodname,
+            sampler_config: llm::DEFAULT_SAMPLER_CONFIG,
+            base,
         }
     }
 
@@ -58,13 +59,14 @@ impl IResource for NobodyWhoSampler {
             godot::meta::PropertyInfo::new_export::<bool>("ignore_eos"),
         ];
         let method_properties = match self.method {
-            SamplerMethod::Greedy => vec![],
-            SamplerMethod::Temperature => vec![
+            SamplerMethodName::Greedy => vec![],
+            SamplerMethodName::Temperature => vec![
                 godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<f32>("temperature")
+                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
             ],
-            SamplerMethod::MirostatV2 => vec![
+            SamplerMethodName::MirostatV2 => vec![
                 godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
                 godot::meta::PropertyInfo::new_export::<f32>("tau"),
                 godot::meta::PropertyInfo::new_export::<f32>("eta")
             ]
@@ -72,28 +74,78 @@ impl IResource for NobodyWhoSampler {
         base_properties.into_iter().chain(penalty_properties).chain(method_properties).collect()
     }
 
-    // fn get_property() {
-    // }
+    fn get_property(&self, property: StringName) -> Option<Variant> {
+        match (&self.sampler_config.method, property.to_string().as_str()) {
+            (_, "method") => Some(Variant::from(self.method)),
+            (_, "penalty_last_n") => Some(Variant::from(self.sampler_config.penalty_last_n)),
+            (_, "penalty_repeat") => Some(Variant::from(self.sampler_config.penalty_repeat)),
+            (_, "penalty_freq") => Some(Variant::from(self.sampler_config.penalty_freq)),
+            (_, "penalty_present") => Some(Variant::from(self.sampler_config.penalty_present)),
+            (_, "penalize_nl") => Some(Variant::from(self.sampler_config.penalize_nl)),
+            (_, "ignore_eos") => Some(Variant::from(self.sampler_config.ignore_eos)),
+            (llm::SamplerMethod::Temperature(conf), "temperature") => Some(Variant::from(conf.temperature)),
+            (llm::SamplerMethod::Temperature(conf), "seed") => Some(Variant::from(conf.seed)),
+            (llm::SamplerMethod::MirostatV2(conf), "eta") => Some(Variant::from(conf.eta)),
+            (llm::SamplerMethod::MirostatV2(conf), "tau") => Some(Variant::from(conf.tau)),
+            (llm::SamplerMethod::MirostatV2(conf), "temperature") => Some(Variant::from(conf.temperature)),
+            (llm::SamplerMethod::MirostatV2(conf), "seed") => Some(Variant::from(conf.seed)),
+            _ => panic!("Unexpected get property: {:?}", property)
+        }
+    }
 
     fn set_property(&mut self, property: StringName, value: Variant) -> bool {
-        // let mut obj: Gd<Object> = self.base.to_gd().upcast::<Object>();
-        // // this line doesn't work:
-        // self.base.notify_property_list_changed();
-        if property == "method".into() {
-            let new_method = SamplerMethod::try_from_variant(&value).expect("Unexpected: Got invalid sampler method"); 
-            self.method = new_method;
-            self.base.to_gd().upcast::<Object>().notify_property_list_changed();
-            return true;
+        match (&mut self.sampler_config.method, property.to_string().as_str()) {
+            (_, "method") => {
+                let new_method = SamplerMethodName::try_from_variant(&value).expect("Unexpected: Got invalid sampler method"); 
+                self.method = new_method;
+                self.base.to_gd().upcast::<Object>().notify_property_list_changed();
+                return true;
+            }
+            (_, "penalty_last_n") => {
+                self.sampler_config.penalty_last_n = i32::try_from_variant(&value).expect("Unexpected type for penalty_last_n");
+            }
+            (_, "penalty_repeat") => {
+                self.sampler_config.penalty_repeat = f32::try_from_variant(&value).expect("Unexpected type for penalty_repeat");
+            }
+            (_, "penalty_freq") => {
+                self.sampler_config.penalty_freq = f32::try_from_variant(&value).expect("Unexpected type for penalty_freq");
+            }
+            (_, "penalty_present") => {
+                self.sampler_config.penalty_present = f32::try_from_variant(&value).expect("Unexpected type for penalty_present");
+            }
+            (_, "penalize_nl") => {
+                self.sampler_config.penalize_nl = bool::try_from_variant(&value).expect("Unexpected type for penalize_nl");
+            }
+            (_, "ignore_eos") => {
+                self.sampler_config.ignore_eos = bool::try_from_variant(&value).expect("Unexpected type for ignore_eos");
+            }
+
+            (llm::SamplerMethod::Temperature(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+            (llm::SamplerMethod::Temperature(conf), "temperature") => {
+                conf.temperature = f32::try_from_variant(&value).expect("Unexpected type for temperature");
+            }
+
+            (llm::SamplerMethod::MirostatV2(conf), "tau") => {
+                conf.tau = f32::try_from_variant(&value).expect("Unexpected type for tau");
+            }
+            (llm::SamplerMethod::MirostatV2(conf), "eta") => {
+                conf.eta = f32::try_from_variant(&value).expect("Unexpected type for eta");
+            }
+            (llm::SamplerMethod::MirostatV2(conf), "temperature") => {
+                conf.temperature = f32::try_from_variant(&value).expect("Unexpected type for temperature");
+            }
+            (llm::SamplerMethod::MirostatV2(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+            _ => panic!("Unexpected property name: {:?}", property)
         }
         true
+
     }
 }
 
-impl NobodyWhoSampler {
-    pub fn get_sampler_config(&self) -> llm::SamplerConfig {
-        llm::DEFAULT_SAMPLER_CONFIG
-    }
-}
 
 #[derive(GodotClass)]
 #[class(base=Node)]
@@ -258,7 +310,7 @@ impl NobodyWhoChat {
     fn get_sampler_config(&mut self) -> SamplerConfig {
         if let Some(gd_sampler) = self.sampler.as_mut() {
             let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
-            nobody_sampler.get_sampler_config()
+            nobody_sampler.sampler_config.clone()
         } else {
             SamplerConfig::default()
         }

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -17,7 +17,8 @@ unsafe impl ExtensionLibrary for NobodyWhoExtension {}
 enum SamplerMethodName {
     Greedy,
     Temperature,
-    MirostatV2
+    MirostatV2,
+    TopK,
 }
 
 #[derive(GodotClass)]
@@ -38,6 +39,7 @@ impl IResource for NobodyWhoSampler {
         let methodname = match llm::SamplerConfig::default().method {
             llm::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
             llm::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
+            llm::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
             llm::SamplerMethod::Greedy => SamplerMethodName::Greedy,
         };
         Self {
@@ -69,7 +71,11 @@ impl IResource for NobodyWhoSampler {
                 godot::meta::PropertyInfo::new_export::<f32>("temperature"),
                 godot::meta::PropertyInfo::new_export::<f32>("tau"),
                 godot::meta::PropertyInfo::new_export::<f32>("eta")
-            ]
+            ],
+            SamplerMethodName::TopK => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<i32>("top_k"),
+            ],
         };
         base_properties.into_iter().chain(penalty_properties).chain(method_properties).collect()
     }
@@ -89,6 +95,8 @@ impl IResource for NobodyWhoSampler {
             (llm::SamplerMethod::MirostatV2(conf), "tau") => Some(Variant::from(conf.tau)),
             (llm::SamplerMethod::MirostatV2(conf), "temperature") => Some(Variant::from(conf.temperature)),
             (llm::SamplerMethod::MirostatV2(conf), "seed") => Some(Variant::from(conf.seed)),
+            (llm::SamplerMethod::TopK(conf), "top_k") => Some(Variant::from(conf.top_k)),
+            (llm::SamplerMethod::TopK(conf), "seed") => Some(Variant::from(conf.seed)),
             _ => {
                 // self.base.to_gd().get_property()
                 None
@@ -105,6 +113,7 @@ impl IResource for NobodyWhoSampler {
                 self.sampler_config.method = match new_method {
                     SamplerMethodName::Temperature => llm::SamplerMethod::Temperature(llm::TemperatureConfig::default()),
                     SamplerMethodName::MirostatV2 => llm::SamplerMethod::MirostatV2(llm::MirostatV2Config::default()),
+                    SamplerMethodName::TopK => llm::SamplerMethod::TopK(llm::TopKConfig::default()),
                     SamplerMethodName::Greedy => llm::SamplerMethod::Greedy,
                 };
                 self.base.to_gd().upcast::<Object>().notify_property_list_changed();
@@ -146,6 +155,13 @@ impl IResource for NobodyWhoSampler {
                 conf.temperature = f32::try_from_variant(&value).expect("Unexpected type for temperature");
             }
             (llm::SamplerMethod::MirostatV2(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+
+            (llm::SamplerMethod::TopK(conf), "top_k") => {
+                conf.top_k = i32::try_from_variant(&value).expect("Unexpected type for top_k");
+            }
+            (llm::SamplerMethod::TopK(conf), "seed") => {
                 conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
             }
             _ => godot_warn!("Set unexpected property name: {:?}", property)

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -1,4 +1,3 @@
-use crate::chat_state;
 use lazy_static::lazy_static;
 use llama_cpp_2::context::params::LlamaContextParams;
 use llama_cpp_2::context::LlamaContext;

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -94,6 +94,27 @@ pub struct SamplerConfig {
     pub ignore_eos: bool,
 }
 
+impl Default for SamplerConfig {
+    fn default () -> Self {
+        Self {
+            penalty_last_n: -1,
+            penalty_repeat: 0.0,
+            penalty_freq: 0.0,
+            penalty_present: 0.0,
+            penalize_nl: false,
+            ignore_eos: false,
+            method : SamplerMethod::Temperature(TemperatureConfig::default()),
+            // method : SamplerMethod::MirostatV2(MirostatV2Config {
+            //     seed: 1234,
+            //     temperature: 0.8,
+            //     tau: 5.0,
+            //     eta: 0.1,
+            // }),
+        }
+    }
+}
+
+
 #[derive(Clone)]
 pub enum SamplerMethod {
     MirostatV2(MirostatV2Config),
@@ -109,27 +130,31 @@ pub struct MirostatV2Config {
     pub eta: f32,
 }
 
+impl Default for MirostatV2Config {
+    fn default() -> Self {
+        Self {
+            seed: 1234,
+            temperature: 0.8,
+            tau: 5.0,
+            eta: 0.1
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct TemperatureConfig {
     pub seed: u32,
     pub temperature: f32,
 }
 
-// defaults here match the defaults read from `llama-cli --help`
-pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig {
-    penalty_last_n: -1,
-    penalty_repeat: 0.0,
-    penalty_freq: 0.0,
-    penalty_present: 0.0,
-    penalize_nl: false,
-    ignore_eos: false,
-    method : SamplerMethod::MirostatV2(MirostatV2Config {
-        seed: 1234,
-        temperature: 0.8,
-        tau: 5.0,
-        eta: 0.1,
-    }),
-};
+impl Default for TemperatureConfig {
+    fn default() -> Self {
+        Self {
+            seed: 1234,
+            temperature: 0.8,
+        }
+    }
+}
 
 fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampler {
     // init mirostat sampler

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -83,62 +83,87 @@ pub fn get_model(
     Ok(Arc::new(model))
 }
 
-pub enum SamplerConfig {
-    MirostatV2(MirostatV2Config)
-}
-
-pub struct MirostatV2Config {
-    pub seed: u32,
-    pub temperature: f32,
+#[derive(Clone)]
+pub struct SamplerConfig {
+    pub method: SamplerMethod,
     pub penalty_last_n: i32,
     pub penalty_repeat: f32,
     pub penalty_freq: f32,
     pub penalty_present: f32,
     pub penalize_nl: bool,
     pub ignore_eos: bool,
-    pub mirostat_tau: f32,
-    pub mirostat_eta: f32,
+}
+
+#[derive(Clone)]
+pub enum SamplerMethod {
+    MirostatV2(MirostatV2Config),
+    Temperature(TemperatureConfig),
+    Greedy,
+}
+
+#[derive(Clone)]
+pub struct MirostatV2Config {
+    pub seed: u32,
+    pub temperature: f32,
+    pub tau: f32,
+    pub eta: f32,
+}
+
+#[derive(Clone)]
+pub struct TemperatureConfig {
+    pub seed: u32,
+    pub temperature: f32,
 }
 
 // defaults here match the defaults read from `llama-cli --help`
-pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig::MirostatV2( MirostatV2Config {
-    seed: 1234,
-    temperature: 0.8,
+pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig {
     penalty_last_n: -1,
     penalty_repeat: 0.0,
     penalty_freq: 0.0,
     penalty_present: 0.0,
     penalize_nl: false,
     ignore_eos: false,
-    mirostat_tau: 5.0,
-    mirostat_eta: 0.1,
-});
+    method : SamplerMethod::MirostatV2(MirostatV2Config {
+        seed: 1234,
+        temperature: 0.8,
+        tau: 5.0,
+        eta: 0.1,
+    }),
+};
 
 fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampler {
     // init mirostat sampler
-    match sampler_config {
-        SamplerConfig::MirostatV2(config) => {
-            LlamaSampler::chain(
-                [
-                    LlamaSampler::penalties(
-                        model.n_vocab(),
-                        model.token_eos().0,
-                        model.token_nl().0,
-                        config.penalty_last_n,
-                        config.penalty_repeat,
-                        config.penalty_freq,
-                        config.penalty_present,
-                        config.penalize_nl,
-                        config.ignore_eos,
-                    ),
-                    LlamaSampler::temp(config.temperature),
-                    //LlamaSampler::mirostat_v2(config.seed, config.mirostat_tau, config.mirostat_eta),
-                    LlamaSampler::dist(config.seed),
-                ],
-                true, // no pperf
-            )
+    let penalties = LlamaSampler::penalties(
+        model.n_vocab(),
+        model.token_eos().0,
+        model.token_nl().0,
+        sampler_config.penalty_last_n,
+        sampler_config.penalty_repeat,
+        sampler_config.penalty_freq,
+        sampler_config.penalty_present,
+        sampler_config.penalize_nl,
+        sampler_config.ignore_eos,
+    );
+    let chainvec = match sampler_config.method {
+        SamplerMethod::MirostatV2(conf) => {
+            vec![
+                penalties,
+                LlamaSampler::temp(conf.temperature),
+                LlamaSampler::mirostat_v2(conf.seed, conf.tau, conf.eta),
+            ]
+        },
+        SamplerMethod::Temperature(conf) => {
+            vec![
+                penalties,
+                LlamaSampler::temp(conf.temperature),
+                LlamaSampler::dist(conf.seed),
+            ]
         }
-    }
+        SamplerMethod::Greedy => {
+            vec![LlamaSampler::greedy()]
+        }
+    };
+    LlamaSampler::chain(chainvec, true)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -123,6 +123,7 @@ pub enum SamplerMethod {
     Greedy,
 }
 
+#[derive(Clone)]
 pub struct TopKConfig {
     pub top_k: i32,
     pub seed: u32
@@ -181,7 +182,7 @@ fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampl
         sampler_config.penalize_nl,
         sampler_config.ignore_eos,
     );
-    let methodvec = match sampler_config.method {
+    let chainvec = match sampler_config.method {
         SamplerMethod::MirostatV2(conf) => {
             vec![
                 penalties,
@@ -197,16 +198,19 @@ fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampl
             ]
         }
         SamplerMethod::Greedy => {
-            vec![LlamaSampler::greedy()]
+            vec![
+                penalties,
+                LlamaSampler::greedy()
+            ]
         }
         SamplerMethod::TopK(conf) => {
             vec![
+                penalties,
                 LlamaSampler::top_k(conf.top_k),
                 LlamaSampler::dist(conf.seed)
             ]
         }
     };
-    let chainvec = vec![penalties].into_iter().chain(methodvec).collect();
     LlamaSampler::chain(chainvec, true)
 }
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -83,8 +83,11 @@ pub fn get_model(
     Ok(Arc::new(model))
 }
 
-// random candidates
-pub struct SamplerConfig {
+pub enum SamplerConfig {
+    MirostatV2(MirostatV2Config)
+}
+
+pub struct MirostatV2Config {
     pub seed: u32,
     pub temperature: f32,
     pub penalty_last_n: i32,
@@ -97,44 +100,45 @@ pub struct SamplerConfig {
     pub mirostat_eta: f32,
 }
 
-impl Default for SamplerConfig {
-    fn default() -> Self {
-        SamplerConfig {
-            seed: 1234,
-            temperature: 0.8,
-            penalty_last_n: -1,
-            penalty_repeat: 0.0,
-            penalty_freq: 0.0,
-            penalty_present: 0.0,
-            penalize_nl: false,
-            ignore_eos: false,
-            mirostat_tau: 5.0,
-            mirostat_eta: 0.1,
+// defaults here match the defaults read from `llama-cli --help`
+pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig::MirostatV2( MirostatV2Config {
+    seed: 1234,
+    temperature: 0.8,
+    penalty_last_n: -1,
+    penalty_repeat: 0.0,
+    penalty_freq: 0.0,
+    penalty_present: 0.0,
+    penalize_nl: false,
+    ignore_eos: false,
+    mirostat_tau: 5.0,
+    mirostat_eta: 0.1,
+});
+
+fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampler {
+    // init mirostat sampler
+    match sampler_config {
+        SamplerConfig::MirostatV2(config) => {
+            LlamaSampler::chain(
+                [
+                    LlamaSampler::penalties(
+                        model.n_vocab(),
+                        model.token_eos().0,
+                        model.token_nl().0,
+                        config.penalty_last_n,
+                        config.penalty_repeat,
+                        config.penalty_freq,
+                        config.penalty_present,
+                        config.penalize_nl,
+                        config.ignore_eos,
+                    ),
+                    LlamaSampler::temp(config.temperature),
+                    //LlamaSampler::mirostat_v2(config.seed, config.mirostat_tau, config.mirostat_eta),
+                    LlamaSampler::dist(config.seed),
+                ],
+                true, // no pperf
+            )
         }
     }
-}
-
-fn make_sampler(model: &LlamaModel, config: SamplerConfig) -> LlamaSampler {
-    // init mirostat sampler
-    LlamaSampler::chain(
-        [
-            LlamaSampler::penalties(
-                model.n_vocab(),
-                model.token_eos().0,
-                model.token_nl().0,
-                config.penalty_last_n,
-                config.penalty_repeat,
-                config.penalty_freq,
-                config.penalty_present,
-                config.penalize_nl,
-                config.ignore_eos,
-            ),
-            LlamaSampler::temp(config.temperature),
-            //LlamaSampler::mirostat_v2(config.seed, config.mirostat_tau, config.mirostat_eta),
-            LlamaSampler::dist(config.seed),
-        ],
-        true, // Do not calculate performance metrics
-    )
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -119,7 +119,19 @@ impl Default for SamplerConfig {
 pub enum SamplerMethod {
     MirostatV2(MirostatV2Config),
     Temperature(TemperatureConfig),
+    TopK(TopKConfig),
     Greedy,
+}
+
+pub struct TopKConfig {
+    pub top_k: i32,
+    pub seed: u32
+}
+
+impl Default for TopKConfig {
+    fn default() -> Self {
+        Self { top_k : 40, seed : 1234 }
+    }
 }
 
 #[derive(Clone)]
@@ -169,7 +181,7 @@ fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampl
         sampler_config.penalize_nl,
         sampler_config.ignore_eos,
     );
-    let chainvec = match sampler_config.method {
+    let methodvec = match sampler_config.method {
         SamplerMethod::MirostatV2(conf) => {
             vec![
                 penalties,
@@ -187,7 +199,14 @@ fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampl
         SamplerMethod::Greedy => {
             vec![LlamaSampler::greedy()]
         }
+        SamplerMethod::TopK(conf) => {
+            vec![
+                LlamaSampler::top_k(conf.top_k),
+                LlamaSampler::dist(conf.seed)
+            ]
+        }
     };
+    let chainvec = vec![penalties].into_iter().chain(methodvec).collect();
     LlamaSampler::chain(chainvec, true)
 }
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -7,7 +7,6 @@ use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::model::{AddBos, Special};
-use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 use std::pin::pin;
 use std::sync::mpsc::{Receiver, Sender};

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -12,6 +12,8 @@ use llama_cpp_2::token::LlamaToken;
 use std::pin::pin;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, LazyLock, Mutex};
+use crate::chat_state;
+use crate::sampler_config::{make_sampler, SamplerConfig};
 
 const MAX_TOKEN_STR_LEN: usize = 128;
 
@@ -81,137 +83,6 @@ pub fn get_model(
             ))
         })?;
     Ok(Arc::new(model))
-}
-
-#[derive(Clone)]
-pub struct SamplerConfig {
-    pub method: SamplerMethod,
-    pub penalty_last_n: i32,
-    pub penalty_repeat: f32,
-    pub penalty_freq: f32,
-    pub penalty_present: f32,
-    pub penalize_nl: bool,
-    pub ignore_eos: bool,
-}
-
-impl Default for SamplerConfig {
-    fn default () -> Self {
-        Self {
-            penalty_last_n: -1,
-            penalty_repeat: 0.0,
-            penalty_freq: 0.0,
-            penalty_present: 0.0,
-            penalize_nl: false,
-            ignore_eos: false,
-            method : SamplerMethod::Temperature(TemperatureConfig::default()),
-            // method : SamplerMethod::MirostatV2(MirostatV2Config {
-            //     seed: 1234,
-            //     temperature: 0.8,
-            //     tau: 5.0,
-            //     eta: 0.1,
-            // }),
-        }
-    }
-}
-
-
-#[derive(Clone)]
-pub enum SamplerMethod {
-    MirostatV2(MirostatV2Config),
-    Temperature(TemperatureConfig),
-    TopK(TopKConfig),
-    Greedy,
-}
-
-#[derive(Clone)]
-pub struct TopKConfig {
-    pub top_k: i32,
-    pub seed: u32
-}
-
-impl Default for TopKConfig {
-    fn default() -> Self {
-        Self { top_k : 40, seed : 1234 }
-    }
-}
-
-#[derive(Clone)]
-pub struct MirostatV2Config {
-    pub seed: u32,
-    pub temperature: f32,
-    pub tau: f32,
-    pub eta: f32,
-}
-
-impl Default for MirostatV2Config {
-    fn default() -> Self {
-        Self {
-            seed: 1234,
-            temperature: 0.8,
-            tau: 5.0,
-            eta: 0.1
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct TemperatureConfig {
-    pub seed: u32,
-    pub temperature: f32,
-}
-
-impl Default for TemperatureConfig {
-    fn default() -> Self {
-        Self {
-            seed: 1234,
-            temperature: 0.8,
-        }
-    }
-}
-
-fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampler {
-    // init mirostat sampler
-    let penalties = LlamaSampler::penalties(
-        model.n_vocab(),
-        model.token_eos().0,
-        model.token_nl().0,
-        sampler_config.penalty_last_n,
-        sampler_config.penalty_repeat,
-        sampler_config.penalty_freq,
-        sampler_config.penalty_present,
-        sampler_config.penalize_nl,
-        sampler_config.ignore_eos,
-    );
-    let chainvec = match sampler_config.method {
-        SamplerMethod::MirostatV2(conf) => {
-            vec![
-                penalties,
-                LlamaSampler::temp(conf.temperature),
-                LlamaSampler::mirostat_v2(conf.seed, conf.tau, conf.eta),
-            ]
-        },
-        SamplerMethod::Temperature(conf) => {
-            vec![
-                penalties,
-                LlamaSampler::temp(conf.temperature),
-                LlamaSampler::dist(conf.seed),
-            ]
-        }
-        SamplerMethod::Greedy => {
-            vec![
-                penalties,
-                LlamaSampler::greedy()
-            ]
-        }
-        SamplerMethod::TopK(conf) => {
-            vec![
-                penalties,
-                LlamaSampler::top_k(conf.top_k),
-                LlamaSampler::dist(conf.seed)
-            ]
-        }
-    };
-    LlamaSampler::chain(chainvec, true)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nobodywho/src/sampler_config.rs
+++ b/nobodywho/src/sampler_config.rs
@@ -21,32 +21,40 @@ impl Default for SamplerConfig {
             penalty_present: 0.0,
             penalize_nl: false,
             ignore_eos: false,
-            method: SamplerMethod::Temperature(TemperatureConfig::default()),
-            // method : SamplerMethod::MirostatV2(MirostatV2Config {
-            //     seed: 1234,
-            //     temperature: 0.8,
-            //     tau: 5.0,
-            //     eta: 0.1,
-            // }),
+            method: SamplerMethod::MirostatV2(MirostatV2 {
+                seed: 1234,
+                temperature: 0.8,
+                tau: 5.0,
+                eta: 0.1,
+            }),
         }
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum SamplerMethod {
-    MirostatV2(MirostatV2Config),
-    Temperature(TemperatureConfig),
-    TopK(TopKConfig),
-    Greedy,
+    MirostatV2(MirostatV2),
+    Temperature(Temperature),
+    TopK(TopK),
+    Greedy(Greedy),
 }
 
-#[derive(Clone)]
-pub struct TopKConfig {
+#[derive(Clone, Debug)]
+pub struct Greedy {}
+
+impl Default for Greedy {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TopK {
     pub top_k: i32,
     pub seed: u32,
 }
 
-impl Default for TopKConfig {
+impl Default for TopK {
     fn default() -> Self {
         Self {
             top_k: 40,
@@ -55,15 +63,15 @@ impl Default for TopKConfig {
     }
 }
 
-#[derive(Clone)]
-pub struct MirostatV2Config {
+#[derive(Clone, Debug)]
+pub struct MirostatV2 {
     pub seed: u32,
     pub temperature: f32,
     pub tau: f32,
     pub eta: f32,
 }
 
-impl Default for MirostatV2Config {
+impl Default for MirostatV2 {
     fn default() -> Self {
         Self {
             seed: 1234,
@@ -74,13 +82,13 @@ impl Default for MirostatV2Config {
     }
 }
 
-#[derive(Clone)]
-pub struct TemperatureConfig {
+#[derive(Clone, Debug)]
+pub struct Temperature {
     pub seed: u32,
     pub temperature: f32,
 }
 
-impl Default for TemperatureConfig {
+impl Default for Temperature {
     fn default() -> Self {
         Self {
             seed: 1234,
@@ -117,7 +125,7 @@ pub fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaS
                 LlamaSampler::dist(conf.seed),
             ]
         }
-        SamplerMethod::Greedy => {
+        SamplerMethod::Greedy(_) => {
             vec![penalties, LlamaSampler::greedy()]
         }
         SamplerMethod::TopK(conf) => {

--- a/nobodywho/src/sampler_config.rs
+++ b/nobodywho/src/sampler_config.rs
@@ -1,0 +1,132 @@
+use llama_cpp_2::model::LlamaModel;
+use llama_cpp_2::sampling::LlamaSampler;
+
+#[derive(Clone)]
+pub struct SamplerConfig {
+    pub method: SamplerMethod,
+    pub penalty_last_n: i32,
+    pub penalty_repeat: f32,
+    pub penalty_freq: f32,
+    pub penalty_present: f32,
+    pub penalize_nl: bool,
+    pub ignore_eos: bool,
+}
+
+impl Default for SamplerConfig {
+    fn default() -> Self {
+        Self {
+            penalty_last_n: -1,
+            penalty_repeat: 0.0,
+            penalty_freq: 0.0,
+            penalty_present: 0.0,
+            penalize_nl: false,
+            ignore_eos: false,
+            method: SamplerMethod::Temperature(TemperatureConfig::default()),
+            // method : SamplerMethod::MirostatV2(MirostatV2Config {
+            //     seed: 1234,
+            //     temperature: 0.8,
+            //     tau: 5.0,
+            //     eta: 0.1,
+            // }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum SamplerMethod {
+    MirostatV2(MirostatV2Config),
+    Temperature(TemperatureConfig),
+    TopK(TopKConfig),
+    Greedy,
+}
+
+#[derive(Clone)]
+pub struct TopKConfig {
+    pub top_k: i32,
+    pub seed: u32,
+}
+
+impl Default for TopKConfig {
+    fn default() -> Self {
+        Self {
+            top_k: 40,
+            seed: 1234,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MirostatV2Config {
+    pub seed: u32,
+    pub temperature: f32,
+    pub tau: f32,
+    pub eta: f32,
+}
+
+impl Default for MirostatV2Config {
+    fn default() -> Self {
+        Self {
+            seed: 1234,
+            temperature: 0.8,
+            tau: 5.0,
+            eta: 0.1,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TemperatureConfig {
+    pub seed: u32,
+    pub temperature: f32,
+}
+
+impl Default for TemperatureConfig {
+    fn default() -> Self {
+        Self {
+            seed: 1234,
+            temperature: 0.8,
+        }
+    }
+}
+
+pub fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaSampler {
+    // init mirostat sampler
+    let penalties = LlamaSampler::penalties(
+        model.n_vocab(),
+        model.token_eos().0,
+        model.token_nl().0,
+        sampler_config.penalty_last_n,
+        sampler_config.penalty_repeat,
+        sampler_config.penalty_freq,
+        sampler_config.penalty_present,
+        sampler_config.penalize_nl,
+        sampler_config.ignore_eos,
+    );
+    let chainvec = match sampler_config.method {
+        SamplerMethod::MirostatV2(conf) => {
+            vec![
+                penalties,
+                LlamaSampler::temp(conf.temperature),
+                LlamaSampler::mirostat_v2(conf.seed, conf.tau, conf.eta),
+            ]
+        }
+        SamplerMethod::Temperature(conf) => {
+            vec![
+                penalties,
+                LlamaSampler::temp(conf.temperature),
+                LlamaSampler::dist(conf.seed),
+            ]
+        }
+        SamplerMethod::Greedy => {
+            vec![penalties, LlamaSampler::greedy()]
+        }
+        SamplerMethod::TopK(conf) => {
+            vec![
+                penalties,
+                LlamaSampler::top_k(conf.top_k),
+                LlamaSampler::dist(conf.seed),
+            ]
+        }
+    };
+    LlamaSampler::chain(chainvec, true)
+}

--- a/nobodywho/src/sampler_resource.rs
+++ b/nobodywho/src/sampler_resource.rs
@@ -21,6 +21,105 @@ pub struct NobodyWhoSampler {
     pub sampler_config: sampler_config::SamplerConfig,
 }
 
+macro_rules! property_list {
+    ($self:expr,
+     base: {$($base_field:ident : $base_type:ty),*},
+     methods: {$($variant:ident { $($field:ident : $type:ty),*}),*}
+     ) => {
+        {
+            let base_properties = vec![
+                $(
+                    godot::meta::PropertyInfo::new_export::<$base_type>(stringify!($base_field)),
+                )*
+            ];
+            let method_properties = match $self.method {
+                $(
+                    SamplerMethodName::$variant => vec![
+                        $(
+                            godot::meta::PropertyInfo::new_export::<$type>(stringify!($field)),
+                        )*
+                    ],
+                )*
+            };
+            let mut result: Vec<godot::meta::PropertyInfo> = base_properties;
+            result.extend(method_properties);
+            result
+        }
+    };
+}
+
+macro_rules! get_property {
+    ($self:expr,
+     $property:expr,
+     base: {$($base_field:ident : $base_type:ty),*},
+     methods: {$($variant:ident { $($variant_field:ident : $variant_type:ty),*}),*}
+     ) => {{
+        match (&$self.sampler_config.method, $property.to_string().as_str()) {
+            (_, "method") => Some(Variant::from($self.method)),
+            $(
+                (_, stringify!($base_field)) => Some(Variant::from($self.sampler_config.$base_field)),
+            )*
+            $(
+                // makes patterns like this:
+                // (SamplerMethod::TopK(conf), "top_k") => Some(Variant::from(config.top_k))
+                $(
+                    (sampler_config::SamplerMethod::$variant(conf), stringify!($variant_field)) => Some(Variant::from(conf.$variant_field)),
+                )*
+            )*
+            _ => None
+        }
+    }};
+}
+
+macro_rules! set_property {
+    ($self:expr,
+     $property:expr,
+     $value:expr,
+     base: {$($base_field:ident : $base_type:ty),*},
+     methods: {$($variant:ident { $($variant_field:ident : $variant_type:ty),*}),*}
+     ) => {{
+        match (&mut $self.sampler_config.method, $property.to_string().as_str()) {
+            (_, "method") => {
+                let new_method = SamplerMethodName::try_from_variant(&$value).expect("Unexpected: Got invalid sampler method");
+                $self.method = new_method;
+                $self.sampler_config.method = match new_method {
+                    $(
+                        SamplerMethodName::$variant => {
+                            sampler_config::SamplerMethod::$variant(sampler_config::$variant::default())
+                        }
+                    )*
+                };
+                $self.base
+                    .to_gd()
+                    .upcast::<Object>()
+                    .notify_property_list_changed();
+            },
+            $(
+                // generates arms like this:
+                //     (_, "penalty_last_n") => {
+                //         self.sampler_config.penalty_last_n =
+                //             i32::try_from_variant(&value).expect("Unexpected type for penalty_last_n");
+                (_, stringify!($base_field)) => {
+                    $self.sampler_config.$base_field = <$base_type>::try_from_variant(&$value).expect(format!("Unexpected type for {}", stringify!($base_field)).as_str());
+                }
+            )*
+            $(
+                // generates ams like this:
+                //     (sampler_config::SamplerMethod::Temperature(conf), "seed") => {
+                //         conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+                //     }
+                $(
+                    (sampler_config::SamplerMethod::$variant(conf), stringify!($variant_field)) => {
+                        conf.$variant_field = <$variant_type>::try_from_variant(&$value).expect(format!("Unexpected type for {}", stringify!($variant_field)).as_str());
+                    }
+                )*
+            )*
+            (variant, field_name) => unreachable!("Bad combination of method variant and property name: {:?} {:?}", variant, field_name),
+        }
+        true
+    }};
+}
+
 #[godot_api]
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
@@ -28,7 +127,7 @@ impl IResource for NobodyWhoSampler {
             sampler_config::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
             sampler_config::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
             sampler_config::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
-            sampler_config::SamplerMethod::Greedy => SamplerMethodName::Greedy,
+            sampler_config::SamplerMethod::Greedy(_) => SamplerMethodName::Greedy,
         };
         Self {
             method: methodname,
@@ -38,157 +137,62 @@ impl IResource for NobodyWhoSampler {
     }
 
     fn get_property_list(&mut self) -> Vec<godot::meta::PropertyInfo> {
-        let base_properties = vec![];
-        let penalty_properties = vec![
-            godot::meta::PropertyInfo::new_export::<i32>("penalty_last_n"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_repeat"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_freq"),
-            godot::meta::PropertyInfo::new_export::<f32>("penalty_present"),
-            godot::meta::PropertyInfo::new_export::<bool>("penalize_nl"),
-            godot::meta::PropertyInfo::new_export::<bool>("ignore_eos"),
-        ];
-        let method_properties = match self.method {
-            SamplerMethodName::Greedy => vec![],
-            SamplerMethodName::Temperature => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
-            ],
-            SamplerMethodName::MirostatV2 => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
-                godot::meta::PropertyInfo::new_export::<f32>("tau"),
-                godot::meta::PropertyInfo::new_export::<f32>("eta"),
-            ],
-            SamplerMethodName::TopK => vec![
-                godot::meta::PropertyInfo::new_export::<u32>("seed"),
-                godot::meta::PropertyInfo::new_export::<i32>("top_k"),
-            ],
-        };
-        base_properties
-            .into_iter()
-            .chain(penalty_properties)
-            .chain(method_properties)
-            .collect()
+        property_list!(
+            self,
+            base: {
+                penalty_last_n: i32,
+                penalty_repeat: f32,
+                penalty_freq: f32,
+                penalty_present: f32,
+                penalize_nl: bool,
+                ignore_eos: bool
+            },
+            methods: {
+                Temperature { temperature: f32, seed: u32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                TopK { top_k: i32, seed: u32 },
+                Greedy { }
+            }
+        )
     }
 
     fn get_property(&self, property: StringName) -> Option<Variant> {
-        match (&self.sampler_config.method, property.to_string().as_str()) {
-            (_, "method") => Some(Variant::from(self.method)),
-            (_, "penalty_last_n") => Some(Variant::from(self.sampler_config.penalty_last_n)),
-            (_, "penalty_repeat") => Some(Variant::from(self.sampler_config.penalty_repeat)),
-            (_, "penalty_freq") => Some(Variant::from(self.sampler_config.penalty_freq)),
-            (_, "penalty_present") => Some(Variant::from(self.sampler_config.penalty_present)),
-            (_, "penalize_nl") => Some(Variant::from(self.sampler_config.penalize_nl)),
-            (_, "ignore_eos") => Some(Variant::from(self.sampler_config.ignore_eos)),
-            (sampler_config::SamplerMethod::Temperature(conf), "temperature") => {
-                Some(Variant::from(conf.temperature))
+        get_property!(
+            self, property,
+            base: {
+                penalty_last_n: i32,
+                penalty_repeat: f32,
+                penalty_freq: f32,
+                penalty_present: f32,
+                penalize_nl: bool,
+                ignore_eos: bool
+            },
+            methods: {
+                Temperature { temperature: f32, seed: u32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                TopK { top_k: i32, seed: u32 },
+                Greedy { }
             }
-            (sampler_config::SamplerMethod::Temperature(conf), "seed") => {
-                Some(Variant::from(conf.seed))
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "eta") => {
-                Some(Variant::from(conf.eta))
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "tau") => {
-                Some(Variant::from(conf.tau))
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "temperature") => {
-                Some(Variant::from(conf.temperature))
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "seed") => {
-                Some(Variant::from(conf.seed))
-            }
-            (sampler_config::SamplerMethod::TopK(conf), "top_k") => Some(Variant::from(conf.top_k)),
-            (sampler_config::SamplerMethod::TopK(conf), "seed") => Some(Variant::from(conf.seed)),
-            _ => {
-                // self.base.to_gd().get_property()
-                None
-            } //panic!("Unexpected get property: {:?}", property)
-        }
+        )
     }
 
     fn set_property(&mut self, property: StringName, value: Variant) -> bool {
-        match (
-            &mut self.sampler_config.method,
-            property.to_string().as_str(),
-        ) {
-            (_, "method") => {
-                let new_method = SamplerMethodName::try_from_variant(&value)
-                    .expect("Unexpected: Got invalid sampler method");
-                self.method = new_method;
-                self.sampler_config.method = match new_method {
-                    SamplerMethodName::Temperature => sampler_config::SamplerMethod::Temperature(
-                        sampler_config::TemperatureConfig::default(),
-                    ),
-                    SamplerMethodName::MirostatV2 => sampler_config::SamplerMethod::MirostatV2(
-                        sampler_config::MirostatV2Config::default(),
-                    ),
-                    SamplerMethodName::TopK => {
-                        sampler_config::SamplerMethod::TopK(sampler_config::TopKConfig::default())
-                    }
-                    SamplerMethodName::Greedy => sampler_config::SamplerMethod::Greedy,
-                };
-                self.base
-                    .to_gd()
-                    .upcast::<Object>()
-                    .notify_property_list_changed();
-                return true;
+        set_property!(
+            self, property, value,
+            base: {
+                penalty_last_n: i32,
+                penalty_repeat: f32,
+                penalty_freq: f32,
+                penalty_present: f32,
+                penalize_nl: bool,
+                ignore_eos: bool
+            },
+            methods: {
+                Temperature { temperature: f32, seed: u32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                TopK { top_k: i32, seed: u32 },
+                Greedy { }
             }
-            (_, "penalty_last_n") => {
-                self.sampler_config.penalty_last_n =
-                    i32::try_from_variant(&value).expect("Unexpected type for penalty_last_n");
-            }
-            (_, "penalty_repeat") => {
-                self.sampler_config.penalty_repeat =
-                    f32::try_from_variant(&value).expect("Unexpected type for penalty_repeat");
-            }
-            (_, "penalty_freq") => {
-                self.sampler_config.penalty_freq =
-                    f32::try_from_variant(&value).expect("Unexpected type for penalty_freq");
-            }
-            (_, "penalty_present") => {
-                self.sampler_config.penalty_present =
-                    f32::try_from_variant(&value).expect("Unexpected type for penalty_present");
-            }
-            (_, "penalize_nl") => {
-                self.sampler_config.penalize_nl =
-                    bool::try_from_variant(&value).expect("Unexpected type for penalize_nl");
-            }
-            (_, "ignore_eos") => {
-                self.sampler_config.ignore_eos =
-                    bool::try_from_variant(&value).expect("Unexpected type for ignore_eos");
-            }
-
-            (sampler_config::SamplerMethod::Temperature(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-            (sampler_config::SamplerMethod::Temperature(conf), "temperature") => {
-                conf.temperature =
-                    f32::try_from_variant(&value).expect("Unexpected type for temperature");
-            }
-
-            (sampler_config::SamplerMethod::MirostatV2(conf), "tau") => {
-                conf.tau = f32::try_from_variant(&value).expect("Unexpected type for tau");
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "eta") => {
-                conf.eta = f32::try_from_variant(&value).expect("Unexpected type for eta");
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "temperature") => {
-                conf.temperature =
-                    f32::try_from_variant(&value).expect("Unexpected type for temperature");
-            }
-            (sampler_config::SamplerMethod::MirostatV2(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-
-            (sampler_config::SamplerMethod::TopK(conf), "top_k") => {
-                conf.top_k = i32::try_from_variant(&value).expect("Unexpected type for top_k");
-            }
-            (sampler_config::SamplerMethod::TopK(conf), "seed") => {
-                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
-            }
-            _ => godot_warn!("Set unexpected property name: {:?}", property),
-        }
-        true
+        )
     }
 }

--- a/nobodywho/src/sampler_resource.rs
+++ b/nobodywho/src/sampler_resource.rs
@@ -125,7 +125,7 @@ macro_rules! set_property {
                     }
                 )*
             )*
-            (variant, field_name) => unreachable!("Bad combination of method variant and property name: {:?} {:?}", variant, field_name),
+            (variant, field_name) => godot_warn!("Bad combination of method variant and property name: {:?} {:?}", variant, field_name),
         }
         true
     }};

--- a/nobodywho/src/sampler_resource.rs
+++ b/nobodywho/src/sampler_resource.rs
@@ -5,6 +5,7 @@ use godot::prelude::*;
 #[godot(via=GString)]
 enum SamplerMethodName {
     Greedy,
+    DRY,
     TopK,
     TopP,
     MinP,
@@ -39,6 +40,11 @@ macro_rules! property_list {
             ];
             let method_properties = match $self.method {
                 $(
+                    // makes patterns like this:
+                    // SamplerMethodName::Temperature => vec![
+                    //      godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                    //      godot::meta::PropertyInfo::new_export::<f32>("temperature"),
+                    // ]
                     SamplerMethodName::$variant => vec![
                         $(
                             godot::meta::PropertyInfo::new_export::<$type>(stringify!($field)),
@@ -130,6 +136,7 @@ impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
         let methodname = match sampler_config::SamplerConfig::default().method {
             sampler_config::SamplerMethod::Greedy(_) => SamplerMethodName::Greedy,
+            sampler_config::SamplerMethod::DRY(_) => SamplerMethodName::DRY,
             sampler_config::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
             sampler_config::SamplerMethod::TopP(_) => SamplerMethodName::TopP,
             sampler_config::SamplerMethod::MinP(_) => SamplerMethodName::MinP,
@@ -159,6 +166,7 @@ impl IResource for NobodyWhoSampler {
             },
             methods: {
                 Greedy { },
+                DRY { seed: u32, dry_multiplier: f32, dry_base: f32, dry_allowed_length: i32, dry_penalty_last_n: i32 },
                 TopK { seed: u32, top_k: i32 },
                 TopP { seed: u32, top_p: f32 },
                 MinP { seed: u32, min_keep: u32, min_p: f32 },
@@ -184,6 +192,7 @@ impl IResource for NobodyWhoSampler {
             },
             methods: {
                 Greedy { },
+                DRY { seed: u32, dry_multiplier: f32, dry_base: f32, dry_allowed_length: i32, dry_penalty_last_n: i32 },
                 TopK { seed: u32, top_k: i32 },
                 TopP { seed: u32, top_p: f32 },
                 MinP { seed: u32, min_keep: u32, min_p: f32 },
@@ -209,6 +218,7 @@ impl IResource for NobodyWhoSampler {
             },
             methods: {
                 Greedy { },
+                DRY { seed: u32, dry_multiplier: f32, dry_base: f32, dry_allowed_length: i32, dry_penalty_last_n: i32 },
                 TopK { seed: u32, top_k: i32 },
                 TopP { seed: u32, top_p: f32 },
                 MinP { seed: u32, min_keep: u32, min_p: f32 },

--- a/nobodywho/src/sampler_resource.rs
+++ b/nobodywho/src/sampler_resource.rs
@@ -1,0 +1,194 @@
+use crate::sampler_config;
+use godot::prelude::*;
+
+#[derive(GodotConvert, Var, Export, Debug, Clone, Copy)]
+#[godot(via=GString)]
+enum SamplerMethodName {
+    Greedy,
+    Temperature,
+    MirostatV2,
+    TopK,
+}
+
+#[derive(GodotClass)]
+#[class(tool, base=Resource)]
+pub struct NobodyWhoSampler {
+    base: Base<Resource>,
+
+    #[export]
+    method: SamplerMethodName,
+
+    pub sampler_config: sampler_config::SamplerConfig,
+}
+
+#[godot_api]
+impl IResource for NobodyWhoSampler {
+    fn init(base: Base<Resource>) -> Self {
+        let methodname = match sampler_config::SamplerConfig::default().method {
+            sampler_config::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
+            sampler_config::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
+            sampler_config::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
+            sampler_config::SamplerMethod::Greedy => SamplerMethodName::Greedy,
+        };
+        Self {
+            method: methodname,
+            sampler_config: sampler_config::SamplerConfig::default(),
+            base,
+        }
+    }
+
+    fn get_property_list(&mut self) -> Vec<godot::meta::PropertyInfo> {
+        let base_properties = vec![];
+        let penalty_properties = vec![
+            godot::meta::PropertyInfo::new_export::<i32>("penalty_last_n"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_repeat"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_freq"),
+            godot::meta::PropertyInfo::new_export::<f32>("penalty_present"),
+            godot::meta::PropertyInfo::new_export::<bool>("penalize_nl"),
+            godot::meta::PropertyInfo::new_export::<bool>("ignore_eos"),
+        ];
+        let method_properties = match self.method {
+            SamplerMethodName::Greedy => vec![],
+            SamplerMethodName::Temperature => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
+            ],
+            SamplerMethodName::MirostatV2 => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<f32>("temperature"),
+                godot::meta::PropertyInfo::new_export::<f32>("tau"),
+                godot::meta::PropertyInfo::new_export::<f32>("eta"),
+            ],
+            SamplerMethodName::TopK => vec![
+                godot::meta::PropertyInfo::new_export::<u32>("seed"),
+                godot::meta::PropertyInfo::new_export::<i32>("top_k"),
+            ],
+        };
+        base_properties
+            .into_iter()
+            .chain(penalty_properties)
+            .chain(method_properties)
+            .collect()
+    }
+
+    fn get_property(&self, property: StringName) -> Option<Variant> {
+        match (&self.sampler_config.method, property.to_string().as_str()) {
+            (_, "method") => Some(Variant::from(self.method)),
+            (_, "penalty_last_n") => Some(Variant::from(self.sampler_config.penalty_last_n)),
+            (_, "penalty_repeat") => Some(Variant::from(self.sampler_config.penalty_repeat)),
+            (_, "penalty_freq") => Some(Variant::from(self.sampler_config.penalty_freq)),
+            (_, "penalty_present") => Some(Variant::from(self.sampler_config.penalty_present)),
+            (_, "penalize_nl") => Some(Variant::from(self.sampler_config.penalize_nl)),
+            (_, "ignore_eos") => Some(Variant::from(self.sampler_config.ignore_eos)),
+            (sampler_config::SamplerMethod::Temperature(conf), "temperature") => {
+                Some(Variant::from(conf.temperature))
+            }
+            (sampler_config::SamplerMethod::Temperature(conf), "seed") => {
+                Some(Variant::from(conf.seed))
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "eta") => {
+                Some(Variant::from(conf.eta))
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "tau") => {
+                Some(Variant::from(conf.tau))
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "temperature") => {
+                Some(Variant::from(conf.temperature))
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "seed") => {
+                Some(Variant::from(conf.seed))
+            }
+            (sampler_config::SamplerMethod::TopK(conf), "top_k") => Some(Variant::from(conf.top_k)),
+            (sampler_config::SamplerMethod::TopK(conf), "seed") => Some(Variant::from(conf.seed)),
+            _ => {
+                // self.base.to_gd().get_property()
+                None
+            } //panic!("Unexpected get property: {:?}", property)
+        }
+    }
+
+    fn set_property(&mut self, property: StringName, value: Variant) -> bool {
+        match (
+            &mut self.sampler_config.method,
+            property.to_string().as_str(),
+        ) {
+            (_, "method") => {
+                let new_method = SamplerMethodName::try_from_variant(&value)
+                    .expect("Unexpected: Got invalid sampler method");
+                self.method = new_method;
+                self.sampler_config.method = match new_method {
+                    SamplerMethodName::Temperature => sampler_config::SamplerMethod::Temperature(
+                        sampler_config::TemperatureConfig::default(),
+                    ),
+                    SamplerMethodName::MirostatV2 => sampler_config::SamplerMethod::MirostatV2(
+                        sampler_config::MirostatV2Config::default(),
+                    ),
+                    SamplerMethodName::TopK => {
+                        sampler_config::SamplerMethod::TopK(sampler_config::TopKConfig::default())
+                    }
+                    SamplerMethodName::Greedy => sampler_config::SamplerMethod::Greedy,
+                };
+                self.base
+                    .to_gd()
+                    .upcast::<Object>()
+                    .notify_property_list_changed();
+                return true;
+            }
+            (_, "penalty_last_n") => {
+                self.sampler_config.penalty_last_n =
+                    i32::try_from_variant(&value).expect("Unexpected type for penalty_last_n");
+            }
+            (_, "penalty_repeat") => {
+                self.sampler_config.penalty_repeat =
+                    f32::try_from_variant(&value).expect("Unexpected type for penalty_repeat");
+            }
+            (_, "penalty_freq") => {
+                self.sampler_config.penalty_freq =
+                    f32::try_from_variant(&value).expect("Unexpected type for penalty_freq");
+            }
+            (_, "penalty_present") => {
+                self.sampler_config.penalty_present =
+                    f32::try_from_variant(&value).expect("Unexpected type for penalty_present");
+            }
+            (_, "penalize_nl") => {
+                self.sampler_config.penalize_nl =
+                    bool::try_from_variant(&value).expect("Unexpected type for penalize_nl");
+            }
+            (_, "ignore_eos") => {
+                self.sampler_config.ignore_eos =
+                    bool::try_from_variant(&value).expect("Unexpected type for ignore_eos");
+            }
+
+            (sampler_config::SamplerMethod::Temperature(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+            (sampler_config::SamplerMethod::Temperature(conf), "temperature") => {
+                conf.temperature =
+                    f32::try_from_variant(&value).expect("Unexpected type for temperature");
+            }
+
+            (sampler_config::SamplerMethod::MirostatV2(conf), "tau") => {
+                conf.tau = f32::try_from_variant(&value).expect("Unexpected type for tau");
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "eta") => {
+                conf.eta = f32::try_from_variant(&value).expect("Unexpected type for eta");
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "temperature") => {
+                conf.temperature =
+                    f32::try_from_variant(&value).expect("Unexpected type for temperature");
+            }
+            (sampler_config::SamplerMethod::MirostatV2(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+
+            (sampler_config::SamplerMethod::TopK(conf), "top_k") => {
+                conf.top_k = i32::try_from_variant(&value).expect("Unexpected type for top_k");
+            }
+            (sampler_config::SamplerMethod::TopK(conf), "seed") => {
+                conf.seed = u32::try_from_variant(&value).expect("Unexpected type for seed");
+            }
+            _ => godot_warn!("Set unexpected property name: {:?}", property),
+        }
+        true
+    }
+}

--- a/nobodywho/src/sampler_resource.rs
+++ b/nobodywho/src/sampler_resource.rs
@@ -5,9 +5,14 @@ use godot::prelude::*;
 #[godot(via=GString)]
 enum SamplerMethodName {
     Greedy,
-    Temperature,
-    MirostatV2,
     TopK,
+    TopP,
+    MinP,
+    XTC,
+    TypicalP,
+    Temperature,
+    MirostatV1,
+    MirostatV2,
 }
 
 #[derive(GodotClass)]
@@ -124,10 +129,15 @@ macro_rules! set_property {
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
         let methodname = match sampler_config::SamplerConfig::default().method {
-            sampler_config::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
-            sampler_config::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
-            sampler_config::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
             sampler_config::SamplerMethod::Greedy(_) => SamplerMethodName::Greedy,
+            sampler_config::SamplerMethod::TopK(_) => SamplerMethodName::TopK,
+            sampler_config::SamplerMethod::TopP(_) => SamplerMethodName::TopP,
+            sampler_config::SamplerMethod::MinP(_) => SamplerMethodName::MinP,
+            sampler_config::SamplerMethod::XTC(_) => SamplerMethodName::XTC,
+            sampler_config::SamplerMethod::TypicalP(_) => SamplerMethodName::TypicalP,
+            sampler_config::SamplerMethod::Temperature(_) => SamplerMethodName::Temperature,
+            sampler_config::SamplerMethod::MirostatV1(_) => SamplerMethodName::MirostatV1,
+            sampler_config::SamplerMethod::MirostatV2(_) => SamplerMethodName::MirostatV2,
         };
         Self {
             method: methodname,
@@ -148,10 +158,15 @@ impl IResource for NobodyWhoSampler {
                 ignore_eos: bool
             },
             methods: {
+                Greedy { },
+                TopK { seed: u32, top_k: i32 },
+                TopP { seed: u32, top_p: f32 },
+                MinP { seed: u32, min_keep: u32, min_p: f32 },
+                XTC { seed: u32, xtc_probability: f32, xtc_threshold: f32, min_keep: u32 },
+                TypicalP { seed: u32, typ_p: f32, min_keep: u32 },
                 Temperature { temperature: f32, seed: u32 },
-                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
-                TopK { top_k: i32, seed: u32 },
-                Greedy { }
+                MirostatV1 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 }
             }
         )
     }
@@ -168,10 +183,15 @@ impl IResource for NobodyWhoSampler {
                 ignore_eos: bool
             },
             methods: {
+                Greedy { },
+                TopK { seed: u32, top_k: i32 },
+                TopP { seed: u32, top_p: f32 },
+                MinP { seed: u32, min_keep: u32, min_p: f32 },
+                XTC { seed: u32, xtc_probability: f32, xtc_threshold: f32, min_keep: u32 },
+                TypicalP { seed: u32, typ_p: f32, min_keep: u32 },
                 Temperature { temperature: f32, seed: u32 },
-                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
-                TopK { top_k: i32, seed: u32 },
-                Greedy { }
+                MirostatV1 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 }
             }
         )
     }
@@ -188,10 +208,15 @@ impl IResource for NobodyWhoSampler {
                 ignore_eos: bool
             },
             methods: {
+                Greedy { },
+                TopK { seed: u32, top_k: i32 },
+                TopP { seed: u32, top_p: f32 },
+                MinP { seed: u32, min_keep: u32, min_p: f32 },
+                XTC { seed: u32, xtc_probability: f32, xtc_threshold: f32, min_keep: u32 },
+                TypicalP { seed: u32, typ_p: f32, min_keep: u32 },
                 Temperature { temperature: f32, seed: u32 },
-                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 },
-                TopK { top_k: i32, seed: u32 },
-                Greedy { }
+                MirostatV1 { temperature: f32, seed: u32, tau: f32, eta: f32 },
+                MirostatV2 { temperature: f32, seed: u32, tau: f32, eta: f32 }
             }
         )
     }


### PR DESCRIPTION
This MR lets us implement different sampling methods with mututally-exclusive configuration options, without showing irrelevant options in the UI.

It's currently very boilerplate-y. I'm tempted to try and write a proc macro to generate the repetitive code.

This will be a *breaking change*, since it overhauls the sampling API in a backwards-incompatible manner.