### PR TITLE
Bugfix: allow multiple grammar invocations by shortening the lifespan of a stateful sampler

### DIFF
--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -1,7 +1,7 @@
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::sampling::LlamaSampler;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SamplerConfig {
     pub method: SamplerMethod,
     pub penalty_last_n: i32,


### PR DESCRIPTION
Fixes #134 