### PR TITLE
Fix: broken macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
             ./nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.pdb
 
   cargo-build-macos:
-    runs-on: macos-15
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
our current buildjobs for mac fails with the following error:

<summary> failing build log
<details>

```
   CMAKE_TOOLCHAIN_FILE_aarch64-apple-darwin = None
  CMAKE_TOOLCHAIN_FILE_aarch64_apple_darwin = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_aarch64-apple-darwin = None
  CMAKE_GENERATOR_aarch64_apple_darwin = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_aarch64-apple-darwin = None
  CMAKE_PREFIX_PATH_aarch64_apple_darwin = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_aarch64-apple-darwin = None
  CMAKE_aarch64_apple_darwin = None
  HOST_CMAKE = None
  CMAKE = None
  running: cd "/Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp" "-DCMAKE_OSX_ARCHITECTURES=arm64" "-DLLAMA_BUILD_TESTS=OFF" "-DLLAMA_BUILD_EXAMPLES=OFF" "-DLLAMA_BUILD_SERVER=OFF" "-DLLAMA_BUILD_TOOLS=OFF" "-DLLAMA_CURL=OFF" "-DCMAKE_BUILD_PARALLEL_LEVEL=3" "-DBUILD_SHARED_LIBS=OFF" "-DGGML_BLAS=OFF" "-DGGML_OPENMP=ON" "-DCMAKE_INSTALL_PREFIX=/Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=15.5" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=15.5" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=15.5" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Release"
  -- The C compiler identification is AppleClang 17.0.0.17000013
  -- The CXX compiler identification is AppleClang 17.0.0.17000013
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Found Git: /opt/homebrew/bin/git (found version "2.51.0")
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
  -- Found Threads: TRUE
  -- Warning: ccache not found - consider installing it for faster compilation or disable this warning with GGML_CCACHE=OFF
  -- CMAKE_SYSTEM_PROCESSOR: arm64
  -- GGML_SYSTEM_ARCH: ARM
  -- Including CPU backend
  -- Accelerate framework found
  -- Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES) 
  -- Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES) 
  -- Could NOT find OpenMP (missing: OpenMP_C_FOUND OpenMP_CXX_FOUND) 
  -- ARM detected
  -- Performing Test GGML_COMPILER_SUPPORTS_FP16_FORMAT_I3E
  -- Performing Test GGML_COMPILER_SUPPORTS_FP16_FORMAT_I3E - Failed
  -- ARM -mcpu not found, -mcpu=native will be used
  -- Performing Test GGML_MACHINE_SUPPORTS_dotprod
  -- Performing Test GGML_MACHINE_SUPPORTS_dotprod - Success
  -- Performing Test GGML_MACHINE_SUPPORTS_i8mm
  -- Performing Test GGML_MACHINE_SUPPORTS_i8mm - Failed
  -- Performing Test GGML_MACHINE_SUPPORTS_noi8mm
  -- Performing Test GGML_MACHINE_SUPPORTS_noi8mm - Success
  -- Performing Test GGML_MACHINE_SUPPORTS_sve
  -- Performing Test GGML_MACHINE_SUPPORTS_sve - Failed
  -- Performing Test GGML_MACHINE_SUPPORTS_nosve
  -- Performing Test GGML_MACHINE_SUPPORTS_nosve - Success
  -- Performing Test GGML_MACHINE_SUPPORTS_sme
  -- Performing Test GGML_MACHINE_SUPPORTS_sme - Failed
  -- Performing Test GGML_MACHINE_SUPPORTS_nosme
  -- Performing Test GGML_MACHINE_SUPPORTS_nosme - Success
  -- ARM feature DOTPROD enabled
  -- ARM feature MATMUL_INT8 enabled
  -- ARM feature FMA enabled
  -- ARM feature FP16_VECTOR_ARITHMETIC enabled
  -- Adding CPU backend variant ggml-cpu: -mcpu=native+dotprod+noi8mm+nosve+nosme 
  -- Metal framework found
  -- The ASM compiler identification is AppleClang
  -- Found assembler: /usr/bin/cc
  -- Including METAL backend
  -- ggml version: 0.0.6097
  -- ggml commit:  9515c613
  -- Running inside GitHub Actions - copying license files
  -- Copying /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/licenses/LICENSE-curl to /Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build/bin/LICENSE-curl
  -- Copying /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/licenses/LICENSE-httplib to /Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build/bin/LICENSE-httplib
  -- Copying /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/licenses/LICENSE-jsonhpp to /Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build/bin/LICENSE-jsonhpp
  -- Copying /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/licenses/LICENSE-linenoise to /Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build/bin/LICENSE-linenoise
  -- Configuring done (9.1s)
  -- Generating done (0.1s)
  -- Build files have been written to: /Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build
  running: cd "/Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build" && LC_ALL="C" "cmake" "--build" "/Users/runner/work/nobodywho/nobodywho/nobodywho/target/debug/build/llama-cpp-sys-2-b87022d75d8bacff/out/build" "--target" "install" "--config" "Release" "--parallel" "3"
  [  2%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml.c.o
  [  4%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml.cpp.o
  [  2%] Building CXX object common/CMakeFiles/build_info.dir/build-info.cpp.o
  [  4%] Built target build_info
  [  5%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-alloc.c.o
  [  6%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-backend.cpp.o
  [  8%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-opt.cpp.o
  [  9%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-threading.cpp.o
  [ 10%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-quants.c.o
  [ 12%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/gguf.cpp.o
  [ 13%] Linking CXX static library libggml-base.a
  [ 13%] Built target ggml-base
  [ 15%] Generate assembly for embedded Metal library
  Embedding Metal library
  [ 16%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.c.o
  [ 17%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.cpp.o
  [ 19%] Building C object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal.m.o
  [ 20%] Building ASM object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/__/__/__/autogenerated/ggml-metal-embed.s.o
  [ 21%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/repack.cpp.o
  [ 23%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/hbm.cpp.o
  [ 24%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/quants.c.o
  [ 26%] Linking CXX static library libggml-metal.a
  [ 26%] Built target ggml-metal
  [ 27%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/traits.cpp.o
  [ 28%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/amx.cpp.o
  [ 30%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/mmq.cpp.o
  [ 31%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/binary-ops.cpp.o
  [ 32%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/unary-ops.cpp.o
  [ 34%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/vec.cpp.o
  [ 35%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ops.cpp.o
  [ 36%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/llamafile/sgemm.cpp.o
  [ 38%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/arm/quants.c.o

  --- stderr
  CMake Warning at ggml/src/ggml-cpu/CMakeLists.txt:79 (message):
    OpenMP not found
  Call Stack (most recent call first):
    ggml/src/CMakeLists.txt:372 (ggml_add_cpu_backend_variant_impl)


  CMake Warning:
    Manually-specified variables were not used by the project:

      CMAKE_BUILD_PARALLEL_LEVEL


  /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/ggml/src/ggml-cpu/arch/arm/quants.c:217:88: error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm', but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is compiled without support for 'i8mm'
    217 |             sumv0 = vmlaq_f32(sumv0,(vcvtq_f32_s32(vmmlaq_s32((vmmlaq_s32((vmmlaq_s32((vmmlaq_s32(vdupq_n_s32(0), l0, r0)),
        |                                                                                        ^
  /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/ggml/src/ggml-cpu/arch/arm/quants.c:217:76: error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm', but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is compiled without support for 'i8mm'
    217 |             sumv0 = vmlaq_f32(sumv0,(vcvtq_f32_s32(vmmlaq_s32((vmmlaq_s32((vmmlaq_s32((vmmlaq_s32(vdupq_n_s32(0), l0, r0)),
        |                                                                            ^
  /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/ggml/src/ggml-cpu/arch/arm/quants.c:217:64: error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm', but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is compiled without support for 'i8mm'
    217 |             sumv0 = vmlaq_f32(sumv0,(vcvtq_f32_s32(vmmlaq_s32((vmmlaq_s32((vmmlaq_s32((vmmlaq_s32(vdupq_n_s32(0), l0, r0)),
        |                                                                ^
  /Users/runner/.cargo/git/checkouts/llama-cpp-rs-274405c613038803/abe8b5a/llama-cpp-sys-2/llama.cpp/ggml/src/ggml-cpu/arch/arm/quants.c:217:52: error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm', but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is compiled without support for 'i8mm'
    217 |             sumv0 = vmlaq_f32(sumv0,(vcvtq_f32_s32(vmmlaq_s32((vmmlaq_s32((vmmlaq_s32((vmmlaq_s32(vdupq_n_s32(0), l0, r0)),
        |                                                    ^
  4 errors generated.
  make[2]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/arm/quants.c.o] Error 1
  make[2]: *** Waiting for unfinished jobs....
  make[1]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/all] Error 2
  make: *** [all] Error 2

  thread 'main' panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.54/src/lib.rs:1119:5:

  command did not execute successfully, got: exit status: 2
```

</details>
</summary>
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce or add a test to the example game.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 