### PR TITLE
Improve WorkerError

### DIFF
--- a/nobodywho/src/llm.rs
+++ b/nobodywho/src/llm.rs
@@ -104,7 +104,7 @@ pub enum WorkerError {
     #[error("Llama.cpp failed decoding: {0}")]
     DecodeError(#[from] llama_cpp_2::DecodeError),
 
-    #[error("Lama.cpp failed fetching chat template: {0}")]
+    #[error("Lama.cpp failed fetching chat template from the model file. This is likely because you're using an older GGUF file, which might not include a chat template. For example, this is the case for most LLaMA2-based GGUF files. Try using a more recent GGUF model file. If you want to check if a given model includes a chat template, you can use the gguf-dump script from llama.cpp. Here is a more technical detailed error: {0}")]
     ChatTemplateError(#[from] llama_cpp_2::ChatTemplateError),
 
     #[error("Lama.cpp failed fetching chat template: {0}")]
@@ -113,11 +113,8 @@ pub enum WorkerError {
     #[error("Failed applying the jinja chat template: {0}")]
     ApplyTemplateError(#[from] minijinja::Error),
 
-    #[error("Context exceeded maximum length")]
-    ContextLengthExceededError,
-
     #[error("Could not send newly generated token out to the game engine.")]
-    SendError, // this is actually a SendError<LLMOutput>, but that becomes recursive and weord.
+    SendError, // this is actually a SendError<LLMOutput>, but that becomes recursive and weird.
 
     #[error("Global Inference Lock was poisoned.")]
     GILPoisonError, // this is actually a std::sync::PoisonError<std::sync::MutexGuard<'static, ()>>, but that doesn't implement Send, so we do this


### PR DESCRIPTION
## Description
The main difference is a more detailed error message for the `ChatTemplateError` variant, which is encountered when trying to load a GGUF model that doesn't contain a chat template.

Fixes #96 

There are two other small fixes: 
- fix a typo in a comment
- remove the `ContextLimitExceeded` error variant, which has been redundant since #51 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
I ran the tests.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 