### PR TITLE
Configurable logging

### DIFF
--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -6,6 +6,10 @@ pub mod llm;
 // pub mod llmactor;
 pub mod sampler_config;
 
+pub fn send_llamacpp_logs_to_tracing() {
+    llama_cpp_2::send_logs_to_tracing(llama_cpp_2::LogOptions::default().with_logs_enabled(true));
+}
+
 #[cfg(test)]
 pub mod test_utils {
     use crate::llm::{get_model, Model};

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -3,6 +3,7 @@ mod sampler_resource;
 use godot::classes::{INode, ProjectSettings};
 use godot::prelude::*;
 use nobodywho::{llm, sampler_config};
+use tracing_subscriber::prelude::*;
 
 use crate::sampler_resource::NobodyWhoSampler;
 
@@ -358,5 +359,95 @@ impl NobodyWhoEmbedding {
     /// Returns a value between 0 and 1, where 1 is the highest similarity.
     fn cosine_similarity(a: PackedFloat32Array, b: PackedFloat32Array) -> f32 {
         nobodywho::embed::cosine_similarity(a.as_slice(), b.as_slice())
+    }
+
+    #[func]
+    fn set_log_level(level: String) {
+        set_log_level(&level);
+    }
+}
+
+// LOGGING
+
+// Writer that forwards to Godot logging
+struct GodotWriter;
+
+impl std::io::Write for GodotWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if let Ok(s) = std::str::from_utf8(buf) {
+            let trimmed = s.trim();
+            if !trimmed.is_empty() {
+                // Check if it's an error message (simplistic approach)
+                // You might want more sophisticated detection based on your format
+                if trimmed.contains("ERROR") {
+                    godot_error!("{}", trimmed);
+                } else if trimmed.contains("WARN") {
+                    godot_warn!("{}", trimmed);
+                } else {
+                    godot_print!("{}", trimmed);
+                }
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for GodotWriter {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self::Writer {
+        GodotWriter
+    }
+}
+
+static INIT: std::sync::Once = std::sync::Once::new();
+// Static handle to the filter
+static LEVEL_HANDLE: std::sync::Mutex<
+    Option<
+        tracing_subscriber::reload::Handle<
+            tracing_subscriber::filter::LevelFilter,
+            tracing_subscriber::Registry,
+        >,
+    >,
+> = std::sync::Mutex::new(None);
+
+pub fn set_log_level(level_str: &str) {
+    let level: tracing::Level = match level_str.to_uppercase().parse() {
+        Ok(level) => level,
+        Err(e) => {
+            godot_error!("Invalid log level '{level_str}': {e}");
+            return;
+        }
+    };
+
+    // First-time initialization
+    INIT.call_once(|| {
+        // Create a reloadable filter
+        let (filter, filter_handle) = tracing_subscriber::reload::Layer::new(
+            tracing_subscriber::filter::LevelFilter::from_level(level),
+        );
+        // Store the handle for future updates
+        *LEVEL_HANDLE.lock().unwrap() = Some(filter_handle);
+
+        // Let fmt layer handle the formatting, but use our custom writer
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_writer(GodotWriter)
+            .with_ansi(false);
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .init();
+    });
+
+    if let Some(handle) = &*LEVEL_HANDLE.lock().unwrap() {
+        if let Err(e) = handle.modify(|filter| {
+            *filter = tracing_subscriber::filter::LevelFilter::from_level(level);
+        }) {
+            godot_error!("Failed to update log level: {}", e);
+        }
     }
 }


### PR DESCRIPTION
## Description

The current state of things is that very few things are logged into godot, using `godot_print!`, `godot_warn!` or `godot_error!`, and that everything else is just put out on stdout.

My experience is that most godot devs don't get the stdout logs. Most reported issues don't contain the logs that could be emitted by NobodyWho.

We can do much better, especially since we now use `tracing` internally, and `llama-cpp-rs` supports using `tracing` as well.

This PR adds the `set_log_level` method on `NobodyWhoChat`, `NobodyWhoEmbedding` and `NobodyWhoModel`.

If called with a log level string (i.e. "TRACE", "DEBUG", "INFO", "WARN", or "ERROR"), it sets that log level (globally).

This PR is built on top of #139, so we should merge that one first.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce or add a test to the example game.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 