### PR TITLE
Fix deepseek template rendering

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -499,14 +499,24 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
+checksum = "cff7b8df5e85e30b87c2b0b3f58ba3a87b68e133738bf512a7713769326dbca9"
 dependencies = [
  "memo-map",
  "self_cell",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac3e47a9006ed0500425a092c9f8b2e56d10f8aeec8ce870c5e8a7c6ef2d7c3"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]
@@ -541,6 +551,7 @@ dependencies = [
  "llama-cpp-2",
  "llama-cpp-sys-2",
  "minijinja",
+ "minijinja-contrib",
  "rusqlite",
  "serde",
  "sqlite-vec",

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.4.39"
 llama-cpp-sys-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", rev = "5f49768" }
 llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", rev = "5f49768" }
 lazy_static = "1.5.0"
+minijinja-contrib = { version = "2.7.0", features = ["pycompat"] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", rev = "5f49768", features = ["vulkan"] }

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -15,6 +15,10 @@ static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| {
         },
     );
     env.add_function("strftime_now", strftime_now);
+
+    // add a bunch of python-isms, like str.split() or dict.get()
+    // was introduced in #106 to fix the deepseek chat template
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
     env
 });
 

--- a/nobodywho/src/chat_state.rs
+++ b/nobodywho/src/chat_state.rs
@@ -160,4 +160,18 @@ Hello, world!<|eot_id|><|start_header_id|>assistant<|end_header_id|>
         let result = strftime_now("%H:%M:%S");
         assert!(result.len() == 8, "Expected format HH:MM:SS to be 8 chars");
     }
+
+    #[test]
+    fn test_deepseek_template() {
+        let template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}";
+        let mut chatstate = ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into());
+        chatstate.add_message("user".into(), "Hello, world!".into());
+        chatstate.add_message(
+            "assistant".into(),
+            "<think>beep boop robot thinky</think>".into(),
+        );
+        let rendered = chatstate.render_diff();
+        println!("{:?}", rendered);
+        assert!(rendered.is_ok());
+    }
 }


### PR DESCRIPTION
## Description
The deepseek template includes the expression `content.split('</think>')[-1]`, which breaks, since split is not implemented on strings in minijinja by default. This is fixed by using the unknown_method_callback from [here](https://docs.rs/minijinja-contrib/latest/minijinja_contrib/pycompat/fn.unknown_method_callback.html), to teach minijinja how to do a bunch of python-isms.

Two other solutions were considered:
1. using the new google/minja template engine, which is designed specifically for LLM chat templates.
2. doing a dirty find/replace in the template, to use the `| split` filter instead of the `.split()` method.

I think this solution is better than the other two.

This fixes part of #94 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I wrote a test that shows how the template rendering crashes on deepseek's chat template.
Then I implemented the fix, and saw that the test now succeeds as well. Yay.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 