### PR TITLE
Add Stop Tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gguf
+*.vscode

--- a/integration-test/chat.gd
+++ b/integration-test/chat.gd
@@ -5,11 +5,31 @@ func run_test():
 	model_node = get_node("../ChatModel")
 	system_prompt = "You are a helpful assistant, capable of answering questions about the world."
 
-	# say soemthing
+	test_say()
+	test_antiprompts()
+
+	return true
+
+func test_say():
 	say("Please tell me what the capital city of Denmark is.")
 
-	# wait for the response
 	var response = await response_finished
+
 	print("✨ Got response: " + response)
 	assert("Copenhagen" in response)
 	return true
+
+func test_antiprompts():
+	sampler.antiprompts = ["lion"]
+	start_worker() # restart the worker to include the antiprompts
+    
+	say("List these animals in order: horse, giraffe, lion, dog, cat, mouse")
+    var response = await response_finished
+    print("✨ Got antiprompt response: " + response)
+
+    assert("giraffe" in response, "Should not stop before the antiprompt")    
+    assert("lion" in response, "Should reach the antiprompt")
+    assert(not "dog" in response, "Should stop at antiprompt")
+    assert(not "cat" in response, "Should not continue past antiprompt")
+    
+    return true

--- a/integration-test/chat.gd
+++ b/integration-test/chat.gd
@@ -8,7 +8,7 @@ func run_test():
 	
 	assert(await test_say())
 	assert(await test_antiprompts())
-
+	assert(await test_antiprompts_multitokens())
 	return true
 
 func test_say():
@@ -21,16 +21,35 @@ func test_say():
 	return true
 
 func test_antiprompts():
-	stop_tokens = PackedStringArray(["horse"])
+	stop_tokens = PackedStringArray(["fly"])
 	start_worker() # restart the worker to include the antiprompts
 	
-	say("List these animals in alphabetical order: cat, dog, giraffe, horse, lion, mouse")
+	say("List these animals in alphabetical order: cat, dog, fly, lion, mouse")
 	var response = await response_finished
 
 	print("✨ Got antiprompt response: " + response)
 
-	assert("giraffe" in response, "Should not stop before the antiprompt")
-	assert("horse" in response, "Should reach the antiprompt")
+	assert("dog" in response, "Should not stop before the antiprompt")
+	assert("fly" in response, "Should reach the antiprompt")
+	assert(not "lion" in response, "Should stop at antiprompt")
+	assert(not "mouse" in response, "Should not continue past antiprompt")
+	
+	return true
+
+
+func test_antiprompts_multitokens():
+	stop_tokens = PackedStringArray(["horse-rider"])
+	system_prompt = "You only list the words in alphabetical order. nothing else."
+
+	start_worker() # restart the worker to include the antiprompts
+	
+	say("List all the words in alphabetical order: dog, horse-rider, lion, mouse")
+	var response = await response_finished
+
+	print("✨ Got antiprompt response: " + response)
+
+	assert("dog" in response, "Should not stop before the antiprompt")
+	assert("horse-rider" in response, "Should reach the antiprompt")
 	assert(not "lion" in response, "Should stop at antiprompt")
 	assert(not "mouse" in response, "Should not continue past antiprompt")
 	

--- a/integration-test/chat.gd
+++ b/integration-test/chat.gd
@@ -5,8 +5,9 @@ func run_test():
 	model_node = get_node("../ChatModel")
 	system_prompt = "You are a helpful assistant, capable of answering questions about the world."
 
-	test_say()
-	test_antiprompts()
+	
+	assert(await test_say())
+	assert(await test_antiprompts())
 
 	return true
 
@@ -20,17 +21,17 @@ func test_say():
 	return true
 
 func test_antiprompts():
-	stop_tokens = PackedStringArray(["lion"])
+	stop_tokens = PackedStringArray(["horse"])
 	start_worker() # restart the worker to include the antiprompts
 	
-	say("List these animals in order: horse, giraffe, lion, dog, cat, mouse")
+	say("List these animals in alphabetical order: cat, dog, giraffe, horse, lion, mouse")
 	var response = await response_finished
 
 	print("✨ Got antiprompt response: " + response)
 
 	assert("giraffe" in response, "Should not stop before the antiprompt")
-	assert("lion" in response, "Should reach the antiprompt")
-	assert(not "dog" in response, "Should stop at antiprompt")
-	assert(not "cat" in response, "Should not continue past antiprompt")
+	assert("horse" in response, "Should reach the antiprompt")
+	assert(not "lion" in response, "Should stop at antiprompt")
+	assert(not "mouse" in response, "Should not continue past antiprompt")
 	
 	return true

--- a/integration-test/chat.gd
+++ b/integration-test/chat.gd
@@ -20,16 +20,17 @@ func test_say():
 	return true
 
 func test_antiprompts():
-	sampler.antiprompts = ["lion"]
+	stop_tokens = PackedStringArray(["lion"])
 	start_worker() # restart the worker to include the antiprompts
-    
+	
 	say("List these animals in order: horse, giraffe, lion, dog, cat, mouse")
-    var response = await response_finished
-    print("✨ Got antiprompt response: " + response)
+	var response = await response_finished
 
-    assert("giraffe" in response, "Should not stop before the antiprompt")    
-    assert("lion" in response, "Should reach the antiprompt")
-    assert(not "dog" in response, "Should stop at antiprompt")
-    assert(not "cat" in response, "Should not continue past antiprompt")
-    
-    return true
+	print("✨ Got antiprompt response: " + response)
+
+	assert("giraffe" in response, "Should not stop before the antiprompt")
+	assert("lion" in response, "Should reach the antiprompt")
+	assert(not "dog" in response, "Should stop at antiprompt")
+	assert(not "cat" in response, "Should not continue past antiprompt")
+	
+	return true

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -114,7 +114,7 @@ struct NobodyWhoChat {
 
 
     #[export]
-    /// The system prompt for the chat, this is the basic instructions for the LLM's behavior.
+    /// Stop tokens to stop generation at these specified tokens.
     stop_tokens: PackedStringArray,
 
     #[export]

--- a/nobodywho/src/lib.rs
+++ b/nobodywho/src/lib.rs
@@ -112,6 +112,11 @@ struct NobodyWhoChat {
     /// The system prompt for the chat, this is the basic instructions for the LLM's behavior.
     system_prompt: GString,
 
+
+    #[export]
+    /// The system prompt for the chat, this is the basic instructions for the LLM's behavior.
+    stop_tokens: PackedStringArray,
+
     #[export]
     /// This is the maximum number of tokens that can be stored in the chat history. It will delete information from the chat history if it exceeds this limit.
     /// Higher values use more VRAM, but allow for longer "short term memory" for the LLM.
@@ -130,6 +135,7 @@ impl INode for NobodyWhoChat {
             model_node: None,
             sampler: None,
             system_prompt: "".into(),
+            stop_tokens: PackedStringArray::new(),
             context_length: 4096,
             prompt_tx: None,
             completion_rx: None,
@@ -201,6 +207,7 @@ impl NobodyWhoChat {
             // start the llm worker
             let n_ctx = self.context_length;
             let system_prompt = self.system_prompt.to_string();
+            let stop_tokens: Vec<String> = self.stop_tokens.to_vec().into_iter().map(|g| g.to_string()).collect();
             std::thread::spawn(move || {
                 run_completion_worker(
                     model,
@@ -209,6 +216,7 @@ impl NobodyWhoChat {
                     sampler_config,
                     n_ctx,
                     system_prompt,
+                    stop_tokens,
                 );
             });
 

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -403,7 +403,7 @@ fn has_stop_tokens(last_n_tokens: &VecDeque<String>, stop_tokens: &[String]) -> 
     let last_n_concatenated: String = last_n_tokens.iter().fold(String::new(), |acc, x| acc + x);
     stop_tokens
         .iter()
-        .any(|stop_token| last_n_concatenated.ends_with(stop_token))
+        .any(|stop_token| last_n_concatenated.contains(stop_token))
 }
 
 pub enum EmbeddingsOutput {

--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -325,10 +325,6 @@ fn run_completion_worker_result(
                 break;
             }
 
-            // Check for stop tokens
-            if check_stop_tokens(&ctx, &[new_token], &stop_tokens)? {
-                break;
-            }
 
             // Convert token to text and stream to user
             let output_string = ctx.model.token_to_str_with_size(
@@ -344,6 +340,12 @@ fn run_completion_worker_result(
                 .map_err(|_| WorkerError::SendError)?;
 
             debug_assert!(n_past == ctx.get_kv_cache_token_count());
+
+            // Check for stop tokens
+            if has_stop_tokens(&ctx, &[new_token], &stop_tokens)? {
+                break;
+            }
+            
         }
 
         // Update chat state with generated response
@@ -381,7 +383,7 @@ fn run_completion_worker_result(
 /// # Returns
 /// * `Ok(should_stop)` - Whether generation should stop
 /// * `Err(WorkerError)` - If token operations fail
-fn check_stop_tokens(
+fn has_stop_tokens(
     ctx: &LlamaContext,
     last_tokens: &[LlamaToken],
     stop_tokens: &[String],


### PR DESCRIPTION
## Description
This feature will add stop tokens  / reverse prompt / antiprompts to the chat node.
Basically when these tokens are encountered the inference will stop. 


This will return the stop token as well. This allows the user to remove it themselves or not. 
