### PR TITLE
Token to unicode issue

### DIFF
--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -328,22 +328,20 @@ where
             drop(decode_guard);
             self.n_past += 1; // keep count
 
-            // Convert token to text
+            // Attempt to convert token(s) to text
             let token_to_str_result = self
                 .ctx
                 .model
                 .tokens_to_str(&token_vec, Special::Tokenize);
-            // fall back to "U+FFFD REPLACEMENT CHARACTER"
-            // when encountering bytes that aren't valid UTF-8
-            // wikipedia: "used to replace an unknown, unrecognised, or unrepresentable character"
             
             
             // If current tokens cannot be turned into to valid 
-            // utf8 code then read another token
+            // utf8 code then read another token and try again.
             let token_string = match token_to_str_result {
                 Err(_) => continue,
                 Ok(str) => {token_vec.clear();str}
             };
+            
 
 
 


### PR DESCRIPTION
Model like Qwen3 can now output emojis. The fix is implemented in the token to string step. Instead of attempting converting each token to a string and outputting ("�") otherwise, we now convert tokens to bytes and read up to 4 bytes before outputting ("�").

The choice of 4 as the number of bytes to read comes from the utf8 standard. 

Closes #102 