### PR TITLE
Fixes for chat history with tools

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -355,7 +355,11 @@ impl<'a> Worker<'_, ChatWorker> {
         )?;
         chat_state.add_system_message(system_prompt);
 
-        let grammar = grammar_from_tools(&tools);
+        let grammar = if tools.len() > 0 {
+            grammar_from_tools(&tools).ok()
+        } else {
+            None
+        };
 
         Ok(Worker::new_with_type(
             model,
@@ -364,7 +368,7 @@ impl<'a> Worker<'_, ChatWorker> {
             ChatWorker {
                 chat_state,
                 tools,
-                tool_grammar: grammar.ok(),
+                tool_grammar: grammar,
                 should_stop,
             },
         )?)
@@ -482,6 +486,11 @@ impl<'a> Worker<'_, ChatWorker> {
             self.ctx.model,
             tools.iter().map(|t| t.to_chat_state_tool()).collect(),
         )?;
+        self.extra.tool_grammar = if tools.len() > 0 {
+            grammar_from_tools(&tools).ok()
+        } else {
+            None
+        };
         self.extra.tools = tools;
         self.extra.chat_state.add_system_message(system_prompt);
         Ok(())

--- a/nobodywho/godot/integration-test/chat.gd
+++ b/nobodywho/godot/integration-test/chat.gd
@@ -122,6 +122,12 @@ func test_stop_generation():
 	assert("2" in response, "Should stop at 2")
 	assert(not "8" in response, "Should not continue past 2")
 
+	# test get/set history w/ tool call messages in there
+	var messages = await get_chat_history()
+	set_chat_history(messages)
+	var messages_again = await get_chat_history()
+	assert(messages == messages_again)
+
 	# clean up: disconnect signal handler
 	for dict in response_updated.get_connections():
 		response_updated.disconnect(dict.callable)


### PR DESCRIPTION
This PR lumps together three fixes:

1. Handling changes in the tools available when running reset_chat
2. Handle serializing and deserializing chat history messages that include tool calls.
3. Handle race condition that could cause data being emitted to a signal before anything is listening on the signal

This is a replacement for #180 