### PR TITLE
fix: invoke min_p when min_p is selected

### DIFF
--- a/nobodywho/src/sampler_config.rs
+++ b/nobodywho/src/sampler_config.rs
@@ -252,7 +252,7 @@ pub fn make_sampler(model: &LlamaModel, sampler_config: SamplerConfig) -> LlamaS
         SamplerMethod::MinP(conf) => {
             vec![
                 penalties,
-                LlamaSampler::top_p(conf.min_p, conf.min_keep as usize),
+                LlamaSampler::min_p(conf.min_p, conf.min_keep as usize),
                 LlamaSampler::dist(conf.seed),
             ]
         }


### PR DESCRIPTION
Whoops.. So far the min_p sampler config has actually been invoking the top_p sampler in llama.cpp. 

Quick and easy fix.