### PR TITLE
Feature: Reset system prompt

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -220,4 +220,52 @@ mod tests {
         // run stuff
         local.run_until(check_results).await;
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_reset_context() {
+        test_utils::init_test_tracing();
+
+        // Setup
+        let model = test_utils::load_test_model();
+        let system_prompt =
+            "You are a helpful assistant. The user asks you a question, and you provide an answer."
+                .to_string();
+        let params = llm::LLMActorParams {
+            model,
+            sampler_config: SamplerConfig::default(),
+            n_ctx: 4096,
+            stop_tokens: vec![],
+            use_embeddings: false,
+        };
+
+        let (mock_output, mut response_rx) = MockOutput::new();
+        let (say_tx, say_rx) = mpsc::channel(2);
+
+        let local = tokio::task::LocalSet::new();
+        local.spawn_local(simple_chat_loop(
+            params,
+            system_prompt,
+            say_rx,
+            Box::new(mock_output),
+        ));
+
+        let check_results = async move {
+            let _ = say_tx.send(ChatMsg::Say("Hello, world.".to_string())).await;
+            let response_1 = response_rx.recv().await.unwrap();
+
+            let new_system_prompt = "You're a wizard, Harry.".to_string();
+            let _ = say_tx.send(ChatMsg::ResetContext(new_system_prompt)).await;
+
+            let _ = say_tx.send(ChatMsg::Say("Hello, world.".to_string())).await;
+            let response_2 = response_rx.recv().await.unwrap();
+
+            assert!(
+                response_1 != response_2,
+                "Expected responses to differ after resetting context, got {response_1} and {response_2}"
+            );
+        };
+
+        // run stuff
+        local.run_until(check_results).await;
+    }
 }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -44,7 +44,7 @@ pub trait ChatOutput {
 
 pub enum ChatMsg {
     Say(String),
-    ResetContext,
+    ResetContext(String),
 }
 
 #[tracing::instrument(level = "trace", skip(output, params))]
@@ -96,7 +96,7 @@ pub async fn simple_chat_loop(
                 // render diff just to update the internal length state
                 let _ = chat_state.render_diff();
             }
-            ChatMsg::ResetContext => {
+            ChatMsg::ResetContext(system_prompt) => {
                 chat_state.reset();
                 chat_state.add_message("system".to_string(), system_prompt.clone());
                 actor.reset_context().await?;

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -244,7 +244,8 @@ impl NobodyWhoChat {
     #[func]
     fn reset_context(&mut self) {
         if let Some(msg_tx) = self.msg_tx.as_mut() {
-            let resp = msg_tx.blocking_send(chat::ChatMsg::ResetContext);
+            let sysem_prompt = self.system_prompt.to_string();
+            let resp = msg_tx.blocking_send(chat::ChatMsg::ResetContext(sysem_prompt));
             if let Err(msg) = resp {
                 // check error
                 godot_error!("Couldn't reset context: {:?}", msg);


### PR DESCRIPTION
## Description
This PR adds the ability to update the system prompt when calling `reset_context()`. When `reset_context()` is called the system prompt of the `NobodyWhoChat` will now be copied and sent with the `ChatMsg::ResetContext` message. If the system prompt of the `NobodyWhoChat` node didn't change, this will cause no difference to the current implementation of `reset_context()`.

My use case for this is that I need to update chat system prompts at runtime so that the same `NobodyWhoChat` node can be used for different NPCs with different personalities.

This seemed to be the simplest implementation of this feature, but it does couple the system prompt variable to whoever is sending the `ChatMsg`, and it may not be immediately obvious why `ChatMsg::ResetContext` has an associated string.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

I added `test_reset_context()` which tests that LLM output differs when sent the same message after resetting the context with a new system prompt. Let me know if you want any changes made to the test, or additional tests (such as testing that LLM output is the same after resetting the context with the same system prompt).

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 