### PR TITLE
fix: unity builds cant find models

### DIFF
--- a/nobodywho/unity/src/Runtime/NobodyWhoModel.cs
+++ b/nobodywho/unity/src/Runtime/NobodyWhoModel.cs
@@ -16,6 +16,20 @@ namespace NobodyWho
         // only used for GUI
         public bool _useGpuIfAvailable = true;
 
+        private void Awake()
+        {
+            #if !UNITY_EDITOR
+            // In builds, dispose the editor-initialized wrapper and load model from StreamingAssets
+            if (wrapper != null)
+            {
+                wrapper.Dispose();
+            }
+            string fileName = Path.GetFileName(_modelPath);
+            string runtimePath = Path.Combine(Application.streamingAssetsPath, fileName);
+            wrapper = ModelWrapper.New(runtimePath, _useGpuIfAvailable);
+            #endif
+        }
+
         // to allow the property pattern (properties can't be serialized and unity uses serieliaed field for the inspector GUI) dwe hook into the validate and sets the values there. 
         private void OnValidate()
         {


### PR DESCRIPTION
## Description

Models do not load when run in unity build - This implements @baroquedub's solution.

Fixes https://github.com/nobodywho-ooo/nobodywho/issues/183
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
