### PR TITLE
fall back to U+fffd on encountering detokenize failure

### DIFF
--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -323,11 +323,13 @@ fn run_completion_worker_result(
             }
 
             // Convert token to text and stream to user
-            let output_string = ctx.model.token_to_str_with_size(
-                new_token,
-                MAX_TOKEN_STR_LEN,
-                Special::Tokenize,
-            )?;
+            let output_string = ctx
+                .model
+                .token_to_str_with_size(new_token, MAX_TOKEN_STR_LEN, Special::Tokenize)
+                .unwrap_or("�".to_string());
+            // fall back to "U+FFFD REPLACEMENT CHARACTER"
+            // when encountering bytes that aren't valid UTF-8
+            // wikipedia: "used to replace an unknown, unrecognised, or unrepresentable character"
 
             response.push_str(&output_string);
 


### PR DESCRIPTION
## Description
Sometimes models will output tokens that don't cleanly detokenize into valid UTF-8 text.

Fixes #99 

I tried running the reproduction example from #99
If I detokenize to bytes (instead of string), it prints stuff like this:

```
[240, 159, 152]
[128]
[240, 159, 152]
[131]
[240, 159, 152]
[132]
[240, 159, 152]
[129]
[240, 159, 152]
[134]
[240, 159, 152]
[130]
[240, 159]
[153, 130]
[226, 152]
[186]
[240, 159, 152]
[138]
[240, 159, 152]
[135]
[240, 159]
[153]
[132]
[240, 159, 152]
[141]
[240, 159, 152]
[152]
[240, 159, 152]
[151]
[240, 159, 152]
[153]
[240, 159, 152]
[139]
[240, 159, 152]
[155]
[240, 159, 152]
[157]
[240, 159, 152]
[156]
[240, 159]
[164]
[170]
[240, 159]
[164]
[163]
```

It seems like the byte sequence `[240, 159, 152, 128]` (the first two tokens in the codeblock above) corresponds to '😀'

The last *three* tokens in the block above concatenate to the byte sequence `[240, 159, 164, 163]`, aka '🤣'.

The issue is some models will emit emoji as several tokens, sometimes more than two tokens. Our inference loop assumes that every single token can be tokenized into a string by itself. This turns out not to be the case.

I think a sane solution could be to buffer tokens that don't cleanly tokenize, then decode the next token and try again.
This is gonna be a bit more tricky to do, for a few reasons. Firstly, the `token_to_str_with_size` function that we use at the moment only accepts a single token (and fails with incomplete tokens like `[240, 159, 152]`). We could work around this by instead using `token_to_bytes_with_size`, concatenating those, and then decoding utf8 bytes to `String` "manually". A second issue is that it either requires introducing another piece of finnicky state the the llm.rs inference loop ([complexity bad. state bad.](https://grugbrain.dev/)), or refactoring our generation logic so we have can repeat the add-to-batch-and-decode without copy-pasting a tonne of code. 

This patch is neither of those thorough fixes. It is a stupid-simple quickfix that just emits the U+FFFD "replacement character" whenever the detokenization fails. This won't result in the emoji being emitted correctly, but it will prevent the model worker from crashing.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 