### PR TITLE
switch back to upstream utilityai/llama-cpp-rs

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -585,8 +585,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.109"
-source = "git+https://github.com/AsbjornOlling/llama-cpp-rs.git?branch=windows-vulkan-filetracker-error-workaround#f6862ac840239b4b1a954348ac7b15102eba7292"
+version = "0.1.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b82db04c1a710842b56ea3a51e60f8abc0efc82424247a44e72075eaefb5f38"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -597,8 +598,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.109"
-source = "git+https://github.com/AsbjornOlling/llama-cpp-rs.git?branch=windows-vulkan-filetracker-error-workaround#f6862ac840239b4b1a954348ac7b15102eba7292"
+version = "0.1.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d960c3662adf16f50085a6c0e704a78069d730dfeff197b941272fa0da6cb9"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -10,8 +10,8 @@ minijinja = { version = "2.11.0", features = ["builtins", "json", "loader"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
-llama-cpp-sys-2 = { git = "https://github.com/AsbjornOlling/llama-cpp-rs.git", branch = "windows-vulkan-filetracker-error-workaround" }
-llama-cpp-2 = { git = "https://github.com/AsbjornOlling/llama-cpp-rs.git", branch = "windows-vulkan-filetracker-error-workaround" }
+llama-cpp-sys-2 = { version = "0.1.112" }
+llama-cpp-2 = { version = "0.1.112" }
 lazy_static = "1.5.0"
 tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.17"
@@ -22,4 +22,4 @@ serde_json = "1.0.140"
 gbnf = { git = "https://github.com/richardanaya/gbnf", branch = "main" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/AsbjornOlling/llama-cpp-rs.git", features = ["vulkan"], branch = "windows-vulkan-filetracker-error-workaround" }
+llama-cpp-2 = { version = "0.1.112", features = ["vulkan"] }

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -41,7 +41,6 @@ rec {
       outputHashes = {
         "gdextension-api-0.2.2" = "sha256-gaxM73OzriSDm6tLRuMTOZxCLky9oS1nq6zTsm0g4tA=";
         "godot-0.2.4" = "sha256-5Kh1j3OpUetuE9qNK85tpZTj8m0Y30CX4okll4TZ9Xc=";
-        "llama-cpp-2-0.1.109" = "sha256-U8uk9jo5Isk/OBqj/wvMvP5Hgq7zU4SYvNaSmwEX3j4=";
         "gbnf-0.2.1" = "sha256-oEP9/OJJWYLMGOPGxgoo5Y4Oh/WyusGZLhS2WF/Y/fU=";
       };
     };


### PR DESCRIPTION
Does what it says on the tin. Our PRs have been merged, so we can use the proper upstream again.