### PR TITLE
Feat: get and set history (unity)

### DIFF
--- a/docs/chat/simple-chat.md
+++ b/docs/chat/simple-chat.md
@@ -185,24 +185,50 @@ This is useful when:
 - Starting a new task that's unrelated to previous ones, where the previous history is irrelevant
 - The LLM gets confused as it has context shifted too much
 
-### Advanced Context Management (Godot Only)
+### Advanced Context Management
 
 If you need more control over what the LLM remembers:
 
-```gdscript
-# See what's in the context
-var messages = await get_chat_history()
-for message in messages:
-    print(message.role, ": ", message.content)
 
-# Set a custom context (useful for templates or saved states)
-var task_context = [
-    {"role": "user", "content": "Analyze the following data:"},
-    {"role": "assistant", "content": "I'm ready to analyze data. Please provide it."},
-    {"role": "user", "content": "Here's the data: " + data_to_analyze}
-]
-set_chat_history(task_context)
-```
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+    # See what's in the context
+    var messages = await get_chat_history()
+    for message in messages:
+        print(message.role, ": ", message.content)
+    
+    # Set a custom context (useful for templates or saved states)
+    var task_context = [
+        {"role": "user", "content": "Analyze the following data:"},
+        {"role": "assistant", "content": "I'm ready to analyze data. Please provide it."},
+        {"role": "user", "content": "Here's the data: " + data_to_analyze}
+    ]
+    set_chat_history(task_context)
+    ```
+
+=== ":simple-unity: Unity"
+
+    ```csharp
+    var history = new Chat.History(
+        new List<Chat.Message>
+        {
+            new NobodyWho.Chat.Message("system", "You need to always remember the word: 'Cucumber'"),
+            new NobodyWho.Chat.Message("user", "what is the word?"),
+            new NobodyWho.Chat.Message("assistant", "Cucumber"),
+        }
+    );
+    chat.SetHistory(history);
+    ```
+    or 
+
+    ```csharp
+    var history = await chat.GetHistory();
+    history.messages[2].content = "I am the captain now"
+    chat.SetHistory(history);
+    ```
+
+
 
 ### Stop Words: Controlling LLM Output
 

--- a/nobodywho/unity/src/Runtime/NobodyWhoBindings.cs
+++ b/nobodywho/unity/src/Runtime/NobodyWhoBindings.cs
@@ -75,6 +75,12 @@ namespace NobodyWho
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "chatwrapper_clear_tools")]
         public static extern ChatError chatwrapper_clear_tools(IntPtr context);
 
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "chatwrapper_get_chat_history")]
+        public static extern JsonPointer chatwrapper_get_chat_history(IntPtr context);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "chatwrapper_set_chat_history")]
+        public static extern ChatError chatwrapper_set_chat_history(IntPtr context, string chat_history);
+
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "chatwrapper_stop")]
         public static extern ChatError chatwrapper_stop(IntPtr context);
 
@@ -112,6 +118,14 @@ namespace NobodyWho
         Nothing = 0,
         Token = 1,
         Done = 2,
+    }
+
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct JsonPointer
+    {
+        public IntPtr ptr;
+        public uint len;
     }
 
     [Serializable]
@@ -348,6 +362,20 @@ namespace NobodyWho
         public void ClearTools()
         {
             var rval = NobodyWhoBindings.chatwrapper_clear_tools(_context);
+            if (rval != ChatError.Ok)
+            {
+                throw new InteropException<ChatError>(rval);
+            }
+        }
+
+        public JsonPointer GetChatHistory()
+        {
+            return NobodyWhoBindings.chatwrapper_get_chat_history(_context);
+        }
+
+        public void SetChatHistory(string chat_history)
+        {
+            var rval = NobodyWhoBindings.chatwrapper_set_chat_history(_context, chat_history);
             if (rval != ChatError.Ok)
             {
                 throw new InteropException<ChatError>(rval);

--- a/nobodywho/unity/src/Runtime/NobodyWhoChat.cs
+++ b/nobodywho/unity/src/Runtime/NobodyWhoChat.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -112,13 +109,18 @@ namespace NobodyWho
             wrapper.SetChatHistory(history_json);
         }
 
-        public History GetHistory()
+        public async Task<History> GetHistory()
         {
-            var res = wrapper.GetChatHistory();
-            string messages = Marshal.PtrToStringAnsi(res.ptr, (int)res.len);
+            // This needs to be async as it might be blocked for quite if the llm is already generating a response
+            return await Task.Run(() =>
+            {
+                var res = wrapper.GetChatHistory();
+                if (res.len == 0)
+                    return new History(new List<Message>());
 
-            History history = JsonUtility.FromJson<History>("{\"messages\":" + messages + "}");
-            return history;
+                string msgs = Marshal.PtrToStringAnsi(res.ptr, (int)res.len);
+                return JsonUtility.FromJson<History>("{\"messages\":" + msgs + "}");
+            });
         }
 
         [Serializable]

--- a/nobodywho/unity/src/Runtime/NobodyWhoChat.cs
+++ b/nobodywho/unity/src/Runtime/NobodyWhoChat.cs
@@ -106,5 +106,42 @@ namespace NobodyWho
             wrapper.ClearTools();
         }
 
+        public void SetHistory(History history)
+        {
+            var history_json = JsonUtility.ToJson(history);
+            wrapper.SetChatHistory(history_json);
+        }
+
+        public History GetHistory()
+        {
+            var res = wrapper.GetChatHistory();
+            string messages = Marshal.PtrToStringAnsi(res.ptr, (int)res.len);
+
+            History history = JsonUtility.FromJson<History>("{\"messages\":" + messages + "}");
+            return history;
+        }
+
+        [Serializable]
+        public class History
+        {
+            public List<Message> messages;
+            public History(List<Message> messages)
+            {
+                this.messages = messages;
+            }
+        }
+
+        [Serializable]
+        public class Message
+        {
+            public string role; // TODO change to enum (user, system, toolkcall, toolresponse)
+            public string content;
+            public Message(string role, string content)
+            {
+                this.role = role;
+                this.content = content;
+            }
+        }
+
     }
 }

--- a/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
+++ b/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
@@ -257,23 +257,39 @@ namespace Tests
             chat.Say("What is the word?");
 
             var history = chat.GetHistory();
-            Assert.IsTrue(history.Count == 3, "History should contain 3 items");
-            Assert.IsTrue(history[0].Contains("system: You need to always remember the word: 'Cucumber;' "), "History should contain the correct system prompt");
+            Assert.IsTrue(history.messages.Count == 3, "History should contain 3 items");
+            Assert.IsTrue(
+                history.messages[0].role == "system",
+                "History should contain the correct system prompt"
+            );
+            Assert.IsTrue(
+                history.messages[1].content == "What is the word?",
+                "History should contain the correct user prompt"
+            );
         }
 
         [Test]
         [Timeout(900000)] // 15 min
         public void WhenSettingChatHistory_ShouldUseHistory()
         {
-            chat.SetHistory(new List<string> { "system: You need to always remember the word: 'Cucumber;' ", "user: what is the word?", "assistant: Cucumber" });
-            chat.ResetContext();
+            var history = new Chat.History(
+                new List<Chat.Message>
+                {
+                    new Chat.Message("system", "You need to always remember the word: 'Cucumber'"),
+                    new Chat.Message("user", "what is the word?"),
+                    new Chat.Message("assistant", "Cucumber"),
+                }
+            );
+            chat.SetHistory(history);
 
             chat.Say("What is the word?");
             string response = chat.GetResponseBlocking();
 
             Assert.IsNotNull(response, "No response received within timeout period");
-            Assert.IsTrue(response.Contains("Cucumber"), "Response should contain the result 'Cucumber'");
+            Assert.IsTrue(
+                response.Contains("Cucumber"),
+                "Response should contain the result 'Cucumber'"
+            );
         }
     }
 }
-

--- a/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
+++ b/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
@@ -247,5 +247,33 @@ namespace Tests
             Assert.IsTrue(response.Contains("Kuwait City"), "Response should contain the result 'Kuwait City'");
             Assert.IsTrue(response.Contains("100"), "Response should contain the result '100'");
         }
+
+        [Test]
+        [Timeout(900000)] // 15 min
+        public void WhenGettingChatHistory_ShouldReturnHistory()
+        {
+            chat.systemPrompt = "You need to always remember the word: 'Cucumber;' ";
+            chat.ResetContext();
+            chat.Say("What is the word?");
+
+            var history = chat.GetHistory();
+            Assert.IsTrue(history.Count == 3, "History should contain 3 items");
+            Assert.IsTrue(history[0].Contains("system: You need to always remember the word: 'Cucumber;' "), "History should contain the correct system prompt");
+        }
+
+        [Test]
+        [Timeout(900000)] // 15 min
+        public void WhenSettingChatHistory_ShouldUseHistory()
+        {
+            chat.SetHistory(new List<string> { "system: You need to always remember the word: 'Cucumber;' ", "user: what is the word?", "assistant: Cucumber" });
+            chat.ResetContext();
+
+            chat.Say("What is the word?");
+            string response = chat.GetResponseBlocking();
+
+            Assert.IsNotNull(response, "No response received within timeout period");
+            Assert.IsTrue(response.Contains("Cucumber"), "Response should contain the result 'Cucumber'");
+        }
     }
 }
+

--- a/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
+++ b/nobodywho/unity/src/Tests/NobodyWhoChatTests.cs
@@ -250,13 +250,13 @@ namespace Tests
 
         [Test]
         [Timeout(900000)] // 15 min
-        public void WhenGettingChatHistory_ShouldReturnHistory()
+        public async Task WhenGettingChatHistory_ShouldReturnHistory()
         {
             chat.systemPrompt = "You need to always remember the word: 'Cucumber;' ";
             chat.ResetContext();
             chat.Say("What is the word?");
 
-            var history = chat.GetHistory();
+            var history = await chat.GetHistory();
             Assert.IsTrue(history.messages.Count == 3, "History should contain 3 items");
             Assert.IsTrue(
                 history.messages[0].role == "system",

--- a/nobodywho/unity/src/lib.rs
+++ b/nobodywho/unity/src/lib.rs
@@ -5,9 +5,7 @@ use interoptopus::{
     callback, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_type, function, pattern, Inventory, InventoryBuilder
 };
 use tracing::{debug, error, warn};
-use core::slice;
-use std::any::Any;
-use std::sync::{Arc, WaitTimeoutResult};
+use std::sync::Arc;
 use std::ffi::c_char;
 
 
@@ -418,7 +416,7 @@ impl Default for PollResponseResult {
 #[repr(C)]
 pub struct JsonPointer {
     pub ptr: *const std::ffi::c_char,
-    pub len: u32, // TODO: add optional ChatError? or 
+    pub len: u32,
 }
 
 impl Default for JsonPointer {

--- a/nobodywho/unity/src/lib.rs
+++ b/nobodywho/unity/src/lib.rs
@@ -5,7 +5,9 @@ use interoptopus::{
     callback, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_type, function, pattern, Inventory, InventoryBuilder
 };
 use tracing::{debug, error, warn};
-use std::sync::Arc;
+use core::slice;
+use std::any::Any;
+use std::sync::{Arc, WaitTimeoutResult};
 use std::ffi::c_char;
 
 
@@ -152,6 +154,7 @@ pub struct ChatWrapper {
     handle: Option<nobodywho::chat::ChatHandle>,
     response_rx: Option<tokio::sync::mpsc::Receiver<nobodywho::llm::WriteOutput>>,
     last_returned_cstring: std::ffi::CString,
+    _cstring_allocation: std::ffi::CString,
     tools: Vec<nobodywho::chat::Tool>,
 }
 
@@ -163,6 +166,7 @@ impl ChatWrapper {
             handle: None,
             response_rx: None,
             last_returned_cstring: std::ffi::CString::default(),
+            _cstring_allocation: std::ffi::CString::default(),
             tools: vec![],
         })
     }
@@ -292,6 +296,37 @@ impl ChatWrapper {
         Ok(())
     }
 
+    #[ffi_service_method(on_panic = "return_default")]
+    pub fn get_chat_history(&mut self) -> JsonPointer {
+        let Some(ref handle) = self.handle else {
+            return JsonPointer::default();
+        };
+        let mut rx = handle.get_chat_history();
+        let chat_history = rx.blocking_recv();
+        let json: String = serde_json::to_string(&chat_history).unwrap_or_default();
+        debug!("chat_history: {json}");
+        let cstring = std::ffi::CString::new(json).unwrap_or_default();
+        self._cstring_allocation = cstring;
+        JsonPointer {
+            ptr: self._cstring_allocation.as_ptr(),
+            len: self._cstring_allocation.as_bytes().len() as u32,
+        }
+    }
+
+    pub fn set_chat_history(&mut self, chat_history: AsciiPointer) -> Result<(), ChatError> {
+        if let Some(ref handle) = self.handle {
+            let string = chat_history.as_str().map_err(|_| ChatError::BadJsonSchema)?;
+            let json: serde_json::Value = serde_json::from_str(string).map_err(|_| ChatError::BadJsonSchema)?;
+            let messages: Vec<nobodywho::chat_state::Message> = serde_json::from_value(json["messages"].clone()).map_err(|_| ChatError::BadJsonSchema)?;
+
+            handle.set_chat_history(messages);
+            Ok(())
+        } else {
+            Err(ChatError::WorkerNotStarted)
+        }
+    }
+
+
     pub fn stop(&mut self) -> Result<(), ChatError> {
         if let Some(ref mut handle) = self.handle {
             handle.stop_generation();
@@ -379,6 +414,21 @@ impl Default for PollResponseResult {
     }
 }
 
+#[ffi_type]
+#[repr(C)]
+pub struct JsonPointer {
+    pub ptr: *const std::ffi::c_char,
+    pub len: u32, // TODO: add optional ChatError? or 
+}
+
+impl Default for JsonPointer {
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null(),
+            len: 0,
+        }
+    }
+}
 /// EMBEDDINGS
 
 #[ffi_type(patterns(ffi_error))]


### PR DESCRIPTION
## Description
This adds editing of the chat history for Unity.



## implementation

So there are several issues due to the async nature of getting the chat states history  and sending a list of data across the ffi boundary. (both of which could be nicely solved with interoptopus 0.15 - which we cannot update to as it relies on .net 8+ which unity does not... read: https://github.com/ralfbiedert/interoptopus/blob/master/UPGRADE_INSTRUCTIONS.md )



Also i think they only way to do a async/await interface on the c# side, as otherwise we will lead our users to write code that will end up being an event hell or blocking on the main loop (i'd rather avoid both).

One possible solution could be using a polling system, the same way as we are doing with the embeddings. this allows us to pass structured data (due to ffi types) which on one hand gives a lot of safety and error handling, but also increases the complexity a lot:

- Distinct data structures for each type of message and parsers between the types (ie. each role type needs a separate line to parse)
- The polling logic needs take take into account lifetimes and when memory should be freed - which gets ugly real fast



The other solution is to throw json (or whatever structured format) across the ffi boundary - much like we do with tool calling. 

- This allows for type checking as we can use unity serialization for it. 
-  This scales badly as we have to rewrite all that logic again for another plugin
 

Before committing to either of these, i think a prudent step would be to check how much work is involved with updating to 0.15.


