### PR TITLE
Multiple contexts, one model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - name: "Install distro dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3 # ...needed to install nix
       - run: |
           sh <(curl -L https://nixos.org/nix/install) --no-daemon
       - name: Restore and cache Nix store

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "chrono",
  "encoding_rs",
  "godot",
+ "lazy_static",
  "llama-cpp-2",
  "llama-cpp-sys-2",
  "minijinja",

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
 llama-cpp-sys-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
 llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04" }
+lazy_static = "1.5.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "4d1df04", features = [

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -591,7 +591,10 @@ mod tests {
         });
 
         dog_prompt_tx
-            .send("Hi! What kind of animal are you? What sound do you make a lot?".to_string())
+            .send(
+                "Hi! What kind of animal are you? Show me by making the sound you make."
+                    .to_string(),
+            )
             .unwrap();
 
         cat_prompt_tx


### PR DESCRIPTION
Closes #81 

So it turns out that running multiple `LlamaContext`s on the same `LlamaModel` struct in parallel crashes hard with a memory error. It seems that this is because llama.cpp is actually not thread safe in that way.

The quick-fix here is to add a mutex which ensures that max one context will generate text at any time. I called this mutex the "Global Inference Lock.

It seems like this is exactly what the LLamaSharp project does to deal with this issue.

A slightly more parallel solution could be to make a mutex lock per-model, but I don't think that this will actually be much more performant, since each `decode` run already uses all available cores.