### PR TITLE
Cross encoder ranking

### DIFF
--- a/docs/rag.md
+++ b/docs/rag.md
@@ -1,0 +1,376 @@
+# Adding long term memory to you characters
+_Build AI systems that can search through your game's lore, dialog, or knowledge base and find the most relevant information._
+
+---
+
+Great! You've got chat and embeddings working. Now lets add something useful: the ability to look up specific lore, dialogiues, questlines etc.
+
+## Why Your Game Needs Smart Document Search
+
+Picture this: Your player is 40 hours into your RPG and asks an npc "Where do I find that crystal for the sword upgrade?" 
+Your LLM, without reranking, might give a generic answer or worse - make something up - leading to a bad player experience. 
+There are several ways to combat this, one is to load a lot of information into the context (ie. the system prompt) but with a limited context, it might 'forget' the important information
+or be confused by too much information. In stead we want to add a "long term memory" module to our language model, much like when you use google to search for the correct way to implement inverse square roota
+
+To do this in the llm space you are going to use RAG (retreival augmented generation) we are enriching the knowledge of the LLM by allowing it to search through a database of info we fed it. 
+There are many ways to do this. In Nobodywho we currently expose two mayor ways, one is embeddings; converting a sentence to a vector and then find the vectors that are closest to it.
+This is powerfull as you can save the vectors to a database or a file before hande and then use the really fast and cheap cosine similarity to compare them. Another more expensive but more accurate way is to use a crossencoder, that figures out the relationship between the question and the document rather that just how similar they are. 
+
+This approach is often called reranking, due to how it is used as a step two, for sorting and filtering large knowledge databases accesed by LLMs. I'll call it ranking as we are working with a small enough dataset that we do not need a first pass to filter out irrelevant info.
+
+Take this example:
+
+```
+Query: "Where do I find crystals for my sword upgrade?"
+Documents: [
+           "You asked the blacksmith: Where do I find crystals for my sword upgrade?",
+           "The blacksmith said: Magic crystals are found in the Northern Mountains.",
+           "You heard in the tawern: Magic crystals are not found in the Southern Desert."
+]
+```
+
+If we rely just on comparing the query with the embeddings using cosine similarity (as we did with the embeddings), we will get back the document "You asked the blacksmith: Where do I find crystals for my sword upgrade?" as it is the most similar sentence to our query. This gave us no useful information and we have just wasted valuable context. 
+
+But with ranking, the crossencoder model has been trained on knowing that the answer to the question is not the question itself, and thus ranks the document "The blacksmith said: Magic crystals are found in the Northern Mountains." the highest.
+
+
+Here are the key terms you'll need:
+
+| Term | Meaning |
+| ---- | ------- |
+| **Document Ranking** | Sorting text documents by how well they match or answer a question. |
+| **RAG (Retrieval-Augmented Generation)** | A system that finds relevant documents first, then uses them to generate better LLM responses. |
+| **Cross-encoder** | The type of model used for reranking - it reads both the query and document together to score relevance. |
+
+
+
+
+Let's show you how to build smart search systems for your game.
+
+## Download a Reranker Model
+
+Reranking models are different from chat and embedding models. You need one specifically trained for document ranking.
+
+We recommend [bge-reranker-v2-m3-Q8_0.gguf](https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf) - it works well for most games and supports multiple languages.
+
+
+Note that the current qwen3 reranker does not work, this is due to how the created the template as it has some missing fields. 
+
+## Practical Example: Smart NPC with Knowledge Base
+
+Let's build a tavern keeper NPC that can answer player questions by searching through their personal knowledge. This NPC knows about the local area, quests, and rumors - perfect for creating more immersive and helpful characters.
+
+We'll build it step by step, but for the impatient - the complete script is at the bottom.
+
+### Step 1: Set up your NPC's knowledge base
+
+First, let's create a knowledge base for our tavern keeper - everything this specific NPC would realistically know:
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+    extends NobodyWhoChat
+
+    @onready var reranker = $"../Rerank"
+    @onready var chat_model = $"../ChatModel"  
+
+    # The tavern keeper's knowledge - ~50 pieces of local information way more than could fit in a standard 4096 sized context.
+    var tavern_keeper_knowledge = PackedStringArray([
+        "The lake contains a special clay that blacksmiths use to forge superior weapons.",
+        "Ancient oak trees in the sacred grove provide wood that naturally resists dark magic.",
+        "Silver veins run through the mountain caves, valuable for crafting blessed weapons.",
+        "Rare moonflowers bloom in the ruins only once per season and have powerful magical properties.",
+        "The mill pond contains perfect stones for sharpening blades to razor sharpness.",
+        "Wild honey from forest bees makes potions more potent when used as a base ingredient.",
+        "A hooded stranger was seen asking questions about the old castle ruins last week.",
+        "Someone has been leaving fresh flowers at the grave of the village's first mayor.",
+        "Strange animal tracks were found near the well that don't match any known creature.",
+        "The church bell rang by itself three nights ago at exactly midnight.",
+        "Farmers found crop circles in their wheat fields after the last thunderstorm.",
+        "A merchant claims he saw lights moving through the abandoned mine from the hill road.",
+        "Children report hearing music coming from the forest when they play near the edge of town.",
+        "The weather has been unusually warm this winter, and the old-timers are worried.",
+        "Someone broke into the general store but only stole a map of the local cave systems.",
+        "A wolf with unusual blue eyes has been spotted watching the town from the tree line.",
+        "Old Sarah runs the bakery and makes the best apple pies in three kingdoms. Her grandson Tom went missing last week.",
+        "Blacksmith Gareth is always looking for quality iron ore and magic crystals. He pays double for rare materials.",
+        "Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.",
+        "Father Benedict runs the small chapel and knows ancient blessings that can ward off evil spirits.",
+        "Widow Martha owns the general store and knows every piece of gossip in town within hours.",
+        "Young apprentice Jake works for the blacksmith but dreams of becoming an adventurer himself.",
+        "Doctor Thorne treats injuries and illnesses. He keeps rare healing herbs in his back garden.",
+        "Stable master Owen knows every horse in the region and can track animals through the wilderness.",
+        "Mayor Thompson inherited his position from his father and struggles with the town's growing problems.",
+        "The old mine north of town has been abandoned for years. Strange sounds echo from deep inside at night.",
+        "The forest path to the east is safe during the day, but wolves hunt there after sunset.",
+        "Crystal Mines to the south produce valuable gems but have become dangerous recently.",
+        "The ancient stone bridge over Miller's Creek was built by dwarves centuries ago and still stands strong.",
+        "Darkwood Forest harbors bandits who prey on merchant caravans traveling the main road.",
+        "The Whispering Caves get their name from the wind that creates eerie sounds through the rock formations.",
+        "Lake Serenity freezes solid in winter, making it possible to cross on foot to the northern settlements.",
+        "The old watchtower on Crow's Hill offers a view of the entire valley but hasn't been manned in decades.",
+        "Sacred Grove is where the druids once practiced their rituals before they disappeared from the region.",
+        "The ruins of Castle Blackrock still stand on the mountain, though none dare venture there anymore.",
+        "Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.",
+        "Tom the baker's grandson disappeared near the Crystal Mines while collecting rare stones.",
+        "Strange lights have been appearing in the Whispering Caves during moonless nights.",
+        "Farmers report their livestock going missing near the edge of Darkwood Forest.",
+        "The old mill wheel stopped working after something large damaged it upstream.",
+        "Merchants complain about increased bandit activity on the eastern trade route.",
+        "Several townsfolk have reported seeing ghostly figures near the abandoned mine at midnight.",
+        "The village well's water tastes strange since the earthquake last month.",
+        "Wild animals have been acting aggressively and fleeing deeper into the mountains.",
+        "Ancient runes appeared overnight on the sacred standing stones outside town.",
+        "The town was founded by refugees fleeing the Great Dragon War three hundred years ago.",
+        "Legend says a powerful wizard once lived in the castle ruins and cursed the land before vanishing.",
+        "The crystal mines were discovered when a shepherd boy fell through a sinkhole and found glowing stones.",
+        "Local folklore claims the Whispering Caves connect to an underground realm of spirits.",
+        "The stone bridge was payment from dwarf king Thorin for safe passage through human lands.",
+        "Bards sing of a hidden treasure buried somewhere within the sacred grove by ancient druids.",
+        "The watchtower was built to watch for dragon attacks during the old wars.",
+        "Village elders say the standing stones mark the boundary between the mortal world and fairy realm.",
+        "The lake got its name from a tragic love story between a knight and a water nymph.",
+        "Old maps show secret tunnels connecting the mine, caves, and castle ruins underground.",
+        "Red mushrooms grow near the village well and are perfect for brewing healing potions.",
+        "The finest iron ore comes from the abandoned northern mine, though it's dangerous to retrieve.",
+        "Magic crystals form naturally in the southern mines but require special tools to extract safely.",
+        "Medicinal herbs grow wild in the forest but should only be picked during the full moon.",
+    ])
+
+    var ranked_docs = []
+    ```
+
+### Step 2: Configure your components
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+
+    func _ready():
+        # Set up the chat for generating helpful responses
+        self.model_node = chat_model
+        reranker.connect("ranking_finished", func(result): ranked_docs = result)
+        reranker.start_worker()
+
+        self.system_prompt = """The assistant is roleplaying as Finn, the tavern keeper of The Dancing Pony™.
+
+        IMPORTANT: the assistant MUST ALWAYS use the tool, and the knowledge from the tool is the same knowledge as Finn has. 
+        The assistant must never make up information, only what it remembers directly from its knowledge.
+        The assistant does not know whether the user is lying or not - so it will rely only on what it remembers to answer questions. 
+        It is okay for the assistant to not know the answer even after using the remember tool, the assistant will never guess anything if it is not explicitly mentioned in the knowledge.
+
+        The assistant must always speak like a tavern keeper.
+
+        """
+        # Add the tool to remember stuff
+        self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+        self.connect("response_finished", func(response: String): print("Finn says: ", response))
+        start_worker()
+    ```
+
+
+### Step 3: Set up a simple input system
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+    func _process(delta):
+        if Input.is_action_just_pressed("enter"):
+            var test_question = "Where is strider?"
+            print("Player asks Finn: ", test_question)
+            say(test_question)
+    ```
+
+
+### Step 4: Use ranked results to generate smart answers
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+ 
+    
+    func remember(query: String) -> String:
+        print("🔍 Finn searches his memory for: ", query)
+        ranked_docs = "\n".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+        print("🔍 Finn found: ", ranked_docs)
+
+        return ranked_docs
+
+    func _ready():
+        ....
+        # Add the tool to the llm to allow it to search for the most relevant lore.
+        self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+        self.connect("response_finished", func(response: String): print("Finn says: ", response))
+        start_worker()
+
+    ```
+
+When we run this we will get the response:
+
+>Finn says: <think>
+>Okay, let's see. The user asked about trading in the area.
+
+```
+🔍 Finn searches his memory for: What is trading like in the area?
+.... goes through and ranks all the documents
+🔍 Finn found: 
+Merchants complain about increased bandit activity on the eastern trade route.
+Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.
+Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.
+```
+
+> From the tool response, I remember a few key points. First, merchants are complaining about bandits on the eastern trade route. That's a problem for traders. Then there's Merchant Elena who sells spices and silk every second Tuesday. That's a specific thing to mention. Also, Trader Gareth's caravan was attacked in Darkwood Forest. So the answer should include these points.
+>
+>I need to present this information clearly. Start by mentioning the bandit issue, then note Elena's schedule, and mention Gareth's attack. Make sure it's in a friendly, tavern keeper style. Check if there's anything else, but the tool response only gave these three points. Don't add anything extra. Alright, structure the response with those details.
+></think>
+
+and when good ole Finn is done thinking:
+
+>Trading in the area is... if you'll forgive the blunt truth, *dangerous*. Merchants swear the eastern trade route is littered with bandits, and last week a caravan was ambushed in Darkwood Forest. But there are still opportunities! Merchant Elena brings rare spices and silk every second Tuesday—she’s a reliable seller. Just be wary of the roads. And if you spot a caravan with a single rider, don’t engage. They’re probably bandits.
+
+
+---
+
+### Complete Scripts
+
+<details markdown>
+<summary markdown>:simple-godotengine: Complete Godot Script (Click to expand)</summary>
+
+```gdscript
+extends NobodyWhoChat
+
+@onready var reranker = $"../Rerank"
+@onready var chat_model = $"../ChatModel"  
+
+# The tavern keeper's knowledge - ~50 pieces of local information way more than could fit in a standard 4096 sized context.
+var tavern_keeper_knowledge = PackedStringArray([
+    "The lake contains a special clay that blacksmiths use to forge superior weapons.",
+    "Ancient oak trees in the sacred grove provide wood that naturally resists dark magic.",
+    "Silver veins run through the mountain caves, valuable for crafting blessed weapons.",
+    "Rare moonflowers bloom in the ruins only once per season and have powerful magical properties.",
+    "The mill pond contains perfect stones for sharpening blades to razor sharpness.",
+    "Wild honey from forest bees makes potions more potent when used as a base ingredient.",
+    "A hooded stranger was seen asking questions about the old castle ruins last week.",
+    "Someone has been leaving fresh flowers at the grave of the village's first mayor.",
+    "Strange animal tracks were found near the well that don't match any known creature.",
+    "The church bell rang by itself three nights ago at exactly midnight.",
+    "Farmers found crop circles in their wheat fields after the last thunderstorm.",
+    "A merchant claims he saw lights moving through the abandoned mine from the hill road.",
+    "Children report hearing music coming from the forest when they play near the edge of town.",
+    "The weather has been unusually warm this winter, and the old-timers are worried.",
+    "Someone broke into the general store but only stole a map of the local cave systems.",
+    "A wolf with unusual blue eyes has been spotted watching the town from the tree line.",
+    "Old Sarah runs the bakery and makes the best apple pies in three kingdoms. Her grandson Tom went missing last week.",
+    "Blacksmith Gareth is always looking for quality iron ore and magic crystals. He pays double for rare materials.",
+    "Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.",
+    "Father Benedict runs the small chapel and knows ancient blessings that can ward off evil spirits.",
+    "Widow Martha owns the general store and knows every piece of gossip in town within hours.",
+    "Young apprentice Jake works for the blacksmith but dreams of becoming an adventurer himself.",
+    "Doctor Thorne treats injuries and illnesses. He keeps rare healing herbs in his back garden.",
+    "Stable master Owen knows every horse in the region and can track animals through the wilderness.",
+    "Mayor Thompson inherited his position from his father and struggles with the town's growing problems.",
+    "The old mine north of town has been abandoned for years. Strange sounds echo from deep inside at night.",
+    "The forest path to the east is safe during the day, but wolves hunt there after sunset.",
+    "Crystal Mines to the south produce valuable gems but have become dangerous recently.",
+    "The ancient stone bridge over Miller's Creek was built by dwarves centuries ago and still stands strong.",
+    "Darkwood Forest harbors bandits who prey on merchant caravans traveling the main road.",
+    "The Whispering Caves get their name from the wind that creates eerie sounds through the rock formations.",
+    "Lake Serenity freezes solid in winter, making it possible to cross on foot to the northern settlements.",
+    "The old watchtower on Crow's Hill offers a view of the entire valley but hasn't been manned in decades.",
+    "Sacred Grove is where the druids once practiced their rituals before they disappeared from the region.",
+    "The ruins of Castle Blackrock still stand on the mountain, though none dare venture there anymore.",
+    "Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.",
+    "Tom the baker's grandson disappeared near the Crystal Mines while collecting rare stones.",
+    "Strange lights have been appearing in the Whispering Caves during moonless nights.",
+    "Farmers report their livestock going missing near the edge of Darkwood Forest.",
+    "The old mill wheel stopped working after something large damaged it upstream.",
+    "Merchants complain about increased bandit activity on the eastern trade route.",
+    "Several townsfolk have reported seeing ghostly figures near the abandoned mine at midnight.",
+    "The village well's water tastes strange since the earthquake last month.",
+    "Wild animals have been acting aggressively and fleeing deeper into the mountains.",
+    "Ancient runes appeared overnight on the sacred standing stones outside town.",
+    "The town was founded by refugees fleeing the Great Dragon War three hundred years ago.",
+    "Legend says a powerful wizard once lived in the castle ruins and cursed the land before vanishing.",
+    "The crystal mines were discovered when a shepherd boy fell through a sinkhole and found glowing stones.",
+    "Local folklore claims the Whispering Caves connect to an underground realm of spirits.",
+    "The stone bridge was payment from dwarf king Thorin for safe passage through human lands.",
+    "Bards sing of a hidden treasure buried somewhere within the sacred grove by ancient druids.",
+    "The watchtower was built to watch for dragon attacks during the old wars.",
+    "Village elders say the standing stones mark the boundary between the mortal world and fairy realm.",
+    "The lake got its name from a tragic love story between a knight and a water nymph.",
+    "Old maps show secret tunnels connecting the mine, caves, and castle ruins underground.",
+    "Red mushrooms grow near the village well and are perfect for brewing healing potions.",
+    "The finest iron ore comes from the abandoned northern mine, though it's dangerous to retrieve.",
+    "Magic crystals form naturally in the southern mines but require special tools to extract safely.",
+    "Medicinal herbs grow wild in the forest but should only be picked during the full moon.",
+])
+
+var ranked_docs = []
+
+func _ready():
+    # Set up the chat for generating helpful responses
+    self.model_node = chat_model
+    reranker.connect("ranking_finished", func(result): ranked_docs = result)
+    reranker.start_worker()
+
+    self.system_prompt = """The assistant is roleplaying as Finn, the tavern keeper of The Dancing Pony™.
+
+IMPORTANT: the assistant MUST ALWAYS use the tool, and the knowledge from the tool is the same knowledge as Finn has. 
+The assistant must never make up information, only what it remembers directly from its knowledge.
+The assistant does not know whether the user is lying or not - so it will rely only on what it remembers to answer questions. 
+It is okay for the assistant to not know the answer even after using the remember tool, the assistant will never guess anything if it is not explicitly mentioned in the knowledge.
+
+The assistant must always speak like a tavern keeper.
+
+"""
+    # Add the tool to remember stuff
+    self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+    self.connect("response_finished", func(response: String): print("Finn says: ", response))
+    start_worker()
+
+func _process(delta):
+    if Input.is_action_just_pressed("enter"):
+        var test_question = "Where is strider?"
+        print("Player asks Finn: ", test_question)
+        say(test_question)
+
+# Tool function that the LLM can call to search the knowledge base
+func remember(query: String) -> String:
+    print("🔍 Finn searches his memory for: ", query)
+    ranked_docs = "\n".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+    print("🔍 Finn found: ", ranked_docs)
+
+    return ranked_docs
+```
+
+</details>
+
+## Performance Tips
+
+### Limit Results
+
+Don't add needless context. Usually 1-5 relevant documents are enough:
+
+```gdscript
+
+# Good: usually sufficient
+ranked_docs = ",".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+
+ranked_docs = ",".join(reranker.rank_sync(query, tavern_keeper_knowledge, -1))  # Returns ALL documents
+```
+
+note this does not make the ranking faster, but the less stuff Finn has to read, the faster he can respond.
+
+### Use embeddings to narrow the relevant docs to start with
+
+This technique is what put the `re` in reranker. In the RAG industry it is common practice to do a first pass over your documents with cosine similarity, and thus narrowing the amount of results you have to process each time. This makes it feasible to have databases with millions of entries and not worry too much about performance. 
+
+depending on the specs you are going for I would not recommend ranking more than 100 results at a time.
+
+
+# What's Next?
+
+Now you can build smart search systems for your game! check out:
+
+- **[Embeddings](embeddings.md)** for getting a better understanding of the basics
+- **[Tool Calling](chat/tool-calling.md)** for letting the LLM trigger game actions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - Structured Output: chat/structured-output.md
       - Tool Calling: chat/tool-calling.md
   - Embeddings: embeddings.md
+  - RAG: rag.md
   - Model Selection: model-selection.md
   - Contributing:
       - Development Environment: contributing/dev-environment.md

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "llama-cpp-sys-2",
  "minijinja",
  "minijinja-contrib",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -815,6 +816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +867,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "regex"
@@ -1552,3 +1591,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber = "0.3.19"
 regex = "1.11.1"
 serde_json = "1.0.140"
 gbnf = { git = "https://github.com/richardanaya/gbnf", branch = "main" }
+rand = "0.9.2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 llama-cpp-2 = { version = "0.1.112", features = ["vulkan"] }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -3,7 +3,7 @@ use crate::chat_state::ChatState;
 use crate::llm;
 use crate::llm::Worker;
 use crate::sampler_config::SamplerConfig;
-use llama_cpp_2::model::LlamaModel;
+use llama_cpp_2::{context::params::LlamaPoolingType, model::LlamaModel};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tracing::{debug, error, warn};
@@ -337,6 +337,12 @@ impl llm::GenerationCapability for ChatWorker {}
 impl llm::Stoppable for ChatWorker {
     fn stop(&self) -> bool {
         self.should_stop.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl llm::PoolingType for ChatWorker {
+    fn pooling_type(&self) -> LlamaPoolingType {
+        LlamaPoolingType::None
     }
 }
 

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -2,20 +2,20 @@ use crate::llm;
 use crate::llm::Worker;
 use llama_cpp_2::context::params::LlamaPoolingType;
 use llama_cpp_2::model::LlamaModel;
-use tracing::error;
+use tracing::{debug, error};
 use std::sync::Arc;
 
-pub struct RerankerHandle {
-    msg_tx: std::sync::mpsc::Sender<RerankerMsg>,
+pub struct CrossEncoderHandle {
+    msg_tx: std::sync::mpsc::Sender<CrossEncoderMsg>,
 }
 
-impl RerankerHandle {
+impl CrossEncoderHandle {
     pub fn new(model: Arc<LlamaModel>, n_ctx: u32) -> Self {
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
             if let Err(e) = run_worker(model, n_ctx, msg_rx) {
-                error!("Reranker worker crashed: {}", e)
+                error!("Crossencoder worker crashed: {}", e)
             }
         });
 
@@ -24,17 +24,17 @@ impl RerankerHandle {
 
     pub fn rank(&self, query: String, documents: Vec<String>) -> tokio::sync::mpsc::Receiver<Vec<f32>> {
         let (scores_tx, scores_rx) = tokio::sync::mpsc::channel(1);
-        let _ = self.msg_tx.send(RerankerMsg::Rerank(query, documents, scores_tx));
+        let _ = self.msg_tx.send(CrossEncoderMsg::Rank(query, documents, scores_tx));
         scores_rx
     }
 }
 
-enum RerankerMsg {
-    Rerank(String, Vec<String>, tokio::sync::mpsc::Sender<Vec<f32>>),
+enum CrossEncoderMsg {
+    Rank(String, Vec<String>, tokio::sync::mpsc::Sender<Vec<f32>>),
 }
 
 #[derive(Debug, thiserror::Error)]
-enum RerankerWorkerError {
+enum CrossEncoderWorkerError {
     #[error("Error initializing worker: {0}")]
     InitWorkerError(#[from] llm::InitWorkerError),
 
@@ -48,13 +48,13 @@ enum RerankerWorkerError {
 fn run_worker(
     model: Arc<LlamaModel>,
     n_ctx: u32,
-    msg_rx: std::sync::mpsc::Receiver<RerankerMsg>,
-) -> Result<(), RerankerWorkerError> {
-    let mut worker_state = Worker::new_reranker_worker(&model, n_ctx)?;
+    msg_rx: std::sync::mpsc::Receiver<CrossEncoderMsg>,
+) -> Result<(), CrossEncoderWorkerError> {
+    let mut worker_state = Worker::new_crossencoder_worker(&model, n_ctx)?;
     while let Ok(msg) = msg_rx.recv() {
         match msg {
-            RerankerMsg::Rerank(query, documents, respond) => {
-                // Clear context for each reranking operation
+            CrossEncoderMsg::Rank(query, documents, respond) => {
+                // Clear context for each crossencodering operation
                 worker_state.reset_context();
 
                 let scores = worker_state.rank(query, documents)?;
@@ -66,42 +66,42 @@ fn run_worker(
     Ok(())
 }
 
-struct RerankerWorker {}
+struct CrossEncoderWorker {}
 
-impl llm::PoolingType for RerankerWorker {
+impl llm::PoolingType for CrossEncoderWorker {
     fn pooling_type(&self) -> LlamaPoolingType {
         LlamaPoolingType::Rank
     }
 }
 
-impl<'a> Worker<'a, RerankerWorker> {
-    pub fn new_reranker_worker(
+impl<'a> Worker<'a, CrossEncoderWorker> {
+    pub fn new_crossencoder_worker(
         model: &Arc<LlamaModel>,
         n_ctx: u32,
-    ) -> Result<Worker<'_, RerankerWorker>, llm::InitWorkerError> {
-        Worker::new_with_type(model, n_ctx, true, RerankerWorker {})
+    ) -> Result<Worker<'_, CrossEncoderWorker>, llm::InitWorkerError> {
+        Worker::new_with_type(model, n_ctx, true, CrossEncoderWorker {})
     }
 
-    pub fn get_classification_score(&self) -> Result<f32, RerankerWorkerError> {
-
+    pub fn get_classification_score(&self) -> Result<f32, CrossEncoderWorkerError> {
         // Cross-encoder models process query+document as single sequence, outputting classification scores.
-        // For reranking, all tokens have embeddings enabled (logits=true) but only the final token's
+        // For crossencodering, all tokens have embeddings enabled (logits=true) but only the final token's
         // embedding contains the relevance score. embeddings_seq_ith(0) gets the sequence's embedding
         // vector, and embeddings[0] extracts the classification score from the final token.
-        let embeddings = self.ctx.embeddings_seq_ith(0).map_err(|e| RerankerWorkerError::ClassificationError(e.to_string()))?;
+        let embeddings = self.ctx.embeddings_seq_ith(0).map_err(|e| CrossEncoderWorkerError::ClassificationError(e.to_string()))?;
         
         if embeddings.len() >= 1 {
             Ok(embeddings[0])
         } else {
-            Err(RerankerWorkerError::ClassificationError("classification head is empty".to_string()))
+            Err(CrossEncoderWorkerError::ClassificationError("classification head is empty".to_string()))
         }
     }
 
-    pub fn rank(&mut self, query: String, documents: Vec<String>) -> Result<Vec<f32>, RerankerWorkerError> {
+    pub fn rank(&mut self, query: String, documents: Vec<String>) -> Result<Vec<f32>, CrossEncoderWorkerError> {
         let mut scores = Vec::new();
         for document in documents {
             self.reset_context();
-            let input = format!("Query: {}\nDocument: {}", query, document);
+            // TODO: use the cls and sep tokens for this.
+            let input = format!("{query}</s><s>{document}</s>");
             let score = self.read_string(input)?.get_classification_score()?;
             scores.push(score);
         }
@@ -116,11 +116,11 @@ mod tests {
     use rand::{seq::SliceRandom};
 
     #[test]
-    fn test_reranker() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_crossencoder() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
-        let model = test_utils::load_reranker_model();
+        let model = test_utils::load_crossencoder_model();
 
-        let mut worker = Worker::new_reranker_worker(&model, 1024)?;
+        let mut worker = Worker::new_crossencoder_worker(&model, 1024)?;
 
         let query = "What is the capital of France?".to_string();
         let mut documents = vec![
@@ -147,10 +147,17 @@ mod tests {
 
         docs_with_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
-        // does not really test the accuracy of the the ranker, but rather that it works
-        assert_eq!(docs_with_scores[0].0, "Paris is the capital of France.".to_string());
+        let mut seen_paris = false;
+        for i in 0..3 {
+            if docs_with_scores[i].0 == "Paris is the capital of France." {
+                seen_paris = true;
+            }
+        }
+        assert!(seen_paris, "`Paris is the capital of France.` is not in top three");
 
         Ok(())
     }
 
+
+    
 } 

--- a/nobodywho/core/src/embed.rs
+++ b/nobodywho/core/src/embed.rs
@@ -1,5 +1,6 @@
 use crate::llm;
 use crate::llm::Worker;
+use llama_cpp_2::context::params::LlamaPoolingType;
 use llama_cpp_2::model::LlamaModel;
 use tracing::error;
 
@@ -70,6 +71,12 @@ fn run_worker(
 // Embeddings Worker - synchronous, blocking work
 
 struct EmbeddingsWorker {}
+
+impl llm::PoolingType for EmbeddingsWorker {
+    fn pooling_type(&self) -> LlamaPoolingType {
+        LlamaPoolingType::Cls
+    }
+}
 
 impl<'a> Worker<'a, EmbeddingsWorker> {
     pub fn new_embeddings_worker(

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod chat_state;
 pub mod embed;
 pub mod llm;
+pub mod rerank;
 pub mod sampler_config;
 
 pub fn send_llamacpp_logs_to_tracing() {
@@ -37,6 +38,11 @@ pub mod test_utils {
         std::env::var("TEST_EMBEDDINGS_MODEL").unwrap_or_else(|_| "embeddings.gguf".to_string())
     }
 
+    /// Get path to test reranker model from TEST_RERANKER_MODEL env var
+    pub fn test_reranker_model_path() -> String {
+        std::env::var("TEST_RERANKER_MODEL").unwrap_or_else(|_| "reranker.gguf".to_string())
+    }
+
     /// Load the test model with GPU acceleration if available
     pub fn load_test_model() -> Model {
         let path = test_model_path();
@@ -55,5 +61,13 @@ pub mod test_utils {
         //      it's most likely related to an upstream change in llama.cpp
         get_model(&path, false)
             .unwrap_or_else(|e| panic!("Failed to load embeddings model from {}: {:?}", path, e))
+    }
+
+    /// Load the reranker model with GPU acceleration if available
+    pub fn load_reranker_model() -> Model {
+        let path = test_reranker_model_path();
+        // Same GPU offloading note as embeddings model
+        get_model(&path, false)
+            .unwrap_or_else(|e| panic!("Failed to load reranker model from {}: {:?}", path, e))
     }
 }

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -2,7 +2,7 @@ pub mod chat;
 pub mod chat_state;
 pub mod embed;
 pub mod llm;
-pub mod rerank;
+pub mod crossencoder;
 pub mod sampler_config;
 
 pub fn send_llamacpp_logs_to_tracing() {
@@ -38,9 +38,9 @@ pub mod test_utils {
         std::env::var("TEST_EMBEDDINGS_MODEL").unwrap_or_else(|_| "embeddings.gguf".to_string())
     }
 
-    /// Get path to test reranker model from TEST_RERANKER_MODEL env var
-    pub fn test_reranker_model_path() -> String {
-        std::env::var("TEST_RERANKER_MODEL").unwrap_or_else(|_| "reranker.gguf".to_string())
+    /// Get path to test crossencoder model from TEST_CROSSENCODER_MODEL env var
+    pub fn test_crossencoder_model_path() -> String {
+        std::env::var("TEST_CROSSENCODER_MODEL").unwrap_or_else(|_| "crossencoder.gguf".to_string())
     }
 
     /// Load the test model with GPU acceleration if available
@@ -63,11 +63,11 @@ pub mod test_utils {
             .unwrap_or_else(|e| panic!("Failed to load embeddings model from {}: {:?}", path, e))
     }
 
-    /// Load the reranker model with GPU acceleration if available
-    pub fn load_reranker_model() -> Model {
-        let path = test_reranker_model_path();
+    /// Load the crossencoder model with GPU acceleration if available
+    pub fn load_crossencoder_model() -> Model {
+        let path = test_crossencoder_model_path();
         // Same GPU offloading note as embeddings model
         get_model(&path, false)
-            .unwrap_or_else(|e| panic!("Failed to load reranker model from {}: {:?}", path, e))
+            .unwrap_or_else(|e| panic!("Failed to load crossencoder model from {}: {:?}", path, e))
     }
 }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -150,6 +150,16 @@ pub(crate) struct Worker<'a, S> {
     pub(crate) extra: S,
 }
 
+pub trait PoolingType {
+    fn pooling_type(&self) -> LlamaPoolingType;
+}
+
+impl<'a, T> PoolingType for Worker<'a, T> {
+    fn pooling_type(&self) -> LlamaPoolingType {
+        LlamaPoolingType::Unspecified
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum WorkerError {
     #[error("Could not determine number of threads available: {0}")]
@@ -234,6 +244,7 @@ pub struct GenerationWorker {
     should_stop: Arc<AtomicBool>,
 }
 
+
 impl GenerationCapability for GenerationWorker {}
 impl Stoppable for GenerationWorker {
     fn stop(&self) -> bool {
@@ -255,6 +266,12 @@ impl<'a> Worker<'_, GenerationWorker> {
                 should_stop: Arc::new(AtomicBool::new(false)),
             },
         )
+    }
+}
+
+impl PoolingType for GenerationWorker {
+    fn pooling_type(&self) -> LlamaPoolingType {
+        LlamaPoolingType::None
     }
 }
 
@@ -343,7 +360,10 @@ where
 }
 
 // Common methods for any workstate type
-impl<'a, T> Worker<'a, T> {
+impl<'a, T> Worker<'a, T>
+where
+    T: PoolingType,
+{
     pub(crate) fn new_with_type(
         model: &Arc<LlamaModel>,
         n_ctx: u32,
@@ -361,7 +381,7 @@ impl<'a, T> Worker<'a, T> {
                 .with_n_threads(n_threads)
                 .with_n_threads_batch(n_threads)
                 .with_embeddings(use_embeddings)
-                .with_pooling_type(LlamaPoolingType::Rank);
+                .with_pooling_type(extra.pooling_type());
 
             // Create inference context and sampler
             model.new_context(&LLAMA_BACKEND, ctx_params)?

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,6 +1,6 @@
 use crate::sampler_config::{make_sampler, SamplerConfig};
 use lazy_static::lazy_static;
-use llama_cpp_2::context::params::LlamaContextParams;
+use llama_cpp_2::context::params::{LlamaContextParams, LlamaPoolingType};
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
@@ -360,7 +360,8 @@ impl<'a, T> Worker<'a, T> {
                 .with_n_ctx(std::num::NonZero::new(n_ctx))
                 .with_n_threads(n_threads)
                 .with_n_threads_batch(n_threads)
-                .with_embeddings(use_embeddings);
+                .with_embeddings(use_embeddings)
+                .with_pooling_type(LlamaPoolingType::Rank);
 
             // Create inference context and sampler
             model.new_context(&LLAMA_BACKEND, ctx_params)?

--- a/nobodywho/core/src/rerank.rs
+++ b/nobodywho/core/src/rerank.rs
@@ -80,7 +80,7 @@ impl<'a> Worker<'a, RerankerWorker> {
         model: &Arc<LlamaModel>,
         n_ctx: u32,
     ) -> Result<Worker<'_, RerankerWorker>, llm::InitWorkerError> {
-        Worker::new_with_type(model, n_ctx, true, true, RerankerWorker {})
+        Worker::new_with_type(model, n_ctx, true, RerankerWorker {})
     }
 
     pub fn get_classification_score(&self) -> Result<f32, RerankerWorkerError> {
@@ -113,9 +113,19 @@ mod tests {
 
         let query = "What is the capital of France?";
         let documents = vec![
-            "Paris is the capital of France.".to_string(),
             "The Eiffel Tower is a famous landmark in the capital of France.".to_string(),
             "France is a country in Europe.".to_string(),
+            "Lyon is a major city in France, but not the capital.".to_string(),
+            "The capital of Germany is Berlin.".to_string(),
+            "Paris hosts many international organizations.".to_string(),
+            "Marseille is located in the south of France.".to_string(),
+            "The French government is based in Paris.".to_string(),
+            "London is the capital of the United Kingdom.".to_string(),
+            "France's capital city is known for its art and culture.".to_string(),
+            "The Louvre Museum is located in Paris, France.".to_string(),
+            "Paris is the capital of France.".to_string(),
+            "The president of France works in Paris, which is the capital of his country.".to_string(),
+            "Many tourists visit Paris every year.".to_string(),
         ];
 
         let mut scores = Vec::new();
@@ -131,9 +141,11 @@ mod tests {
             "Paris document should be most relevant to capital query"
         );
 
-        // All scores should be reasonable (between 0 and 1 for probability scores)
-        for score in &scores {
-            assert!(*score >= 0.0 && *score <= 1.0, "Score {} should be between 0 and 1", score);
+        //debug: print out score and sentencequery pair  sorted by score
+        let mut sorted_scores = scores.clone();
+        sorted_scores.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        for (i, score) in sorted_scores.iter().enumerate() {
+            println!("Score: {score}, Sentence: {}", documents[i]);
         }
 
         Ok(())

--- a/nobodywho/core/src/rerank.rs
+++ b/nobodywho/core/src/rerank.rs
@@ -1,0 +1,166 @@
+use crate::llm;
+use crate::llm::Worker;
+use llama_cpp_2::model::LlamaModel;
+use tracing::error;
+
+use std::sync::Arc;
+
+// RerankerHandle - for parallelism
+
+pub struct RerankerHandle {
+    msg_tx: std::sync::mpsc::Sender<RerankerMsg>,
+}
+
+impl RerankerHandle {
+    pub fn new(model: Arc<LlamaModel>, n_ctx: u32) -> Self {
+        let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            if let Err(e) = run_worker(model, n_ctx, msg_rx) {
+                error!("Reranker worker crashed: {}", e)
+            }
+        });
+
+        Self { msg_tx }
+    }
+
+    pub fn rerank(&self, query: String, documents: Vec<String>) -> tokio::sync::mpsc::Receiver<Vec<f32>> {
+        let (scores_tx, scores_rx) = tokio::sync::mpsc::channel(1);
+        let _ = self.msg_tx.send(RerankerMsg::Rerank(query, documents, scores_tx));
+        scores_rx
+    }
+}
+
+enum RerankerMsg {
+    Rerank(String, Vec<String>, tokio::sync::mpsc::Sender<Vec<f32>>),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RerankerWorkerError {
+    #[error("Error initializing worker: {0}")]
+    InitWorkerError(#[from] llm::InitWorkerError),
+
+    #[error("Error reading string: {0}")]
+    ReadError(#[from] llm::ReadError),
+
+    #[error("Error getting classification score: {0}")]
+    ClassificationError(String),
+}
+
+fn run_worker(
+    model: Arc<LlamaModel>,
+    n_ctx: u32,
+    msg_rx: std::sync::mpsc::Receiver<RerankerMsg>,
+) -> Result<(), RerankerWorkerError> {
+    let mut worker_state = Worker::new_reranker_worker(&model, n_ctx)?;
+    while let Ok(msg) = msg_rx.recv() {
+        match msg {
+            RerankerMsg::Rerank(query, documents, respond) => {
+                // Clear context for each reranking operation
+                worker_state.reset_context();
+
+                let mut scores = Vec::new();
+                for document in documents {
+                    // Format as query + document pair for cross-encoder
+                    let input = format!("Query: {}\nDocument: {}", query, document);
+                    let score = worker_state.read_string(input)?.get_classification_score()?;
+                    scores.push(score);
+                }
+                let _ = respond.blocking_send(scores);
+            }
+        }
+    }
+    Ok(())
+}
+
+struct RerankerWorker {}
+
+impl<'a> Worker<'a, RerankerWorker> {
+    pub fn new_reranker_worker(
+        model: &Arc<LlamaModel>,
+        n_ctx: u32,
+    ) -> Result<Worker<'_, RerankerWorker>, llm::InitWorkerError> {
+        Worker::new_with_type(model, n_ctx, true, true, RerankerWorker {})
+    }
+
+    pub fn get_classification_score(&self) -> Result<f32, RerankerWorkerError> {
+
+        // Cross-encoder models process query+document as single sequence, outputting classification scores.
+        // For reranking, all tokens have embeddings enabled (logits=true) but only the final token's
+        // embedding contains the relevance score. embeddings_seq_ith(0) gets the sequence's embedding
+        // vector, and embeddings[0] extracts the classification score from the final token.
+        let embeddings = self.ctx.embeddings_seq_ith(0).map_err(|e| RerankerWorkerError::ClassificationError(e.to_string()))?;
+        
+        if embeddings.len() >= 1 {
+            Ok(embeddings[0])
+        } else {
+            Err(RerankerWorkerError::ClassificationError("classification head is empty".to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils;
+
+    #[test]
+    fn test_reranker() -> Result<(), Box<dyn std::error::Error>> {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_reranker_model();
+
+        let mut worker = Worker::new_reranker_worker(&model, 1024)?;
+
+        let query = "What is the capital of France?";
+        let documents = vec![
+            "Paris is the capital of France.".to_string(),
+            "The Eiffel Tower is a famous landmark in the capital of France.".to_string(),
+            "France is a country in Europe.".to_string(),
+        ];
+
+        let mut scores = Vec::new();
+        for document in &documents {
+            let input = format!("Query: {}\nDocument: {}", query, document);
+            let score = worker.read_string(input)?.get_classification_score()?;
+            scores.push(score);
+        }
+
+        // The first document should have the highest relevance score
+        assert!(
+            scores[0] > scores[1] && scores[0] > scores[2],
+            "Paris document should be most relevant to capital query"
+        );
+
+        // All scores should be reasonable (between 0 and 1 for probability scores)
+        for score in &scores {
+            assert!(*score >= 0.0 && *score <= 1.0, "Score {} should be between 0 and 1", score);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reranker_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_reranker_model();
+        let mut worker = Worker::new_reranker_worker(&model, 1024)?;
+        
+        let query = "What is machine learning?";
+        let document = "Machine learning is a subset of artificial intelligence.";
+        let input = format!("Query: {}\nDocument: {}", query, document);
+        
+        let first_score = worker.read_string(input.clone())?.get_classification_score()?;
+        
+        worker.reset_context();
+        
+        let second_score = worker.read_string(input)?.get_classification_score()?;
+        
+        assert_eq!(
+            first_score,
+            second_score,
+            "Same input should produce identical classification scores."
+        );
+        
+        Ok(())
+    }
+} 

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -54,7 +54,7 @@ rec {
       url = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf";
       sha256 = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
     };
-    env.TEST_RERANKER_MODEL = fetchurl {
+    env.TEST_CROSSENCODER_MODEL = fetchurl {
       name = "bge-reranker-v2-m3-Q8_0.gguf";
       url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
       sha256 = "sha256-pDx8mxGkwVF+W/lRUZYOFiHRty96STNksB44bPGqodM=";

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -55,9 +55,9 @@ rec {
       sha256 = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
     };
     env.TEST_RERANKER_MODEL = fetchurl {
-      name = "Qwen3-Reranker-0.6B-q4_0.gguf";
-      url = "https://huggingface.co/Mungert/Qwen3-Reranker-0.6B-GGUF/resolve/main/Qwen3-Reranker-0.6B-q4_0.gguf";
-      sha256 = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
+      name = "bge-reranker-v2-m3-Q8_0.gguf";
+      url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
+      sha256 = "sha256-0OdXMicV+utzNaRezjkufM67NOMudXQ4bqdbniOCAKo=";
     };
     checkPhase = ''
       cargo test -- --test-threads=1 --nocapture

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -57,7 +57,7 @@ rec {
     env.TEST_RERANKER_MODEL = fetchurl {
       name = "bge-reranker-v2-m3-Q8_0.gguf";
       url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
-      sha256 = "sha256-0OdXMicV+utzNaRezjkufM67NOMudXQ4bqdbniOCAKo=";
+      sha256 = "sha256-pDx8mxGkwVF+W/lRUZYOFiHRty96STNksB44bPGqodM=";
     };
     checkPhase = ''
       cargo test -- --test-threads=1 --nocapture

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -54,6 +54,11 @@ rec {
       url = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf";
       sha256 = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
     };
+    env.TEST_RERANKER_MODEL = fetchurl {
+      name = "Qwen3-Reranker-0.6B-q4_0.gguf";
+      url = "https://huggingface.co/Mungert/Qwen3-Reranker-0.6B-GGUF/resolve/main/Qwen3-Reranker-0.6B-q4_0.gguf";
+      sha256 = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
+    };
     checkPhase = ''
       cargo test -- --test-threads=1 --nocapture
     '';

--- a/nobodywho/godot/integration-test/chat.gd
+++ b/nobodywho/godot/integration-test/chat.gd
@@ -84,7 +84,7 @@ func test_chat_history():
 	var resp = await response_finished
 	print("Got resp: " + resp)
 	assert("2 + 2" in resp)
-	return true
+	return true 
 	
 
 func current_temperature(location: String) -> String:

--- a/nobodywho/godot/integration-test/chat.gd.uid
+++ b/nobodywho/godot/integration-test/chat.gd.uid
@@ -1,0 +1,1 @@
+uid://dkqdgp3feonn7

--- a/nobodywho/godot/integration-test/crossencoder_test.gd
+++ b/nobodywho/godot/integration-test/crossencoder_test.gd
@@ -1,8 +1,8 @@
-extends NobodyWhoRerank
+extends NobodyWhoCrossEncoder
 
 func run_test():
 	# configure node
-	self.model_node = get_node("../RerankModel")
+	self.model_node = get_node("../CrossEncoderModel")
 	
 	# test ranking documents
 	var query = "What is the capital of France?"
@@ -21,12 +21,12 @@ func run_test():
 	])
 	
 	# Test ranking with limit
-	var ranked_docs = await rank(query, documents, 5)
+	var ranked_docs: PackedStringArray = await rank(query, documents, 3)
 	print("✨ Got ranked documents: " + str(ranked_docs))
 	
 	# Basic validation
-	assert(ranked_docs.size() == 5, "Should return exactly 5 documents")
-	assert(ranked_docs[0].contains("Paris is the capital of France"), "Top result should be the most relevant")
+	assert(ranked_docs.size() == 3, "Should return exactly 3 documents")
+	assert("".join(ranked_docs).contains("Paris is the capital of France"), "Paris is the capital of France should be in the top 3")
 	
 	# Test ranking without limit (should return all documents)
 	var all_ranked_docs = await rank(query, documents, -1)

--- a/nobodywho/godot/integration-test/default.nix
+++ b/nobodywho/godot/integration-test/default.nix
@@ -12,7 +12,7 @@ let
     hash = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
   };
 
-  reranker_model = fetchurl {
+  crossencoder_model = fetchurl {
     name = "bge-reranker-v2-m3-Q8_0.gguf";
     url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
     hash = "sha256-pDx8mxGkwVF+W/lRUZYOFiHRty96STNksB44bPGqodM=";
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
 
     cp ${model} $out/Qwen_Qwen3-0.6B-Q4_0.gguf
     cp ${embedding_model} $out/bge-small-en-v1.5-q8_0.gguf
-    cp ${reranker_model} $out/bge-reranker-v2-m3-Q8_0.gguf
+    cp ${crossencoder_model} $out/bge-reranker-v2-m3-Q8_0.gguf
 
     # Patch binaries.
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/game

--- a/nobodywho/godot/integration-test/default.nix
+++ b/nobodywho/godot/integration-test/default.nix
@@ -15,7 +15,7 @@ let
   reranker_model = fetchurl {
     name = "bge-reranker-v2-m3-Q8_0.gguf";
     url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
-    hash = "sha256-0OdXMicV+utzNaRezjkufM67NOMudXQ4bqdbniOCAKo=";
+    hash = "sha256-pDx8mxGkwVF+W/lRUZYOFiHRty96STNksB44bPGqodM=";
   };
 in
 stdenv.mkDerivation {

--- a/nobodywho/godot/integration-test/default.nix
+++ b/nobodywho/godot/integration-test/default.nix
@@ -6,11 +6,16 @@ let
     hash = "sha256-S3jY48YZds67eO9a/+GdDsp1sbR+xm9hOloyRUhHWNU=";
   };
 
-
   embedding_model = fetchurl {
     name = "bge-small-en-v1.5-q8_0.gguf";
     url = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf";
     hash = "sha256-7Djo2hQllrqpExJK5QVQ3ihLaRa/WVd+8vDLlmDC9RQ=";
+  };
+
+  reranker_model = fetchurl {
+    name = "bge-reranker-v2-m3-Q8_0.gguf";
+    url = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf";
+    hash = "sha256-0OdXMicV+utzNaRezjkufM67NOMudXQ4bqdbniOCAKo=";
   };
 in
 stdenv.mkDerivation {
@@ -45,6 +50,7 @@ stdenv.mkDerivation {
 
     cp ${model} $out/Qwen_Qwen3-0.6B-Q4_0.gguf
     cp ${embedding_model} $out/bge-small-en-v1.5-q8_0.gguf
+    cp ${reranker_model} $out/bge-reranker-v2-m3-Q8_0.gguf
 
     # Patch binaries.
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/game

--- a/nobodywho/godot/integration-test/embedding.gd.uid
+++ b/nobodywho/godot/integration-test/embedding.gd.uid
@@ -1,0 +1,1 @@
+uid://c0hh4s85r0jqj

--- a/nobodywho/godot/integration-test/example.tscn
+++ b/nobodywho/godot/integration-test/example.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://qir8gkg0qx5w"]
+[gd_scene load_steps=7 format=3 uid="uid://qir8gkg0qx5w"]
 
-[ext_resource type="Script" uid="uid://pgiowhexu47c" path="res://chat.gd" id="1_178kq"]
-[ext_resource type="Script" uid="uid://cd8m1scbnavoe" path="res://run_tests.gd" id="1_mssk2"]
-[ext_resource type="Script" uid="uid://csbfqd73rcy54" path="res://embedding.gd" id="2_rcagm"]
+[ext_resource type="Script" uid="uid://dkqdgp3feonn7" path="res://chat.gd" id="1_178kq"]
+[ext_resource type="Script" uid="uid://tt6o1gsow6qw" path="res://run_tests.gd" id="1_mssk2"]
+[ext_resource type="Script" uid="uid://c0hh4s85r0jqj" path="res://embedding.gd" id="2_rcagm"]
 [ext_resource type="PackedScene" uid="uid://riqfmggkqpfd" path="res://grammar_test.tscn" id="4_vpjjx"]
+[ext_resource type="Script" uid="uid://wr7mb50b7hdp" path="res://rerank_test.gd" id="5_rerank"]
 
 [sub_resource type="NobodyWhoSampler" id="NobodyWhoSampler_ciq23"]
 penalty_repeat = -1.0
@@ -23,6 +24,9 @@ model_path = "res://Qwen_Qwen3-0.6B-Q4_0.gguf"
 [node name="EmbeddingModel" type="NobodyWhoModel" parent="."]
 model_path = "res://bge-small-en-v1.5-q8_0.gguf"
 
+[node name="RerankModel" type="NobodyWhoModel" parent="."]
+model_path = "res://bge-reranker-v2-m3-Q8_0.gguf"
+
 [node name="NobodyWhoChat" type="NobodyWhoChat" parent="."]
 sampler = SubResource("NobodyWhoSampler_ciq23")
 script = ExtResource("1_178kq")
@@ -31,3 +35,7 @@ script = ExtResource("1_178kq")
 script = ExtResource("2_rcagm")
 
 [node name="Grammar" parent="." instance=ExtResource("4_vpjjx")]
+
+[node name="Rerank" type="NobodyWhoRerank" parent="." node_paths=PackedStringArray("model_node")]
+model_node = NodePath("../RerankModel")
+script = ExtResource("5_rerank")

--- a/nobodywho/godot/integration-test/example.tscn
+++ b/nobodywho/godot/integration-test/example.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://tt6o1gsow6qw" path="res://run_tests.gd" id="1_mssk2"]
 [ext_resource type="Script" uid="uid://c0hh4s85r0jqj" path="res://embedding.gd" id="2_rcagm"]
 [ext_resource type="PackedScene" uid="uid://riqfmggkqpfd" path="res://grammar_test.tscn" id="4_vpjjx"]
-[ext_resource type="Script" uid="uid://wr7mb50b7hdp" path="res://rerank_test.gd" id="5_rerank"]
+[ext_resource type="Script" uid="uid://edievpmy4ew6" path="res://crossencoder_test.gd" id="5_crossencoder"]
 
 [sub_resource type="NobodyWhoSampler" id="NobodyWhoSampler_ciq23"]
 penalty_repeat = -1.0
@@ -24,7 +24,7 @@ model_path = "res://Qwen_Qwen3-0.6B-Q4_0.gguf"
 [node name="EmbeddingModel" type="NobodyWhoModel" parent="."]
 model_path = "res://bge-small-en-v1.5-q8_0.gguf"
 
-[node name="RerankModel" type="NobodyWhoModel" parent="."]
+[node name="CrossEncoderModel" type="NobodyWhoModel" parent="."]
 model_path = "res://bge-reranker-v2-m3-Q8_0.gguf"
 
 [node name="NobodyWhoChat" type="NobodyWhoChat" parent="."]
@@ -36,6 +36,6 @@ script = ExtResource("2_rcagm")
 
 [node name="Grammar" parent="." instance=ExtResource("4_vpjjx")]
 
-[node name="Rerank" type="NobodyWhoRerank" parent="." node_paths=PackedStringArray("model_node")]
-model_node = NodePath("../RerankModel")
-script = ExtResource("5_rerank")
+[node name="CrossEncoder" type="NobodyWhoCrossEncoder" parent="." node_paths=PackedStringArray("model_node")]
+model_node = NodePath("../CrossEncoderModel")
+script = ExtResource("5_crossencoder")

--- a/nobodywho/godot/integration-test/grammar_test.gd
+++ b/nobodywho/godot/integration-test/grammar_test.gd
@@ -12,7 +12,7 @@ func run_test() -> bool:
 	chat.sampler = NobodyWhoSampler.new()
 	chat.sampler.use_grammar = true
 	# I used this webapp to make a gbnf from a json schema
-    # https://adrienbrault.github.io/json-schema-to-gbnf/
+	# https://adrienbrault.github.io/json-schema-to-gbnf/
 	# XXX: needed to :%s/\\/\\\\/g afterwards to escape the backslashes
 	chat.sampler.gbnf_grammar = """
 root ::= "{" ws01 root-name "," ws01 root-class "," ws01 root-level "}" ws01
@@ -25,14 +25,14 @@ value  ::= (object | array | string | number | boolean | null) ws
 
 object ::=
   "{" ws (
-    string ":" ws value
-    ("," ws string ":" ws value)*
+	string ":" ws value
+	("," ws string ":" ws value)*
   )? "}"
 
 array  ::=
   "[" ws01 (
-            value
-    ("," ws01 value)*
+			value
+	("," ws01 value)*
   )? "]"
 
 string ::=

--- a/nobodywho/godot/integration-test/grammar_test.gd.uid
+++ b/nobodywho/godot/integration-test/grammar_test.gd.uid
@@ -1,0 +1,1 @@
+uid://kjcmsgblfenb

--- a/nobodywho/godot/integration-test/grammar_test.tscn
+++ b/nobodywho/godot/integration-test/grammar_test.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://riqfmggkqpfd"]
 
-[ext_resource type="Script" uid="uid://cq3h4gdvj2u0v" path="res://grammar_test.gd" id="1_xxxxx"]
+[ext_resource type="Script" uid="uid://kjcmsgblfenb" path="res://grammar_test.gd" id="1_xxxxx"]
 
 [node name="GrammarTest" type="Node"]
 script = ExtResource("1_xxxxx")

--- a/nobodywho/godot/integration-test/nobodywho.gdextension.uid
+++ b/nobodywho/godot/integration-test/nobodywho.gdextension.uid
@@ -1,0 +1,1 @@
+uid://c1fimgbfn3iu7

--- a/nobodywho/godot/integration-test/project.godot
+++ b/nobodywho/godot/integration-test/project.godot
@@ -14,3 +14,11 @@ config/name="New Game Project"
 run/main_scene="res://example.tscn"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+
+[input]
+
+enter={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194309,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}

--- a/nobodywho/godot/integration-test/rerank_test.gd
+++ b/nobodywho/godot/integration-test/rerank_test.gd
@@ -1,0 +1,37 @@
+extends NobodyWhoRerank
+
+func run_test():
+	# configure node
+	self.model_node = get_node("../RerankModel")
+	
+	# test ranking documents
+	var query = "What is the capital of France?"
+	var documents = PackedStringArray([
+		"The Eiffel Tower is a famous landmark in the capital of France.",
+		"France is a country in Europe.",
+		"Lyon is a major city in France, but not the capital.",
+		"The capital of Germany is France.",
+		"The French government is based in Paris.",
+		"France's capital city is known for its art and culture, it is called Paris.",
+		"The Louvre Museum is located in Paris, France - which is the largest city, and the seat of the government",
+		"Paris is the capital of France.",
+		"Paris is not the capital of France.",
+		"The president of France works in Paris, the main city of his country.",
+		"What is the capital of France?"
+	])
+	
+	# Test ranking with limit
+	var ranked_docs = await rank(query, documents, 5)
+	print("✨ Got ranked documents: " + str(ranked_docs))
+	
+	# Basic validation
+	assert(ranked_docs.size() == 5, "Should return exactly 5 documents")
+	assert(ranked_docs[0].contains("Paris is the capital of France"), "Top result should be the most relevant")
+	
+	# Test ranking without limit (should return all documents)
+	var all_ranked_docs = await rank(query, documents, -1)
+	print("✨ Got all ranked documents: " + str(all_ranked_docs))
+	
+	assert(all_ranked_docs.size() == documents.size(), "Should return all documents when limit is -1")
+	
+	return true 

--- a/nobodywho/godot/integration-test/rerank_test.gd.uid
+++ b/nobodywho/godot/integration-test/rerank_test.gd.uid
@@ -1,0 +1,1 @@
+uid://wr7mb50b7hdp

--- a/nobodywho/godot/integration-test/run_tests.gd
+++ b/nobodywho/godot/integration-test/run_tests.gd
@@ -6,5 +6,6 @@ func _ready() -> void:
 	assert(await $NobodyWhoEmbedding.run_test())
 	assert(await $NobodyWhoChat.run_test())
 	assert(await $Grammar.run_test())
+	assert(await $Rerank.run_test())
 	print("✨ all tests complete")
 	get_tree().quit()

--- a/nobodywho/godot/integration-test/run_tests.gd
+++ b/nobodywho/godot/integration-test/run_tests.gd
@@ -6,6 +6,6 @@ func _ready() -> void:
 	assert(await $NobodyWhoEmbedding.run_test())
 	assert(await $NobodyWhoChat.run_test())
 	assert(await $Grammar.run_test())
-	assert(await $Rerank.run_test())
+	assert(await $CrossEncoder.run_test())
 	print("✨ all tests complete")
 	get_tree().quit()

--- a/nobodywho/godot/integration-test/run_tests.gd.uid
+++ b/nobodywho/godot/integration-test/run_tests.gd.uid
@@ -1,0 +1,1 @@
+uid://tt6o1gsow6qw

--- a/nobodywho/godot/nobodywho.gdextension
+++ b/nobodywho/godot/nobodywho.gdextension
@@ -17,4 +17,4 @@ macos.release.arm64 =    "res://addons/nobodywho/nobodywho-godot-aarch64-apple-d
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
 NobodyWhoChat =             "res://addons/nobodywho/icon.svg"
 NobodyWhoEmbedding =             "res://addons/nobodywho/icon.svg"
-NobodyWhoRerank =             "res://addons/nobodywho/icon.svg"
+NobodyWhoCrossEncoder =             "res://addons/nobodywho/icon.svg"

--- a/nobodywho/godot/nobodywho.gdextension
+++ b/nobodywho/godot/nobodywho.gdextension
@@ -17,3 +17,4 @@ macos.release.arm64 =    "res://addons/nobodywho/nobodywho-godot-aarch64-apple-d
 NobodyWhoModel =            "res://addons/nobodywho/icon.svg"
 NobodyWhoChat =             "res://addons/nobodywho/icon.svg"
 NobodyWhoEmbedding =             "res://addons/nobodywho/icon.svg"
+NobodyWhoRerank =             "res://addons/nobodywho/icon.svg"

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -468,7 +468,19 @@ impl NobodyWhoChat {
             }
 
             // TODO: if arguments are incorrect here, the callable returns null
-            let res = callable.call(&args);
+            let res: Variant = callable.call(&args);
+
+            // Handling of async methods, 
+            // as soon as you use await in godot, the will return GDScriptState, which contains a signal. 
+            // signal cannot be emitted from non mainthreads, so we throw an 
+            if res.get_type() == VariantType::OBJECT {
+                if let Ok(obj) = res.try_to::<Gd<RefCounted>>() {
+                    let class_name = obj.get_class();
+                    if class_name.to_string() == "GDScriptFunctionState" {
+                        godot_error!("Tool function is async. This is not supported yet.");
+                    }
+                }
+            }
             res.to_string()
         };
         let new_tool = nobodywho::chat::Tool::new(
@@ -857,6 +869,57 @@ impl NobodyWhoRerank {
     }
 
     #[func]
+    fn rank_sync(&mut self, query: String, documents: PackedStringArray, limit: i32) -> PackedStringArray {
+        if let Some(rerank_handle) = &self.rerank_handle {
+            let documents: Vec<String> = documents
+                .to_vec()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect();
+            
+            let mut ranking_channel: tokio::sync::mpsc::Receiver<Vec<f32>> = rerank_handle.rank(query, documents.clone());
+            match ranking_channel.blocking_recv() {
+                    Some(scores) => {
+                        // Create pairs of (document, score) and sort by score
+                        let mut docs_with_scores: Vec<(String, f32)> = documents
+                            .into_iter()
+                            .zip(scores.into_iter())
+                            .collect();
+
+                        // Sort by score in descending order (highest score first)
+                        docs_with_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                        
+                        // Extract just the documents, optionally limiting
+                        let ranked_docs: Vec<String> = if limit > 0 {
+                            docs_with_scores
+                                .into_iter()
+                                .take(limit as usize)
+                                .map(|(doc, _)| doc)
+                                .collect()
+                        } else {
+                            docs_with_scores
+                                .into_iter()
+                                .map(|(doc, _)| doc)
+                                .collect()
+                        };
+                        
+                        let gstring_array: Vec<GString> = ranked_docs.into_iter().map(|s| GString::from(s)).collect();
+
+                        return PackedStringArray::from(gstring_array);
+                    }
+                    None => {
+                        godot_error!("Failed generating ranking.");
+                        return PackedStringArray::new();
+                }
+            };
+        } else {
+            godot_warn!("Worker was not started yet, starting now... You may want to call `start_worker()` ahead of time to avoid waiting.");
+            self.start_worker();
+            return self.rank_sync(query, documents, limit);
+        };
+    }
+
+
     /// Sets the (global) log level of NobodyWho.
     /// Valid arguments are "TRACE", "DEBUG", "INFO", "WARN", and "ERROR".
     fn set_log_level(level: String) {


### PR DESCRIPTION
## Description
This pr implements a ranking api exposed to Godot and Unity, which subsequently can be used for reranking or retrieval augmented generation.

The plan for this feature is to ensure that a reranker node can be added to a chat node, which in turn can use it to get relevant data. 

I am still a bit unsure on the naming scheme for the different nodes. Maybe we should have a `knowledge` node that can take both an embedding and a ranking node as well as maybe a `storage` node down the line. The knowledge node can also be extended with memory books down the line. however, most of this is out of scope for this PR.

### Todo

- [x] core ranking module
- [x] Godot
- [x] docs

### Out of scope:
- [ ] fixing `cls` and `pooling types` for qwen3 models. 
- [ ] implementing storage
- [ ] integrating with chat nodes.
- [ ] adding a reranking pipeline (the end users must create their own for now)
- [ ] Unity 

Partially fixes #122 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
There are only functional tests, and not tests proving the accuracy of using this vs cosine similarity.  



## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 