### PR TITLE
Degrade llama logs

### DIFF
--- a/nobodywho/godot/integration-test/run_tests.gd
+++ b/nobodywho/godot/integration-test/run_tests.gd
@@ -3,6 +3,7 @@ extends Control
 
 func _ready() -> void:
 	print("👷 running tests...")
+	$NobodyWhoChat.set_log_level("info")
 	assert(await $NobodyWhoEmbedding.run_test())
 	assert(await $NobodyWhoChat.run_test())
 	assert(await $Grammar.run_test())


### PR DESCRIPTION
## Description
This degrades the llama log levels. 
It works by changing the threshold to one higher for all info and below log statements. This ensures that our current nobodywho logs levels stay the same. 


llama info -> requires debug or lower
llama debug -> requires trace
llama trace -> requires trace
 
Fixes #179 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
by running the godot test suite and seeing what logs are printed.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 