### PR TITLE
Bump llama-cpp-rs

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -81,7 +81,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.102",
  "which",
 ]
 
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -215,22 +215,22 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.109"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#f36c1d2b857aab8d5c0b3c6abe787f1b94da4ad8"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#81e65dfeaf85b83794f2a753082858eda1e70bdd"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.109"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#f36c1d2b857aab8d5c0b3c6abe787f1b94da4ad8"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#81e65dfeaf85b83794f2a753082858eda1e70bdd"
 dependencies = [
  "bindgen",
  "cc",
@@ -624,9 +624,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -754,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -812,9 +812,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -879,7 +879,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -911,9 +911,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -969,7 +969,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1045,7 +1045,7 @@ checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1152,7 +1152,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -1174,7 +1174,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1252,7 +1252,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1263,7 +1263,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -87,21 +87,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -302,7 +302,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 [[package]]
 name = "godot"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "godot-bindings"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "gdextension-api",
 ]
@@ -319,12 +319,12 @@ dependencies = [
 [[package]]
 name = "godot-cell"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 
 [[package]]
 name = "godot-codegen"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "godot-bindings",
  "heck 0.5.0",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "godot-core"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "godot-ffi"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "godot-macros"
 version = "0.2.4"
-source = "git+https://github.com/godot-rust/gdext.git?branch=master#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
+source = "git+https://github.com/godot-rust/gdext.git?rev=9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0#9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0"
 dependencies = [
  "godot-bindings",
  "libc",
@@ -509,9 +509,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -534,8 +534,8 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.107"
-source = "git+https://github.com/utilityai/llama-cpp-rs.git?branch=main#ec8f6c8a77dbd10d9146ab1848d698c1115a8fd3"
+version = "0.1.109"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#f36c1d2b857aab8d5c0b3c6abe787f1b94da4ad8"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -546,8 +546,8 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.107"
-source = "git+https://github.com/utilityai/llama-cpp-rs.git?branch=main#ec8f6c8a77dbd10d9146ab1848d698c1115a8fd3"
+version = "0.1.109"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs.git?branch=main#f36c1d2b857aab8d5c0b3c6abe787f1b94da4ad8"
 dependencies = [
  "bindgen",
  "cc",
@@ -749,9 +749,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -995,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1233,9 +1233,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1274,18 +1274,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -10,8 +10,8 @@ minijinja = { version = "2.10.1", features = ["builtins", "json", "loader"] }
 minijinja-contrib = { version = "2.10.1", features = ["pycompat"] }
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
-llama-cpp-sys-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", branch = "main" }
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", branch = "main" }
+llama-cpp-sys-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs.git", branch = "main" }
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs.git", branch = "main" }
 lazy_static = "1.5.0"
 tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.17"
@@ -20,4 +20,4 @@ tracing-subscriber = "0.3.19"
 regex = "1.11.1"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", features = ["vulkan"], branch = "main" }
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs.git", branch = "main", features = ["vulkan"] }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -82,15 +82,6 @@ pub fn get_model(
     Ok(Arc::new(model))
 }
 
-#[allow(dead_code)]
-fn print_kv_cache(ctx: &mut LlamaContext) {
-    let mut kv_cache_view = ctx.new_kv_cache_view(1);
-    kv_cache_view.update();
-    for cell in kv_cache_view.cells() {
-        println!("cell: {:?}", cell);
-    }
-}
-
 /// Performs context window shifting by discarding old tokens and shifting remaining ones left.
 /// This prevents context overflow by removing older tokens when nearing context length limits.
 /// As implemented in <https://github.com/ggerganov/llama.cpp/blob/3b4f2e33e2cbfca621e623c4b92b88da57a8c2f4/examples/main/main.cpp#L528>
@@ -111,7 +102,7 @@ fn apply_context_shifting(
     let n_left = n_past - n_keep;
     let n_discard = n_left / 2;
 
-    debug_assert!(n_past == ctx.get_kv_cache_token_count());
+    // debug_assert!(n_past == ctx.get_kv_cache_token_count());
 
     // Delete the first `n_discard` tokens
     ctx.clear_kv_cache_seq(
@@ -120,7 +111,7 @@ fn apply_context_shifting(
         Some((n_keep + n_discard) as u32),
     )?;
 
-    debug_assert!(n_past - n_discard == ctx.get_kv_cache_token_count());
+    // debug_assert!(n_past - n_discard == ctx.get_kv_cache_token_count());
 
     // Shift the context left with `n_discard` tokens
     ctx.kv_cache_seq_add(
@@ -281,7 +272,7 @@ where
                 self.n_past -= apply_context_shifting(&mut self.ctx, self.n_past)?;
                 // check count
                 // XXX: this check is slow
-                debug_assert!(self.n_past == self.ctx.get_kv_cache_token_count());
+                // debug_assert!(self.n_past == self.ctx.get_kv_cache_token_count());
             }
 
             // Sample next token, no need to use sampler.accept as sample already accepts the token.

--- a/nobodywho/godot/Cargo.toml
+++ b/nobodywho/godot/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 nobodywho = { path = "../core" }
-godot = { git = "https://github.com/godot-rust/gdext.git", branch = "master", features = [ "register-docs", "experimental-threads" ] }
+godot = { git = "https://github.com/godot-rust/gdext.git", rev = "9f60c2e815477319e8f5b2d3f0fe2ee9e81391b0", features = [ "register-docs", "experimental-threads" ] }
 tokio = "1.44.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -30,7 +30,7 @@ rec {
       outputHashes = {
         "gdextension-api-0.2.2" = "sha256-gaxM73OzriSDm6tLRuMTOZxCLky9oS1nq6zTsm0g4tA=";
         "godot-0.2.4" = "sha256-5Kh1j3OpUetuE9qNK85tpZTj8m0Y30CX4okll4TZ9Xc=";
-        "llama-cpp-2-0.1.107" = "sha256-vVofBVBlxmKDcypTJGQxOuB5EJ8azwTU/wWiFiSQw1w=";
+        "llama-cpp-2-0.1.109" = "sha256-Fa7YMKd/C0nVU1AvGGImAXOBA1PMEqelv+FBeRAlaRo=";
       };
     };
     env.TEST_MODEL = fetchurl {


### PR DESCRIPTION
This bumps to a new version of llama-cpp-rs. 

For now, this version is my fork of llama-cpp-rs, that uses my fork of llama.cpp, that fixes the vulkan build issue that prevented us from upgrading past the 2025-05-14.

This demonstrates that we can use the latest llama.cpp w/ vulkan again.

Closes #162 