### PR TITLE
Context shifting

### DIFF
--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -42,18 +42,19 @@ struct NobodyWhoSampler {
 #[godot_api]
 impl IResource for NobodyWhoSampler {
     fn init(base: Base<Resource>) -> Self {
+        let sampler_config = SamplerConfig::default();
         Self {
             base,
-            seed: llm::DEFAULT_SAMPLER_CONFIG.seed,
-            temperature: llm::DEFAULT_SAMPLER_CONFIG.temperature,
-            penalty_last_n: llm::DEFAULT_SAMPLER_CONFIG.penalty_last_n,
-            penalty_repeat: llm::DEFAULT_SAMPLER_CONFIG.penalty_repeat,
-            penalty_freq: llm::DEFAULT_SAMPLER_CONFIG.penalty_freq,
-            penalty_present: llm::DEFAULT_SAMPLER_CONFIG.penalty_present,
-            penalize_nl: llm::DEFAULT_SAMPLER_CONFIG.penalize_nl,
-            ignore_eos: llm::DEFAULT_SAMPLER_CONFIG.ignore_eos,
-            mirostat_tau: llm::DEFAULT_SAMPLER_CONFIG.mirostat_tau,
-            mirostat_eta: llm::DEFAULT_SAMPLER_CONFIG.mirostat_eta,
+            seed: sampler_config.seed,
+            temperature: sampler_config.temperature,
+            penalty_last_n: sampler_config.penalty_last_n,
+            penalty_repeat: sampler_config.penalty_repeat,
+            penalty_freq: sampler_config.penalty_freq,
+            penalty_present: sampler_config.penalty_present,
+            penalize_nl: sampler_config.penalize_nl,
+            ignore_eos: sampler_config.ignore_eos,
+            mirostat_tau: sampler_config.mirostat_tau,
+            mirostat_eta: sampler_config.mirostat_eta,
         }
     }
 }
@@ -205,7 +206,7 @@ impl NobodyWhoChat {
             let nobody_sampler: GdRef<NobodyWhoSampler> = gd_sampler.bind();
             nobody_sampler.get_sampler_config()
         } else {
-            llm::DEFAULT_SAMPLER_CONFIG
+            SamplerConfig::default()
         }
     }
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -85,19 +85,22 @@ pub struct SamplerConfig {
     pub mirostat_eta: f32,
 }
 
-// defaults here match the defaults read from `llama-cli --help`
-pub const DEFAULT_SAMPLER_CONFIG: SamplerConfig = SamplerConfig {
-    seed: 1234,
-    temperature: 0.8,
-    penalty_last_n: -1,
-    penalty_repeat: 0.0,
-    penalty_freq: 0.0,
-    penalty_present: 0.0,
-    penalize_nl: false,
-    ignore_eos: false,
-    mirostat_tau: 5.0,
-    mirostat_eta: 0.1,
-};
+impl Default for SamplerConfig {
+    fn default() -> Self {
+        SamplerConfig {
+            seed: 1234,
+            temperature: 0.8,
+            penalty_last_n: -1,
+            penalty_repeat: 0.0,
+            penalty_freq: 0.0,
+            penalty_present: 0.0,
+            penalize_nl: false,
+            ignore_eos: false,
+            mirostat_tau: 5.0,
+            mirostat_eta: 0.1,
+        }
+    }
+}
 
 fn make_sampler(model: &LlamaModel, config: SamplerConfig) -> LlamaSampler {
     // init mirostat sampler
@@ -388,7 +391,7 @@ mod tests {
                 model,
                 prompt_rx,
                 completion_tx,
-                DEFAULT_SAMPLER_CONFIG,
+                SamplerConfig::default(),
                 4096,
                 system_prompt,
             )


### PR DESCRIPTION
This implement context shifting as implemented by `llama.cpp` in [`main`](https://github.com/ggerganov/llama.cpp/blob/3b4f2e33e2cbfca621e623c4b92b88da57a8c2f4/examples/main/main.cpp#L528), but discards the system prompt for simplicity.

Closes #51 

