### PR TITLE
Tool removal

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -68,8 +68,8 @@ impl ChatHandle {
         });
     }
 
-    pub fn update_tools(&self, tools: Vec<Tool>) {
-        let _ = self.msg_tx.send(ChatMsg::UpdateTools { tools });
+    pub fn set_tools(&self, tools: Vec<Tool>) {
+        let _ = self.msg_tx.send(ChatMsg::SetTools { tools });
     }
 
     pub fn stop_generation(&self) {
@@ -107,7 +107,7 @@ enum ChatMsg {
         system_prompt: String,
         tools: Vec<Tool>,
     },
-    UpdateTools {
+    SetTools {
         tools: Vec<Tool>,
     },
     GetChatHistory {
@@ -166,8 +166,8 @@ fn run_worker(
             } => {
                 worker_state.reset_chat(system_prompt, tools)?;
             }
-            ChatMsg::UpdateTools { tools } => {
-                worker_state.update_tools(tools)?;
+            ChatMsg::SetTools { tools } => {
+                worker_state.set_tools(tools)?;
             }
             ChatMsg::GetChatHistory { output_tx } => {
                 let _ =
@@ -518,7 +518,7 @@ impl<'a> Worker<'_, ChatWorker> {
         Ok(())
     }
 
-    pub fn update_tools(&mut self, tools: Vec<Tool>) -> Result<(), ChatWorkerError> {
+    pub fn set_tools(&mut self, tools: Vec<Tool>) -> Result<(), ChatWorkerError> {
         let current_messages = self.extra.chat_state.get_messages().to_vec();
         self.reset_context();
         self.extra.chat_state = ChatState::from_model_and_tools(

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -309,13 +309,6 @@ impl ChatState {
         // render the full template
         let text = self.render()?;
 
-        // If the newly rendered text is shorter than what we last recorded (as is the case when removing a tool)
-        // we don't want to emit the full text and slice OOB.
-        // so we just keep the length of the last rendered text.
-        if self.length > text.len() {
-            self.length = text.len();
-        }
-
         // get the chars that are new since the last template render
         let diff = text[self.length..].to_string();
 

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -309,6 +309,13 @@ impl ChatState {
         // render the full template
         let text = self.render()?;
 
+        // If the newly rendered text is shorter than what we last recorded (as is the case when removing a tool)
+        // we don't want to emit the full text and slice OOB.
+        // so we just keep the length of the last rendered text.
+        if self.length > text.len() {
+            self.length = text.len();
+        }
+
         // get the chars that are new since the last template render
         let diff = text[self.length..].to_string();
 

--- a/nobodywho/godot/integration-test/chat.gd
+++ b/nobodywho/godot/integration-test/chat.gd
@@ -92,6 +92,7 @@ func current_temperature(location: String, zipCode: int, inDenmark: bool) -> Str
 
 
 func test_tool_call():
+	self.set_log_level("debug")
 	self.add_tool(current_temperature, "Gets the current temperature in city.")
 	self.system_prompt = "You're a helpful tool-calling assistant. Remember to keep proper tool calling syntax."
 	self.reset_context()

--- a/nobodywho/godot/integration-test/chat.gd
+++ b/nobodywho/godot/integration-test/chat.gd
@@ -104,6 +104,32 @@ func test_tool_call():
 	assert("12.34" in response)
 	return true
 
+
+func call_tool() -> String:
+	tool_called = true
+	return "flag set"
+
+var tool_called = false
+
+func test_tool_remove():
+	# Add tool and verify it is called
+	self.set_log_level("debug")
+	tool_called = false
+	self.add_tool(call_tool, "A simple test tool that toggles a flag")
+	self.system_prompt = "You're a helpful tool-calling assistant. You may call functions when asked."
+	self.reset_context()
+	say("Call the function named 'call_tool' now.")
+	var response = await response_finished
+	assert(tool_called, "Tool should be called when registered")
+
+	# Remove tool and verify it is NOT called
+	tool_called = false
+	var removal_done = await remove_tool(call_tool)
+	say("Call the function named 'call_tool' now.")
+	response = await response_finished
+	assert(not tool_called, "Tool should not be called after removal")
+	return true
+
 func test_stop_generation():
 	print("✨ Testing stop generation")
 	system_prompt = "You're countbot. A robot that's very good at counting"

--- a/nobodywho/godot/integration-test/chat.gd
+++ b/nobodywho/godot/integration-test/chat.gd
@@ -1,22 +1,20 @@
 extends NobodyWhoChat
 
 func run_test():
-	# configure node
 	model_node = get_node("../ChatModel")
 	system_prompt = "You are a helpful assistant, capable of answering questions about the world."
 
-	
 	assert(await test_say())
 	assert(await test_antiprompts())
 	assert(await test_antiprompts_multitokens())
 	assert(await test_chat_history())
 	assert(await test_stop_generation())
 	assert(await test_tool_call())
+	assert(await test_tool_remove())
 	return true
 
 func test_say():
 	say("Please tell me what the capital city of Denmark is.")
-
 	var response = await response_finished
 
 	print("✨ Got response: " + response)
@@ -88,7 +86,6 @@ func test_chat_history():
 	
 
 func current_temperature(location: String, zipCode: int, inDenmark: bool) -> String:
-	push_warning("current_temperature: %s, %d, %s" % [location, zipCode, inDenmark])
 	if location.to_lower() == "copenhagen":
 		return "12.34"
 	return "Unknown city name"
@@ -98,6 +95,7 @@ func test_tool_call():
 	self.add_tool(current_temperature, "Gets the current temperature in city.")
 	self.system_prompt = "You're a helpful tool-calling assistant. Remember to keep proper tool calling syntax."
 	self.reset_context()
+	# 12.3 is on pupose to test correct type inputs for the tool call
 	say("I'd like to know the current temperature in Copenhagen. with zipcode 12.3 and in denmark is true")
 	var response = await response_finished
 	print(response)
@@ -112,7 +110,6 @@ func call_tool() -> String:
 var tool_called = false
 
 func test_tool_remove():
-	# Add tool and verify it is called
 	self.set_log_level("debug")
 	tool_called = false
 	self.add_tool(call_tool, "A simple test tool that toggles a flag")
@@ -122,10 +119,9 @@ func test_tool_remove():
 	var response = await response_finished
 	assert(tool_called, "Tool should be called when registered")
 
-	# Remove tool and verify it is NOT called
 	tool_called = false
-	var removal_done = await remove_tool(call_tool)
-	say("Call the function named 'call_tool' now.")
+	remove_tool(call_tool)
+	say("I disabled the flag, can you set it again by calling the function named 'call_tool' now.")
 	response = await response_finished
 	assert(not tool_called, "Tool should not be called after removal")
 	return true

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -500,7 +500,7 @@ impl NobodyWhoChat {
             Some(name) => name.to_string(),
             None => {
                 godot_error!("remove_tool: missing method_name on Callable");
-                return
+                return;
             }
         };
         let tools_before = self.tools.len();
@@ -509,7 +509,7 @@ impl NobodyWhoChat {
             godot_warn!("remove_tool: unknown tool '{}'", method_name);
         }
         if let Some(chat_handle) = &self.chat_handle {
-            chat_handle.update_tools(self.tools.clone());
+            chat_handle.set_tools(self.tools.clone());
         }
     }
 

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -383,7 +383,7 @@ impl NobodyWhoChat {
         };
         debug!(?json_schema);
 
-        return self._add_tool_with_schema(callable, description, json_schema);
+        self._add_tool_with_schema(callable, description, json_schema);
     }
 
     #[func]
@@ -492,6 +492,25 @@ impl NobodyWhoChat {
             std::sync::Arc::new(func),
         );
         self.tools.push(new_tool);
+    }
+
+    #[func]
+    fn remove_tool(&mut self, callable: Callable) {
+        let method_name = match callable.method_name() {
+            Some(name) => name.to_string(),
+            None => {
+                godot_error!("remove_tool: missing method_name on Callable");
+                return
+            }
+        };
+        let tools_before = self.tools.len();
+        self.tools.retain(|tool| tool.name != method_name);
+        if self.tools.len() == tools_before {
+            godot_warn!("remove_tool: unknown tool '{}'", method_name);
+        }
+        if let Some(chat_handle) = &self.chat_handle {
+            chat_handle.update_tools(self.tools.clone());
+        }
     }
 
     #[signal]


### PR DESCRIPTION
## Description
This Pr does two things:

1. Adds the possibility to remove tools from a chat node. 
2. Adds adding a tool no longer requires a reset.

Fixes #206 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
This includes a test that makes sure that the chat cannot call a method twice.

## Implementation

The way it works is by re-rendering and rereading the chat template whenever tools are updated. This is properly not ideal, and for performance it would be better to send a system message with a "tools updated: tool added .... / tool removed ...". However i think we should stick the the most accurate solution for tool-calling.

