### PR TITLE
fix: windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,11 +93,11 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install Vulkan SDK
-        uses: jakoch/install-vulkan-sdk-action@v1.0.5
+        uses: jakoch/install-vulkan-sdk-action@v1.2.5
         with:
           vulkan_version: 1.3.296.0
-          install_runtime: true
           cache: true
+          install_runtime: true
           stripdown: true
 
       - name: Build with Cargo


### PR DESCRIPTION
## Description
This tries to solve a regression we had over the weekend where all of our builds were failing du to not being able to find vulkan-1.lib ie. the vulkan runtime.

```
Run jakoch/install-vulkan-sdk-action@v1.0.5
Destination: C:\VulkanSDK\
Cache hit for: cache-windows-x64-vulkan-sdk-1.3.296.0
Received 180355072 of 212261950 (85.0%), 168.8 MBs/sec
Received 212261950 of 212261950 (100.0%), 168.6 MBs/sec
Cache Size: ~202 MB (212261950 B)
"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/9de05688-e81f-4d1b-8115-2775fb19572a/cache.tzst -P -C D:/a/nobodywho/nobodywho --force-local --use-compress-program "zstd -d"
Cache restored successfully
🎯 [Cache] Restored Vulkan SDK in path: 'C:\VulkanSDK\'. Cache Restore ID: 'cache-windows-x64-vulkan-sdk-1.3.296.0'.
Warning: Could not find Vulkan SDK in C:\VulkanSDK\1.3.296.0
Warning: Could not find Vulkan Runtime in C:\VulkanSDK\1.3.296.0\runtime
✅ Done.
```


There has been a lot of updates to the action, but i am not sure exactly what broke what. however after an update to the latest version and a cache reset everything seems to work


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

