### PR TITLE
Adding --target to cargo build for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           rustup default stable
           rustup target add ${{ matrix.target }}
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: cargo build --verbose ${{ matrix.profile == 'release' && '--release' || '' }}
+      - run: cargo build --verbose --target=${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
         working-directory: ./nobodywho
 
       - name: "Rename built file"


### PR DESCRIPTION
## Description
As is mentioned [here](https://rust-lang.github.io/rustup/cross-compilation.html), I'm adding `--target` to `cargo build` command to build the proper target version instead of `arm64` which is the default architecture of the GitHub action runners used to build for Mac.

Fixes #118

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I'll grab the artifacts generated by the build action from this PR and I will run `file` against them.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 