### PR TITLE
Add in-editor documentation

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -307,6 +307,7 @@ version = "0.2.2"
 source = "git+https://github.com/godot-rust/gdext?branch=master#6a5d19d5f8e7563730ccd4738e46f398726b222a"
 dependencies = [
  "godot-bindings",
+ "markdown",
  "proc-macro2",
  "quote",
  "venial",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "llama-cpp-2"
@@ -477,6 +477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "markdown"
+version = "1.0.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,9 +499,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c37e1b517d1dcd0e51dc36c4567b9d5a29262b3ec8da6cb5d35e27a8fb529b5"
+checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
 dependencies = [
  "memo-map",
  "self_cell",
@@ -534,7 +543,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "sqlite-vec",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
 ]
 
 [[package]]
@@ -659,9 +668,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
@@ -757,11 +766,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.10",
 ]
 
 [[package]]
@@ -777,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -816,6 +825,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unicode-id"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
 
 [[package]]
 name = "unicode-ident"

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"] # Compile this crate to a dynamic C library.
 [dependencies]
 encoding_rs = "0.8.34"
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
-    "experimental-threads",
+    "experimental-threads", "register-docs",
 ] }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sqlite-vec = "0.1.5"

--- a/nobodywho/nobodywho.gdextension
+++ b/nobodywho/nobodywho.gdextension
@@ -16,3 +16,4 @@ macos.release.arm64 =    "res://addons/nobodywho/nobodywho-aarch64-apple-darwin-
 [icons]
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
 NobodyWhoChat =             "res://addons/nobodywho/icon.svg"
+NobodyWhoEmbedding =             "res://addons/nobodywho/icon.svg"

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -14,28 +14,41 @@ unsafe impl ExtensionLibrary for NobodyWhoExtension {}
 
 #[derive(GodotClass)]
 #[class(tool, base=Resource)]
+/// Sampler configuration for the LLM.
+/// This tool will help you determine the behavior for you chat.
 struct NobodyWhoSampler {
     base: Base<Resource>,
 
     #[export]
+    /// The seed for the LLM. This ensures detmerminism across runs.
     seed: u32,
     #[export]
+    /// The temperature for the LLM. This controls the randomness of the LLM. A high temperature
+    /// will make the LLM "creative" with its responses, while a low score will make it more deterministic.
     temperature: f32,
     #[export]
+    /// Controls how many previous token are taken into consideration when calculating repeat penalty.
     penalty_last_n: i32,
     #[export]
+    /// Controls the penalty for repeating tokens within the last n tokens. This varies a lot between models.
     penalty_repeat: f32,
     #[export]
+    /// Decreases the likelihood of repeating tokens based on how often they appear.
     penalty_freq: f32,
     #[export]
+    /// Binary penalty if the token has apeared before.
     penalty_present: f32,
     #[export]
+    /// Penalizes newlines.
     penalize_nl: bool,
     #[export]
+    /// Ignores end of sentence tokens.
     ignore_eos: bool,
     #[export]
+    /// Controls the target perplexity for Mirostat.
     mirostat_tau: f32,
     #[export]
+    /// Controls the learning rate for Mirostat.
     mirostat_eta: f32,
 }
 
@@ -78,6 +91,9 @@ impl NobodyWhoSampler {
 
 #[derive(GodotClass)]
 #[class(base=Node)]
+/// The model node is used to load the model, currently only GGUF models are supported.
+///
+/// If you dont know what model to use, we would suggest checking out https://huggingface.co/spaces/k-mktr/gpu-poor-llm-arena
 struct NobodyWhoModel {
     #[export(file = "*.gguf")]
     model_path: GString,
@@ -129,18 +145,53 @@ impl NobodyWhoModel {
 
 #[derive(GodotClass)]
 #[class(base=Node)]
+/// NobodyWhoChat is the main node for interacting with the LLM. It functions as a chat, and can be used to send and receive messages.
+///
+/// The chat node is used to start a new context to send and receive messages (multiple contexts can be used at the same time with the same model).
+/// It requires a call to `start_worker()` before it can be used. If you do not call it, the chat will start the worker when you send the first message.
+/// OBS: The current implementation is dependant on the physics process to handle the LLM output.
+/// This is not the best way to handle this, and means that you cant overwrite the physics process
+///  on any class that inherits NobodyWhoChat.
+///
+/// Example:
+///
+/// ```
+/// extends NobodyWhoChat
+///
+/// func _ready():
+///     # configure node
+///     self.model_node = get_node("../ChatModel")
+///     self.system_prompt = "You are an evil wizard. Always try to curse anyone who talks to you."
+///
+///     # say something
+///     say("Hi there! Who are you?")
+///
+///     # wait for the response
+///     var response = await response_finished
+///     print("Got response: " + response)
+///
+///     # in this example we just use the `response_finished` signal to get the complete response
+///     # in real-world-use you definitely want to connect `response_updated`, which gives one word at a time
+///     # the whole interaction feels *much* smoother if you stream the response out word-by-word.
+/// ```
+///
 struct NobodyWhoChat {
     #[export]
+    /// The model node for the chat.
     model_node: Option<Gd<NobodyWhoModel>>,
 
     #[export]
+    /// The sampler configuration for the chat.
     sampler: Option<Gd<NobodyWhoSampler>>,
 
     #[export]
     #[var(hint = MULTILINE_TEXT)]
+    /// The system prompt for the chat, this is the basic instructions for the LLM's behavior.
     system_prompt: GString,
 
     #[export]
+    /// This is the maximum number of tokens that can be stored in the chat history. it will delete information from the chat history if it exceeds this limit.
+    /// Set this as high as needed, as it will also increase the memory usage of the LLM.
     context_length: u32,
 
     prompt_tx: Option<Sender<String>>,
@@ -211,6 +262,8 @@ impl NobodyWhoChat {
     }
 
     #[func]
+    /// Starts the LLM worker thread. This is required before you can send messages to the LLM.\
+    /// currently this is a blocking call, so be wise with when you call it.
     fn start_worker(&mut self) {
         let mut result = || -> Result<(), String> {
             let model = self.get_model()?;
@@ -256,21 +309,65 @@ impl NobodyWhoChat {
     }
 
     #[func]
+    /// Sends a message to the LLM. This will return a signal that you can use to wait for the response.
+    /// This will start the inference process. meaning you can also listen on the `response_updated` and `response_finished` signals to get the response.
     fn say(&mut self, message: String) {
         self.send_message(message);
     }
 
     #[signal]
+    /// Triggered when a new token is received from the LLM. Returns the new token as a string.
     fn response_updated(new_token: String);
 
     #[signal]
+    /// Triggered when the LLM has finished generating the response. Returns the full response as a string.
     fn response_finished(response: String);
 }
 
 #[derive(GodotClass)]
 #[class(base=Node)]
+/// The Embedding node is used to compare text. This is usefull as we cant predict excact sentences/triggerwords and thus want to compare how similar two sentences are.
+///
+/// This is done by embedding the text into a vector space and then comparing the cosine similarity between the vectors.
+///
+/// A good example of this would be to check if a npc has a trigger word The dragon is slain, and then reponds if the player says
+/// - The great worm is slain
+/// - I killed the dragon
+/// - The dragon is dead
+///
+/// Meaning you can reward the player for killing the dragon or trigger a new quest.
+/// It of course can also be used for other tasks such as checking if the player wants to buy or take something from the npc's inventory.
+///
+/// It requires a "NobodyWhoModel" node to be set with an embeddingsmodel in gguf format.
+/// Example:
+///
+/// ```
+/// extends NobodyWhoEmbedding
+///
+/// func _ready():
+///     # configure node
+///     self.model_node = get_node("../EmbeddingModel""""""")
+///
+///     # generate some embeddings
+///     embed("The dragon is on the hill.")
+///     var dragon_hill_embd = await self.embedding_finished
+///
+///     embed("The dragon is hungry for humans.")
+///     var dragon_hungry_embd = await self.embedding_finished
+///
+///     embed("This doesn't matter.")
+///     var irrelevant_embd = await self.embedding_finished
+///
+///     # test similarity,
+///     # here we show that two embeddings will have high similarity, if they mean similar things
+///     var low_similarity = cosine_similarity(irrelevant_embd, dragon_hill_embd)
+///     var high_similarity = cosine_similarity(dragon_hill_embd, dragon_hungry_embd)
+///     assert(low_similarity < high_similarity)
+/// ```
+///
 struct NobodyWhoEmbedding {
     #[export]
+    /// The model node for the embedding.
     model_node: Option<Gd<NobodyWhoModel>>,
 
     text_tx: Option<Sender<String>>,
@@ -318,6 +415,7 @@ impl INode for NobodyWhoEmbedding {
 #[godot_api]
 impl NobodyWhoEmbedding {
     #[signal]
+    /// Triggered when the embedding has finished. Returns the embedding as a PackedFloat32Array.
     fn embedding_finished(embedding: PackedFloat32Array);
 
     fn get_model(&mut self) -> Result<llm::Model, String> {
@@ -329,6 +427,7 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
+    /// Starts the embedding worker thread. This is required before you can send text to the embedding worker.
     fn start_worker(&mut self) {
         let mut result = || -> Result<(), String> {
             let model = self.get_model()?;
@@ -354,6 +453,10 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
+    /// Embeds a text into a vector space. This will return a signal that you can use to wait for the embedding.
+    /// The signal will return a PackedFloat32Array.
+    /// The Embed function is what takes a text and makes it into a vector. It can the be used in the `cosine_similarity` function to compare two vectors.
+    /// to compare agianst another previously embedded text.
     fn embed(&mut self, text: String) -> Signal {
         // returns signal, so that you can `var vec = await embed("Hello, world!")`
         if let Some(tx) = &self.text_tx {
@@ -370,6 +473,8 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
+    /// Calculates the cosine similarity between two embeddings ie. the similarity between two vectors.
+    /// Returns a value between 0 and 1, where 1 is the highest similarity.
     fn cosine_similarity(a: PackedFloat32Array, b: PackedFloat32Array) -> f32 {
         llm::cosine_similarity(a.as_slice(), b.as_slice())
     }

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -15,22 +15,22 @@ unsafe impl ExtensionLibrary for NobodyWhoExtension {}
 #[derive(GodotClass)]
 #[class(tool, base=Resource)]
 /// Sampler configuration for the LLM.
-/// This tool will help you determine the behavior for you chat.
+/// This will decide how the LLM selects the next token from the logit probabilities.
 struct NobodyWhoSampler {
     base: Base<Resource>,
 
     #[export]
-    /// The seed for the LLM. This ensures detmerminism across runs.
+    /// The seed to use for the LLM.
     seed: u32,
     #[export]
     /// The temperature for the LLM. This controls the randomness of the LLM. A high temperature
     /// will make the LLM "creative" with its responses, while a low score will make it more deterministic.
     temperature: f32,
     #[export]
-    /// Controls how many previous token are taken into consideration when calculating repeat penalty.
+    /// The repeat-last-n option controls the number of tokens in the history to consider for penalizing repetition. A larger value will look further back in the generated text to prevent repetitions, while a smaller value will only consider recent tokens. A value of 0 disables the penalty,
     penalty_last_n: i32,
     #[export]
-    /// Controls the penalty for repeating tokens within the last n tokens. This varies a lot between models.
+    /// The repeat-penalty option helps prevent the model from generating repetitive or monotonous text. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient. The default value is 1.
     penalty_repeat: f32,
     #[export]
     /// Decreases the likelihood of repeating tokens based on how often they appear.
@@ -45,10 +45,10 @@ struct NobodyWhoSampler {
     /// Ignores end of sentence tokens.
     ignore_eos: bool,
     #[export]
-    /// Controls the target perplexity for Mirostat.
+    /// Sets the Mirostat target entropy (tau), which represents the desired perplexity value for the generated text. Adjusting the target entropy allows you to control the balance between coherence and diversity in the generated text. A lower value will result in more focused and coherent text, while a higher value will lead to more diverse and potentially less coherent text. The default value is 5.0.
     mirostat_tau: f32,
     #[export]
-    /// Controls the learning rate for Mirostat.
+    /// Sets the Mirostat learning rate (eta). The learning rate influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. The default value is 0.1.
     mirostat_eta: f32,
 }
 
@@ -149,9 +149,6 @@ impl NobodyWhoModel {
 ///
 /// The chat node is used to start a new context to send and receive messages (multiple contexts can be used at the same time with the same model).
 /// It requires a call to `start_worker()` before it can be used. If you do not call it, the chat will start the worker when you send the first message.
-/// OBS: The current implementation is dependant on the physics process to handle the LLM output.
-/// This is not the best way to handle this, and means that you cant overwrite the physics process
-///  on any class that inherits NobodyWhoChat.
 ///
 /// Example:
 ///
@@ -190,8 +187,8 @@ struct NobodyWhoChat {
     system_prompt: GString,
 
     #[export]
-    /// This is the maximum number of tokens that can be stored in the chat history. it will delete information from the chat history if it exceeds this limit.
-    /// Set this as high as needed, as it will also increase the memory usage of the LLM.
+    /// This is the maximum number of tokens that can be stored in the chat history. It will delete information from the chat history if it exceeds this limit.
+    /// Higher values use more VRAM, but allow for longer "short term memory" for the LLM.
     context_length: u32,
 
     prompt_tx: Option<Sender<String>>,
@@ -262,8 +259,8 @@ impl NobodyWhoChat {
     }
 
     #[func]
-    /// Starts the LLM worker thread. This is required before you can send messages to the LLM.\
-    /// currently this is a blocking call, so be wise with when you call it.
+    /// Starts the LLM worker thread. This is required before you can send messages to the LLM.
+    /// This fuction is blocking and can be a bit slow, so you may want to be strategic about when you call it.
     fn start_worker(&mut self) {
         let mut result = || -> Result<(), String> {
             let model = self.get_model()?;
@@ -309,7 +306,7 @@ impl NobodyWhoChat {
     }
 
     #[func]
-    /// Sends a message to the LLM. This will return a signal that you can use to wait for the response.
+    /// Sends a message to the LLM.
     /// This will start the inference process. meaning you can also listen on the `response_updated` and `response_finished` signals to get the response.
     fn say(&mut self, message: String) {
         self.send_message(message);
@@ -317,6 +314,8 @@ impl NobodyWhoChat {
 
     #[signal]
     /// Triggered when a new token is received from the LLM. Returns the new token as a string.
+    /// It is strongly recommended to connect to this signal, and display the text output as it is
+    /// being generated. This makes for a much nicer user experience.
     fn response_updated(new_token: String);
 
     #[signal]
@@ -326,19 +325,20 @@ impl NobodyWhoChat {
 
 #[derive(GodotClass)]
 #[class(base=Node)]
-/// The Embedding node is used to compare text. This is usefull as we cant predict excact sentences/triggerwords and thus want to compare how similar two sentences are.
+/// The Embedding node is used to compare text. This is useful for detecting whether the user said
+/// something specific, without having to match on literal keywords or sentences.
 ///
 /// This is done by embedding the text into a vector space and then comparing the cosine similarity between the vectors.
 ///
-/// A good example of this would be to check if a npc has a trigger word The dragon is slain, and then reponds if the player says
-/// - The great worm is slain
-/// - I killed the dragon
-/// - The dragon is dead
+/// A good example of this would be to check if a user signals an action like "I'd like to buy the red potion". The following sentences will have high similarity:
+/// - Give me the potion that is red
+/// - I'd like the red one, please.
+/// - Hand me the flask of scarlet hue.
 ///
-/// Meaning you can reward the player for killing the dragon or trigger a new quest.
-/// It of course can also be used for other tasks such as checking if the player wants to buy or take something from the npc's inventory.
+/// Meaning you can trigger a "sell red potion" task based on natural language, without requiring a speciific formulation.
+/// It can of course be used for all sorts of tasks.
 ///
-/// It requires a "NobodyWhoModel" node to be set with an embeddingsmodel in gguf format.
+/// It requires a "NobodyWhoModel" node to be set with a GGUF model capable of generating embeddings.
 /// Example:
 ///
 /// ```
@@ -427,7 +427,7 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
-    /// Starts the embedding worker thread. This is required before you can send text to the embedding worker.
+    /// Starts the embedding worker thread. This is called automatically when you call `embed`, if it wasn't already called.
     fn start_worker(&mut self) {
         let mut result = || -> Result<(), String> {
             let model = self.get_model()?;
@@ -453,10 +453,8 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
-    /// Embeds a text into a vector space. This will return a signal that you can use to wait for the embedding.
+    /// Generates the embedding of a text string. This will return a signal that you can use to wait for the embedding.
     /// The signal will return a PackedFloat32Array.
-    /// The Embed function is what takes a text and makes it into a vector. It can the be used in the `cosine_similarity` function to compare two vectors.
-    /// to compare agianst another previously embedded text.
     fn embed(&mut self, text: String) -> Signal {
         // returns signal, so that you can `var vec = await embed("Hello, world!")`
         if let Some(tx) = &self.text_tx {
@@ -473,7 +471,7 @@ impl NobodyWhoEmbedding {
     }
 
     #[func]
-    /// Calculates the cosine similarity between two embeddings ie. the similarity between two vectors.
+    /// Calculates the similarity between two embedding vectors.
     /// Returns a value between 0 and 1, where 1 is the highest similarity.
     fn cosine_similarity(a: PackedFloat32Array, b: PackedFloat32Array) -> f32 {
         llm::cosine_similarity(a.as_slice(), b.as_slice())

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -346,16 +346,16 @@ impl NobodyWhoChat {
 ///
 /// func _ready():
 ///     # configure node
-///     self.model_node = get_node("../EmbeddingModel""""""")
+///     self.model_node = get_node(“../EmbeddingModel”)
 ///
 ///     # generate some embeddings
-///     embed("The dragon is on the hill.")
+///     embed(“The dragon is on the hill.”)
 ///     var dragon_hill_embd = await self.embedding_finished
 ///
-///     embed("The dragon is hungry for humans.")
+///     embed(“The dragon is hungry for humans.”)
 ///     var dragon_hungry_embd = await self.embedding_finished
 ///
-///     embed("This doesn't matter.")
+///     embed(“This does not matter.”)
 ///     var irrelevant_embd = await self.embedding_finished
 ///
 ///     # test similarity,


### PR DESCRIPTION
Adds docs to the editor and closes #26.

A weird thing happened with " always being escaped, which would fuck up the highlighting. The only nice way to solve is is to fix the godot-rust parser, which is out of scope for now. 