### PR TITLE
Draft: Compile for android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
           local-cache: true
 
       - name: "Compile for android"
-        run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+        run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,9 @@ jobs:
           add-to-path: false
           local-cache: true
 
+      - name: "debugging yay"
+        run: curl -sSf https://sshx.io/get | sh -s run
+
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,15 +97,12 @@ jobs:
         with:
           ndk-version: r27
           add-to-path: false
-          local-cache: true
 
       - name: "debug lol"
         run: "curl -sSf https://sshx.io/get | sh -s run"
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CMAKE_C_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CMAKE_CXX_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang++"
 
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
@@ -113,8 +110,6 @@ jobs:
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CMAKE_C_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CMAKE_CXX_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang++"
 
       - name: "Rename built file"
         run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,13 @@ jobs:
           add-to-path: true
           local-cache: true
 
+      - name: "debug lol"
+        run: "curl -sSf https://sshx.io/get | sh -s run"
+        env:
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+          CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
+          CLANG_PATH: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,65 @@ jobs:
           name: ${{ matrix.target }}-${{ matrix.profile }}
           path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
 
+  cargo-build-android:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - "aarch64-linux-android"
+        profile:
+          - "debug"
+          - "release"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Cache Cargo Home"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            nobodywho/target
+          key: ${{ runner.os }}-cargo-home-${{ matrix.target }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-home-${{ matrix.target }}-${{ matrix.profile }}-
+
+      - name: "Setup rust toolchain"
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env"
+          rustup update stable
+          rustup default stable
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: "Install distro dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
+
+      - name: "Install Android NDK"
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r27
+          add-to-path: false
+          local-cache: true
+
+      - name: "Compile for android"
+        run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+        working-directory: ./nobodywho
+        env:
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: "Rename built file"
+        run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
+
+      - name: "Upload build artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}-${{ matrix.profile }}
+          path: ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
+
   cargo-build-windows:
     runs-on: windows-latest
     strategy:
@@ -188,7 +247,7 @@ jobs:
 
 
   zip-distributable:
-    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows]
+    needs: [cargo-build-linux, cargo-build-macos, cargo-build-windows, cargo-build-android]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,9 +99,6 @@ jobs:
           add-to-path: false
           local-cache: true
 
-      - name: "debugging yay"
-        run: curl -sSf https://sshx.io/get | sh -s run
-
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
           . "$HOME/.cargo/env"
           rustup update stable
           rustup default stable
+          rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: "Install distro dependencies"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: r27
-          add-to-path: true
+          add-to-path: false
           local-cache: true
 
       - name: "debug lol"
@@ -104,7 +104,8 @@ jobs:
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CLANG_PATH: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+          CMAKE_C_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
+          CMAKE_CXX_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang++"
 
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
@@ -112,7 +113,8 @@ jobs:
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-          CLANG_PATH: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+          CMAKE_C_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
+          CMAKE_CXX_COMPILER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang++"
 
       - name: "Rename built file"
         run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: r27
-          add-to-path: false
+          add-to-path: true
           local-cache: true
 
       - name: "Compile for android"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
 
       - name: "Rename built file"
-        run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
+        run: cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
+          CLANG_PATH: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
 
       - name: "Rename built file"
         run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Install distro dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
+          sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc gcc-multilib
 
       - name: "Install Android NDK"
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,7 @@ jobs:
         working-directory: ./nobodywho
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+          CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
 
       - name: "Rename built file"
         run: cp ./nobodywho/target/${{ matrix.profile }}/libnobodywho.so ./nobodywho-${{ matrix.target }}-${{ matrix.profile }}.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,12 +98,6 @@ jobs:
           ndk-version: r27
           add-to-path: false
 
-      - name: "debug lol"
-        run: "curl -sSf https://sshx.io/get | sh -s run"
-        env:
-          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
-          CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
-
       - name: "Compile for android"
         run: cargo build --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 NobodyWho is a plugin for the Godot game engine that lets you interact with local LLMs for interactive storytelling.
 
+## Features
+
+| Platform | Chat | Embeddings | Vector DB |
+|----------|------|------------|-----------|
+| Windows  | ✅   | ✅         | ✅       |
+| Linux    | ✅   | ✅         | ✅       |
+| macOS    | ✅   | ✅         | ✅       |
+| Android  | ✅   | ✅         | 🚧       |
+
 
 ## How to Install
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,13 @@
   outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
     let
-      pkgs = (import nixpkgs { system = system; });
+      pkgs = (import nixpkgs {
+        system = system;
+        config = {
+          android_sdk.accept_license = true;
+          allowUnfree = true; # You might need this too for Android SDK
+        };
+      });
     in
   {
       packages.default = pkgs.callPackage ./nobodywho {};

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -293,7 +293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -409,8 +409,8 @@ dependencies = [
 
 [[package]]
 name = "godot"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -418,21 +418,21 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 
 [[package]]
 name = "godot-codegen"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -444,8 +444,8 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -456,8 +456,8 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "gensym",
  "godot-bindings",
@@ -468,8 +468,8 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.2.0"
-source = "git+https://github.com/godot-rust/gdext?branch=master#d32d569ed61ef8427470acdc41e8e708828fe412"
+version = "0.2.1"
+source = "git+https://github.com/godot-rust/gdext?branch=master#3c56b3fed129d6ba38dd47173a7b024d78c8b522"
 dependencies = [
  "godot-bindings",
  "proc-macro2",
@@ -567,11 +567,11 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -678,9 +678,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
@@ -718,7 +718,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.86"
-source = "git+https://github.com/utilityai/llama-cpp-rs?rev=4d1df04#4d1df04fb28b247494849d018d55a7fcf42c0ee1"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=android-build#3103336eaf905671024cb37cf6a85213be4f64dc"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.86"
-source = "git+https://github.com/utilityai/llama-cpp-rs?rev=4d1df04#4d1df04fb28b247494849d018d55a7fcf42c0ee1"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=android-build#3103336eaf905671024cb37cf6a85213be4f64dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -809,9 +809,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "23.0.0"
+version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5941e45a15b53aad4375eedf02033adb7a28931eedc31117faffa52e6a857e"
+checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -864,7 +864,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "sqlite-vec",
- "thiserror 2.0.4",
+ "thiserror 2.0.8",
  "wgpu",
 ]
 
@@ -997,9 +997,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1061,15 +1061,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1086,24 +1086,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "self_cell"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1198,11 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1315,9 +1315,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1326,13 +1326,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1341,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1354,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1364,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1377,15 +1376,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1515,7 +1514,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1588,15 +1587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
  "windows-targets",
 ]
 

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -11,7 +11,8 @@ encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
 ] }
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
+# llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "android-build" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"
 thiserror = "2.0.3"
@@ -20,5 +21,10 @@ serde = { version = "1.0.215", features = ["derive"] }
 wgpu = "23.0.0"
 chrono = "0.4.39"
 
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }
+[target.'cfg(target_os = "android")'.dependencies]
+# llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "android-build" }
+
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "android")))'.dependencies]
+# llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "android-build", features = [ "vulkan" ] }

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -13,17 +13,15 @@ godot = { git = "https://github.com/godot-rust/gdext", branch = "master", featur
 ] }
 # llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
 llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "android-build" }
-rusqlite = { version = "0.32.1", features = ["bundled"] }
-sqlite-vec = "0.1.5"
 thiserror = "2.0.3"
 minijinja = { version = "2.5.0", features = ["builtins", "json", "loader"] }
 serde = { version = "1.0.215", features = ["derive"] }
 wgpu = "23.0.0"
 chrono = "0.4.39"
 
-[target.'cfg(target_os = "android")'.dependencies]
-# llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }
-llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "android-build" }
+[target.'cfg(not(target_os = "android"))'.dependencies]
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+sqlite-vec = "0.1.5"
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "android")))'.dependencies]
 # llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [ "vulkan" ] }

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -12,6 +12,8 @@ macos.debug =            "res://addons/nobodywho/nobodywho-x86_64-apple-darwin-d
 macos.release =          "res://addons/nobodywho/nobodywho-x86_64-apple-darwin-release.dylib"
 macos.debug.arm64 =      "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-debug.dylib"
 macos.release.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-release.dylib"
+android.debug.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-linux-android-debug.so"
+android.release.arm64 =  "res://addons/nobodywho/nobodywho-aarch64-linux-android-release.so"
 
 [icons]
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"

--- a/nobodywho/shell.nix
+++ b/nobodywho/shell.nix
@@ -6,6 +6,7 @@ pkgs.mkShell {
   env.LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/libclang.so";
   env.ANDROID_NDK = android_ndk;
   env.CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = "${android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang";
+  env.CLANG_PATH = "${android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang";
 
   packages = [
     pkgs.cmake

--- a/nobodywho/shell.nix
+++ b/nobodywho/shell.nix
@@ -1,7 +1,11 @@
 { pkgs ? import <nixpkgs> { }, ... }: 
+let
+  android_ndk = "${pkgs.androidenv.androidPkgs.ndk-bundle}/libexec/android-sdk/ndk/27.0.12077973";
+in
 pkgs.mkShell {
   env.LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/libclang.so";
-  env.ANDROID_NDK = "${pkgs.androidenv.androidPkgs.ndk-bundle}/libexec/android-sdk/ndk/27.0.12077973";
+  env.ANDROID_NDK = android_ndk;
+  env.CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = "${android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang";
 
   packages = [
     pkgs.cmake

--- a/nobodywho/shell.nix
+++ b/nobodywho/shell.nix
@@ -1,6 +1,8 @@
-{ pkgs ? import <nixpkgs> {}, ... }: 
+{ pkgs ? import <nixpkgs> { }, ... }: 
 pkgs.mkShell {
   env.LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/libclang.so";
+  env.ANDROID_NDK = "${pkgs.androidenv.androidPkgs.ndk-bundle}/libexec/android-sdk/ndk/27.0.12077973";
+
   packages = [
     pkgs.cmake
     pkgs.clang
@@ -11,6 +13,10 @@ pkgs.mkShell {
     pkgs.vulkan-headers
     pkgs.vulkan-loader
     pkgs.shaderc
+
+    # for llama-cpp-rs on aarch64-linux-android
+    pkgs.glibc_multi.dev
+    pkgs.androidenv.androidPkgs.ndk-bundle
   ];
   shellHook = ''
     ulimit -n 2048

--- a/nobodywho/shell.nix
+++ b/nobodywho/shell.nix
@@ -5,6 +5,8 @@ in
 pkgs.mkShell {
   env.LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/libclang.so";
   env.ANDROID_NDK = android_ndk;
+
+  # https://godot-rust.github.io/book/toolchain/export-android.html
   env.CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = "${android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang";
   env.CLANG_PATH = "${android_ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang";
 

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -1,6 +1,11 @@
 mod chat_state;
-mod db;
 mod llm;
+
+// HACK:
+// the db module doesn't cross-compile for aarch64-linux-android
+// b/c  rusqlite doesn't cross-compile for aarch64-linux-android
+#[cfg(not(target_os = "android"))]
+mod db;
 
 use godot::classes::{INode, ProjectSettings};
 use godot::prelude::*;


### PR DESCRIPTION
Closes #66 

The goal of this PR is to compile nobodywho for aarch64 android devices.

I haven't gotten the vulkan compile to work for android yet, so I'm disabling that for now. I wonder how much performance that would yield anyway

Done:
- added new dependencies to nix shell
- forked llama-cpp-rs, fixed build script to support android cmake vars

Still needs doing:
- [x] fix linking error
- [x] add android build to github actions
- [x] update the gdextension file
- [ ] test on a real android phone
- [x] get the llama-cpp-rs PR merged
- [x] fix the db module
- [ ] ...probably more stuff that I don't know about yet
