### PR TITLE
Prefix caching

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -239,9 +239,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "find_cuda_helper"
@@ -559,8 +559,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.120"
-source = "git+https://github.com/utilityai/llama-cpp-rs.git?branch=main#a6565b06e2e2433134f932c2692218b5268e86a0"
+version = "0.1.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d574d1f43b31c9e3d0e3bf596a31fa628e4b66894eb5db4dfe78e861c7f74275"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -571,8 +572,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.120"
-source = "git+https://github.com/utilityai/llama-cpp-rs.git?branch=main#a6565b06e2e2433134f932c2692218b5268e86a0"
+version = "0.1.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bdf53b6f486ecaeb96b08cd8a9d9df162f2aafa37efb5b40cf421a419c755"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -10,8 +10,8 @@ minijinja = { version = "2.11.0", features = ["builtins", "json", "loader"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
-llama-cpp-sys-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", branch = "main" }
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", branch = "main" }
+llama-cpp-sys-2 = "0.1.122"
+llama-cpp-2 = "0.1.122"
 lazy_static = "1.5.0"
 tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.17"
@@ -23,4 +23,4 @@ gbnf = "0.2.5"
 rand = "0.9.2"
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "android")))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs.git", branch = "main", features = ["vulkan"] }
+llama-cpp-2 = { version = "0.1.122", features = ["vulkan"] }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -23,8 +23,8 @@
 
 use crate::chat_state::ChatState;
 use crate::chat_state::{self, RenderError};
-use crate::llm;
-use crate::llm::Worker;
+use crate::llm::{self};
+use crate::llm::{Worker, WriteOutput};
 use crate::sampler_config::SamplerConfig;
 use llama_cpp_2::model::AddBos;
 use llama_cpp_2::token::LlamaToken;
@@ -752,20 +752,6 @@ impl<'a> Worker<'_, ChatWorker> {
 
         self.extra.chat_state.add_user_message(text);
 
-        // Check how much of the current KVCache we can keep
-        let render_as_tokens = self.get_render_as_tokens()?;
-        let (prefix_index, token_difference) = self
-            .extra
-            .chat_state
-            .find_prefix_index_and_difference_with_tokens_in_context(&render_as_tokens);
-
-        self.remove_all_tokens_after_index_from_ctx(prefix_index)?;
-
-        // wrap the response callback to keep a copy of the completed response
-        // and to avoid emitting tool calls
-        let (wrapped_respond, resp_receiver) =
-            wrap_respond(respond.clone(), tool_call_begin.into());
-
         let mut sampler = sampler;
         if let Some(ref tool_grammar) = self.extra.tool_grammar {
             sampler.use_grammar = true;
@@ -774,20 +760,13 @@ impl<'a> Worker<'_, ChatWorker> {
             sampler.gbnf_grammar = tool_grammar.to_string();
         }
 
-        // llm go brrr
-        self.read_tokens(token_difference)?.write_until_done(
+        // get the finished response
+        let mut response: String = self.wrapped_update_context_and_write_response(
             sampler.clone(),
             stop_words.clone(),
-            wrapped_respond,
+            respond.clone(),
+            tool_call_begin.into(),
         )?;
-
-        // update the chat_state to match the tokens in the context.
-        self.extra
-            .chat_state
-            .set_tokens_in_context(render_as_tokens);
-
-        // get the finished response
-        let mut response: String = resp_receiver.recv()?;
 
         while let Some(tool_calls) = extract_tool_calls(&response) {
             debug!("Got tool calls! {tool_calls:?}");
@@ -822,33 +801,18 @@ impl<'a> Worker<'_, ChatWorker> {
                     .add_tool_resp(tool_call.name, response);
             }
 
-            // Check how much of the current KVCache we can keep
-            let render_as_tokens = self.get_render_as_tokens()?;
-            let (prefix_index, token_difference) = self
-                .extra
-                .chat_state
-                .find_prefix_index_and_difference_with_tokens_in_context(&render_as_tokens);
-
-            self.remove_all_tokens_after_index_from_ctx(prefix_index)?;
-
-            let (wrapped_respond, resp_receiver) =
-                wrap_respond(respond.clone(), tool_call_begin.into());
-            self.read_tokens(token_difference)?.write_until_done(
+            // get the finished response
+            response = self.wrapped_update_context_and_write_response(
                 sampler.clone(),
                 stop_words.clone(),
-                wrapped_respond,
+                respond.clone(),
+                tool_call_begin.into(),
             )?;
-
-            // get the finished response
-            response = resp_receiver.recv()?;
-
-            self.extra
-                .chat_state
-                .set_tokens_in_context(render_as_tokens);
         }
         debug_assert!(!response.contains(tool_call_begin));
         self.extra.chat_state.add_assistant_message(response);
 
+        // Update tokens_in_context as the model already has seen this respone
         let render_as_tokens = self.get_render_as_tokens()?;
 
         self.extra
@@ -865,6 +829,59 @@ impl<'a> Worker<'_, ChatWorker> {
             .model
             .str_to_token(&render_as_string, AddBos::Never)?;
         Ok(render_as_tokens)
+    }
+
+    fn read_tokens_and_write_response(
+        &mut self,
+        tokens: Vec<LlamaToken>,
+        sampler: SamplerConfig,
+        stop_words: Vec<String>,
+        wrapped_respond: impl FnMut(WriteOutput),
+    ) -> Result<&mut Self, SayError> {
+        Ok(self.read_tokens(tokens)?.write_until_done(
+            sampler.clone(),
+            stop_words.clone(),
+            wrapped_respond,
+        )?)
+    }
+
+    fn wrapped_update_context_and_write_response<F>(
+        &mut self,
+        sampler: SamplerConfig,
+        stop_words: Vec<String>,
+        respond: F,
+        tool_call_begin_token: String,
+    ) -> Result<String, SayError>
+    where
+        F: Fn(llm::WriteOutput) + Clone,
+    {
+        // Check how much of the current KVCache we can keep
+        let render_as_tokens = self.get_render_as_tokens()?;
+        let (prefix_index, token_difference) = self
+            .extra
+            .chat_state
+            .find_prefix_index_and_difference_with_tokens_in_context(&render_as_tokens);
+
+        self.remove_all_tokens_after_index_from_ctx(prefix_index)?;
+
+        // wrap the response callback to keep a copy of the completed response
+        // and to avoid emitting tool calls
+        let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
+
+        // llm go brrr
+        self.read_tokens_and_write_response(
+            token_difference,
+            sampler.clone(),
+            stop_words.clone(),
+            wrapped_respond,
+        )?;
+
+        // update the chat_state to match the tokens in the context.
+        self.extra
+            .chat_state
+            .set_tokens_in_context(render_as_tokens);
+
+        Ok(resp_receiver.recv()?)
     }
 
     pub fn reset_chat(

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -331,19 +331,6 @@ impl ChatState {
         Ok(tokens)
     }
 
-    pub fn render_diff(&mut self) -> Result<String, minijinja::Error> {
-        // render the full template
-        let text = self.render_string()?;
-
-        // get the chars that are new since the last template render
-        let diff = text[self.length..].to_string();
-
-        // note the length of this template render
-        self.length = text.len();
-
-        Ok(diff)
-    }
-
     pub fn find_token_diff_and_prefix_index(
         &mut self,
         ctx_model: &LlamaModel,
@@ -368,8 +355,7 @@ impl ChatState {
                 ),
             };
 
-            self.prefix_cache
-                .extend_from_slice(&tokens[(index as usize)..]);
+            self.prefix_cache = tokens;
 
             return Ok((index, diff));
         }
@@ -384,19 +370,126 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_llama31_template() {
-        // test that llama 3.1 template renders
+    fn test_llama31_template_prefix_caching() {
+        // Load test model for tokenization
+        let model = crate::test_utils::load_test_model();
+
         let template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}";
         let mut chatstate =
             ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
+
+        // First call - should return all tokens as diff (no cache)
         chatstate.add_user_message("Hello, world!".into());
-        let rendered = chatstate.render_diff().unwrap();
-        let expected = "<|bos|><|start_header_id|>user<|end_header_id|>
+        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
 
-Hello, world!<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
+        assert!(
+            diff1.len() > 0,
+            "First call should return all tokens as diff"
+        );
 
-";
-        assert_eq!(rendered, expected)
+        // Cache should now be populated with the full token sequence
+        let cache_len_after_first = chatstate.prefix_cache.len();
+        assert_eq!(
+            cache_len_after_first,
+            diff1.len(),
+            "Cache should contain all tokens from first call"
+        );
+
+        // Second call with same message - should return empty diff
+        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert_eq!(
+            prefix_index2, cache_len_after_first as u32,
+            "Second call should find full prefix match"
+        );
+        assert_eq!(
+            diff2.len(),
+            0,
+            "Second call should return empty diff (no new tokens)"
+        );
+
+        // Third call with additional message - should return only new tokens as diff
+        chatstate.add_assistant_message("Hi there!".into());
+        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert!(
+            prefix_index3 > 0,
+            "Third call should find some prefix match"
+        );
+        assert!(
+            diff3.len() > 0,
+            "Third call should return new tokens as diff"
+        );
+        assert!(
+            prefix_index3 < chatstate.prefix_cache.len() as u32,
+            "Prefix should be less than total cache length"
+        );
+
+        // Verify the cache is updated correctly
+        let expected_full_tokens = chatstate.render_tokens(&model).unwrap();
+        assert_eq!(
+            chatstate.prefix_cache, expected_full_tokens,
+            "Cache should match full token sequence"
+        );
+    }
+
+    #[test]
+    fn test_prefix_caching_edge_cases() {
+        let model = crate::test_utils::load_test_model();
+        let template =
+            "{% for message in messages %}{{ message.role }}: {{ message.content }}{% endfor %}";
+        let mut chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
+
+        // Test 1: Empty messages - should work (empty template produces empty tokens)
+        let (prefix_index, diff) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        assert_eq!(prefix_index, 0);
+        // Empty template with no messages produces empty token sequence
+        assert_eq!(diff.len(), 0, "Empty template should produce empty tokens");
+
+        // Test 2: Add message and ensure partial prefix matching
+        chatstate.add_user_message("Hello".into());
+        let (_prefix_index1, _diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        // Test 3: Same message again - should return empty diff
+        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        assert_eq!(diff2.len(), 0, "Identical render should produce empty diff");
+        assert_eq!(prefix_index2, chatstate.prefix_cache.len() as u32);
+
+        // Test 4: Modify existing message (simulate chat state change)
+        chatstate.messages[0] = Message::Message {
+            role: Role::User,
+            content: "Hello World".into(),
+        };
+        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        // Should find some common prefix but have differences
+        assert!(prefix_index3 > 0, "Should find some common prefix");
+        assert!(diff3.len() > 0, "Should have different tokens");
+
+        println!(
+            "Test 4: prefix_index={}, diff_len={}",
+            prefix_index3,
+            diff3.len()
+        );
+
+        // Test 5: Completely different messages
+        let mut new_chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
+        new_chatstate.add_assistant_message("Goodbye".into());
+        new_chatstate.prefix_cache = chatstate.prefix_cache.clone(); // Simulate existing cache
+
+        let (prefix_index4, diff4) = new_chatstate
+            .find_token_diff_and_prefix_index(&model)
+            .unwrap();
+
+        // Depending on tokenization, might have some common prefix from template
+        assert!(diff4.len() > 0, "Should have different content");
+
+        println!(
+            "Test 5: prefix_index={}, diff_len={}",
+            prefix_index4,
+            diff4.len()
+        );
     }
 
     #[test]
@@ -415,55 +508,193 @@ Hello, world!<|eot_id|><|start_header_id|>assistant<|end_header_id|>
     }
 
     #[test]
-    fn test_deepseek_template() {
+    fn test_deepseek_template_prefix_caching() {
+        let model = crate::test_utils::load_test_model();
         let template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}";
         let mut chatstate =
             ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
+
+        // Test 1: First message - establishes baseline cache
         chatstate.add_user_message("Hello, world!".into());
+        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
+        assert!(
+            diff1.len() > 0,
+            "First call should return all tokens as diff"
+        );
+
+        let initial_cache_size = chatstate.prefix_cache.len();
+        println!("Initial cache size: {}", initial_cache_size);
+
+        // Test 2: Add assistant message with think block - should find common prefix
         chatstate.add_assistant_message("<think>beep boop robot thinky</think>".into());
-        let rendered = chatstate.render_diff();
-        println!("{:?}", rendered);
-        assert!(rendered.is_ok());
+        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert!(
+            prefix_index2 > 0,
+            "Should find some common prefix from BOS token and user message"
+        );
+        assert!(
+            diff2.len() > 0,
+            "Should have new tokens for assistant message"
+        );
+        assert!(
+            prefix_index2 < chatstate.prefix_cache.len() as u32,
+            "Prefix should be less than total cache"
+        );
+
+        println!(
+            "After assistant message: prefix_index={}, diff_len={}, total_cache={}",
+            prefix_index2,
+            diff2.len(),
+            chatstate.prefix_cache.len()
+        );
+
+        // Test 3: Same messages again - should return empty diff
+        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert_eq!(
+            diff3.len(),
+            0,
+            "Identical template render should produce empty diff"
+        );
+        assert_eq!(
+            prefix_index3,
+            chatstate.prefix_cache.len() as u32,
+            "Should match full cache length"
+        );
+
+        // Test 4: Verify cache consistency
+        let expected_tokens = chatstate.render_tokens(&model).unwrap();
+        assert_eq!(
+            chatstate.prefix_cache, expected_tokens,
+            "Cache should exactly match rendered tokens"
+        );
+
+        // Test 5: Verify template renders correctly (basic sanity check)
+        let rendered_text = chatstate.render_string().unwrap();
+        assert!(
+            rendered_text.contains("<|bos|>"),
+            "Should contain BOS token"
+        );
+        assert!(
+            rendered_text.contains("<｜User｜>Hello, world!"),
+            "Should contain user message"
+        );
+        assert!(
+            rendered_text.contains("<｜Assistant｜>"),
+            "Should contain assistant tag (think block should be stripped)"
+        );
+
+        println!("Final rendered text length: {}", rendered_text.len());
     }
 
     #[test]
-    fn test_qwen3_template() {
+    fn test_qwen3_template_prefix_caching() {
+        let model = crate::test_utils::load_test_model();
         let template = "{%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0].role == 'system' %}\n        {{- messages[0].content + '\\n\\n' }}\n    {%- endif %}\n    {{- \"# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) %}\n        {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set content = message.content %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in message.content %}\n                {%- set content = message.content.split('</think>')[-1].lstrip('\\n') %}\n                {%- set reasoning_content = message.content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {%- if loop.last or (not loop.last and reasoning_content) %}\n                {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content.strip('\\n') + '\\n</think>\\n\\n' + content.lstrip('\\n') }}\n            {%- else %}\n                {{- '<|im_start|>' + message.role + '\\n' + content }}\n            {%- endif %}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- '\\n' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- '<tool_call>\\n{\"name\": \"' }}\n                {{- tool_call.name }}\n                {{- '\", \"arguments\": ' }}\n                {%- if tool_call.arguments is string %}\n                    {{- tool_call.arguments }}\n                {%- else %}\n                    {{- tool_call.arguments | tojson }}\n                {%- endif %}\n                {{- '}\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- message.content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- endif %}\n{%- endif %}";
         let mut chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
+
+        // Test 1: First message - establishes baseline cache
         chatstate.add_user_message("Hi, robot!".into());
-        let rendered = chatstate.render_diff();
-        println!("{:?}", rendered);
-        println!("---");
-        assert_eq!(
-            rendered.unwrap(),
-            "<|im_start|>user\nHi, robot!<|im_end|>\n<|im_start|>assistant\n".to_string()
+        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
+        assert!(
+            diff1.len() > 0,
+            "First call should return all tokens as diff"
         );
 
+        let initial_cache_size = chatstate.prefix_cache.len();
+        println!("Initial cache size: {}", initial_cache_size);
+
+        // Test 2: Add assistant message with thinking - should find common prefix
         chatstate.add_assistant_message("<think>\nHm... That's a tough cookie. I think the answer is probably 42.\nCould it be something else?\nNah... It's 42!\n</think>\nThe answer is 42!".into());
-        let rendered = chatstate.render_diff();
-        println!("{:?}", rendered);
-        println!("---");
-        assert_eq!(
-            rendered.unwrap(),
-            "The answer is 42!<|im_end|>\n".to_string()
+        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert!(
+            prefix_index2 > 0,
+            "Should find some common prefix from user message"
+        );
+        assert!(
+            diff2.len() > 0,
+            "Should have new tokens for assistant message"
+        );
+        assert!(
+            prefix_index2 < chatstate.prefix_cache.len() as u32,
+            "Prefix should be less than total cache"
         );
 
+        println!(
+            "After assistant message: prefix_index={}, diff_len={}, total_cache={}",
+            prefix_index2,
+            diff2.len(),
+            chatstate.prefix_cache.len()
+        );
+
+        // Test 3: Same messages again - should return empty diff
+        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert_eq!(
+            diff3.len(),
+            0,
+            "Identical template render should produce empty diff"
+        );
+        assert_eq!(
+            prefix_index3,
+            chatstate.prefix_cache.len() as u32,
+            "Should match entire cache"
+        );
+
+        println!(
+            "Same render: prefix_index={}, diff_len={}",
+            prefix_index3,
+            diff3.len()
+        );
+
+        // Test 4: Add another user message - should reuse existing conversation prefix
         chatstate.add_user_message("What are you on about? I need the real answer.".into());
-        let rendered = chatstate.render_diff();
-        println!("{:?}", rendered);
-        println!("---");
-        assert_eq!(
-            rendered.unwrap(), 
-            "<|im_start|>user\nWhat are you on about? I need the real answer.<|im_end|>\n<|im_start|>assistant\n".to_string()
+        let (prefix_index4, diff4) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert!(prefix_index4 > 0, "Should reuse some conversation history");
+        assert!(
+            diff4.len() > 0,
+            "Should have tokens for new user message + generation prompt"
+        );
+        assert!(
+            prefix_index4 < chatstate.prefix_cache.len() as u32,
+            "Should not match entire cache"
         );
 
+        println!(
+            "New user message: prefix_index={}, diff_len={}, total_cache={}",
+            prefix_index4,
+            diff4.len(),
+            chatstate.prefix_cache.len()
+        );
+
+        // Test 5: Add final assistant message - comprehensive conversation test
         chatstate.add_assistant_message("<think>\nI already told the user that the real answer is 42.\nI guess I'll just tell them again. What an idiot...\n</think>\nThe answer is 42!".into());
-        let rendered = chatstate.render_diff();
-        println!("{:?}", rendered);
-        println!("---");
-        assert_eq!(
-            rendered.unwrap(),
-            "The answer is 42!<|im_end|>\n".to_string()
+        let (prefix_index5, diff5) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+
+        assert!(prefix_index5 > 0, "Should reuse conversation history");
+        assert!(
+            diff5.len() > 0,
+            "Should have tokens for final assistant response"
+        );
+
+        println!(
+            "Final assistant message: prefix_index={}, diff_len={}, total_cache={}",
+            prefix_index5,
+            diff5.len(),
+            chatstate.prefix_cache.len()
+        );
+
+        // Verify cache consistency
+        assert!(
+            chatstate.prefix_cache.len() > initial_cache_size,
+            "Cache should have grown with conversation"
         );
     }
 }

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -337,31 +337,30 @@ impl ChatState {
     ) -> Result<(u32, Vec<LlamaToken>), RenderError> {
         let tokens = self.render_tokens(ctx_model)?;
 
-        if self.prefix_cache.len() > 0 {
-            let longest_common_prefix_index = self
-                .prefix_cache
-                .iter()
-                .zip(tokens.iter())
-                .position(|(a, b)| a != b);
-
-            let (index, diff): (u32, Vec<LlamaToken>) = match longest_common_prefix_index {
-                Some(i) => (i as u32, tokens[i..].iter().cloned().collect()),
-                None => (
-                    self.prefix_cache.len() as u32,
-                    tokens[(self.prefix_cache.len())..]
-                        .iter()
-                        .cloned()
-                        .collect(),
-                ),
-            };
-
-            self.prefix_cache = tokens;
-
-            return Ok((index, diff));
+        if self.prefix_cache.len() == 0 {
+            self.prefix_cache = tokens.clone();
+            return Ok((0, tokens));
         }
 
-        self.prefix_cache = tokens.clone();
-        return Ok((0, tokens));
+        let longest_common_prefix_index = self
+            .prefix_cache
+            .iter()
+            .zip(tokens.iter())
+            .position(|(a, b)| a != b);
+
+        let (index, diff): (u32, Vec<LlamaToken>) = match longest_common_prefix_index {
+            Some(i) => (i as u32, tokens[i..].iter().cloned().collect()),
+            None => (
+                self.prefix_cache.len() as u32,
+                tokens[(self.prefix_cache.len())..]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            ),
+        };
+
+        self.prefix_cache = tokens;
+        return Ok((index, diff));
     }
 }
 

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -189,14 +189,6 @@ impl ChatState {
         }
     }
 
-    pub fn from_model(model: &llama_cpp_2::model::LlamaModel) -> Result<Self, FromModelError> {
-        let template = model.chat_template(None)?.to_string()?;
-        let tokenize = llama_cpp_2::model::Special::Tokenize;
-        let bos = model.token_to_str(model.token_bos(), tokenize)?;
-        let eos = model.token_to_str(model.token_eos(), tokenize)?;
-        Ok(Self::new(template, bos, eos, vec![]))
-    }
-
     pub fn from_model_and_tools(
         model: &llama_cpp_2::model::LlamaModel,
         tools: Vec<Tool>,
@@ -224,6 +216,10 @@ impl ChatState {
         let bos = model.token_to_str(model.token_bos(), tokenize)?;
         let eos = model.token_to_str(model.token_eos(), tokenize)?;
         Ok(Self::new(template, bos, eos, tools))
+    }
+
+    pub fn from_model(model: &llama_cpp_2::model::LlamaModel) -> Result<Self, FromModelError> {
+        ChatState::from_model_and_tools(model, vec![])
     }
 
     pub fn reset(&mut self) {

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -1,9 +1,6 @@
 use std::sync::LazyLock;
 
-use llama_cpp_2::{
-    model::{AddBos, LlamaModel},
-    token::LlamaToken,
-};
+use llama_cpp_2::token::LlamaToken;
 use minijinja::{context, Environment};
 use serde::{self, Deserialize, Serialize};
 use serde_json;
@@ -108,8 +105,7 @@ pub struct ToolCall {
 pub struct ChatState {
     messages: Vec<Message>,
     chat_template: String,
-    prefix_cache: Vec<LlamaToken>,
-    length: usize,
+    tokens_in_context: Vec<LlamaToken>,
     eos_token: String,
     bos_token: String,
     tools: Vec<Tool>,
@@ -186,8 +182,7 @@ impl ChatState {
         Self {
             messages: Vec::new(),
             chat_template,
-            prefix_cache: Vec::new(),
-            length: 0,
+            tokens_in_context: Vec::new(),
             eos_token,
             bos_token,
             tools,
@@ -232,8 +227,8 @@ impl ChatState {
     }
 
     pub fn reset(&mut self) {
-        self.length = 0;
         self.messages = Vec::new();
+        self.tokens_in_context = Vec::new();
     }
 
     pub fn get_messages(&self) -> &[Message] {
@@ -243,6 +238,14 @@ impl ChatState {
     pub fn set_messages(&mut self, messages: Vec<Message>) {
         self.reset();
         self.messages = messages;
+    }
+
+    pub fn get_tokens_in_context(&self) -> &[LlamaToken] {
+        &self.tokens_in_context
+    }
+
+    pub fn set_tokens_in_context(&mut self, tokens: Vec<LlamaToken>) {
+        self.tokens_in_context = tokens;
     }
 
     pub fn add_system_message(&mut self, content: String) {
@@ -277,7 +280,7 @@ impl ChatState {
         });
     }
 
-    fn render_string(&mut self) -> Result<String, minijinja::Error> {
+    pub fn render_string(&mut self) -> Result<String, minijinja::Error> {
         let tmpl = MINIJINJA_ENV.template_from_str(&self.chat_template)?;
 
         let ctx = context! {
@@ -323,173 +326,38 @@ impl ChatState {
         Ok(text)
     }
 
-    fn render_tokens(&mut self, ctx_model: &LlamaModel) -> Result<Vec<LlamaToken>, RenderError> {
-        let text = self.render_string()?;
-        let tokens = ctx_model.str_to_token(&text, AddBos::Never)?;
-        trace!(text);
-
-        Ok(tokens)
-    }
-
-    pub fn find_token_diff_and_prefix_index(
-        &mut self,
-        ctx_model: &LlamaModel,
-    ) -> Result<(u32, Vec<LlamaToken>), RenderError> {
-        let tokens = self.render_tokens(ctx_model)?;
-
-        if self.prefix_cache.len() == 0 {
-            self.prefix_cache = tokens.clone();
-            return Ok((0, tokens));
+    pub fn find_prefix_index_and_difference_with_tokens_in_context(
+        &self,
+        tokens: &Vec<LlamaToken>,
+    ) -> (u32, Vec<LlamaToken>) {
+        if self.tokens_in_context.len() == 0 {
+            return (0, tokens.clone());
         }
 
         let longest_common_prefix_index = self
-            .prefix_cache
+            .tokens_in_context
             .iter()
             .zip(tokens.iter())
             .position(|(a, b)| a != b);
 
-        let (index, diff): (u32, Vec<LlamaToken>) = match longest_common_prefix_index {
+        let (index, difference): (u32, Vec<LlamaToken>) = match longest_common_prefix_index {
             Some(i) => (i as u32, tokens[i..].iter().cloned().collect()),
             None => (
-                self.prefix_cache.len() as u32,
-                tokens[(self.prefix_cache.len())..]
+                self.tokens_in_context.len() as u32,
+                tokens[(self.tokens_in_context.len())..]
                     .iter()
                     .cloned()
                     .collect(),
             ),
         };
 
-        self.prefix_cache = tokens;
-        return Ok((index, diff));
+        return (index, difference);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_llama31_template_prefix_caching() {
-        // Load test model for tokenization
-        let model = crate::test_utils::load_test_model();
-
-        let template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}";
-        let mut chatstate =
-            ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
-
-        // First call - should return all tokens as diff (no cache)
-        chatstate.add_user_message("Hello, world!".into());
-        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
-        assert!(
-            diff1.len() > 0,
-            "First call should return all tokens as diff"
-        );
-
-        // Cache should now be populated with the full token sequence
-        let cache_len_after_first = chatstate.prefix_cache.len();
-        assert_eq!(
-            cache_len_after_first,
-            diff1.len(),
-            "Cache should contain all tokens from first call"
-        );
-
-        // Second call with same message - should return empty diff
-        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        assert_eq!(
-            prefix_index2, cache_len_after_first as u32,
-            "Second call should find full prefix match"
-        );
-        assert_eq!(
-            diff2.len(),
-            0,
-            "Second call should return empty diff (no new tokens)"
-        );
-
-        // Third call with additional message - should return only new tokens as diff
-        chatstate.add_assistant_message("Hi there!".into());
-        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        assert!(
-            prefix_index3 > 0,
-            "Third call should find some prefix match"
-        );
-        assert!(
-            diff3.len() > 0,
-            "Third call should return new tokens as diff"
-        );
-        assert!(
-            prefix_index3 < chatstate.prefix_cache.len() as u32,
-            "Prefix should be less than total cache length"
-        );
-
-        // Verify the cache is updated correctly
-        let expected_full_tokens = chatstate.render_tokens(&model).unwrap();
-        assert_eq!(
-            chatstate.prefix_cache, expected_full_tokens,
-            "Cache should match full token sequence"
-        );
-    }
-
-    #[test]
-    fn test_prefix_caching_edge_cases() {
-        let model = crate::test_utils::load_test_model();
-        let template =
-            "{% for message in messages %}{{ message.role }}: {{ message.content }}{% endfor %}";
-        let mut chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
-
-        // Test 1: Empty messages - should work (empty template produces empty tokens)
-        let (prefix_index, diff) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-        assert_eq!(prefix_index, 0);
-        // Empty template with no messages produces empty token sequence
-        assert_eq!(diff.len(), 0, "Empty template should produce empty tokens");
-
-        // Test 2: Add message and ensure partial prefix matching
-        chatstate.add_user_message("Hello".into());
-        let (_prefix_index1, _diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        // Test 3: Same message again - should return empty diff
-        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-        assert_eq!(diff2.len(), 0, "Identical render should produce empty diff");
-        assert_eq!(prefix_index2, chatstate.prefix_cache.len() as u32);
-
-        // Test 4: Modify existing message (simulate chat state change)
-        chatstate.messages[0] = Message::Message {
-            role: Role::User,
-            content: "Hello World".into(),
-        };
-        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        // Should find some common prefix but have differences
-        assert!(prefix_index3 > 0, "Should find some common prefix");
-        assert!(diff3.len() > 0, "Should have different tokens");
-
-        println!(
-            "Test 4: prefix_index={}, diff_len={}",
-            prefix_index3,
-            diff3.len()
-        );
-
-        // Test 5: Completely different messages
-        let mut new_chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
-        new_chatstate.add_assistant_message("Goodbye".into());
-        new_chatstate.prefix_cache = chatstate.prefix_cache.clone(); // Simulate existing cache
-
-        let (prefix_index4, diff4) = new_chatstate
-            .find_token_diff_and_prefix_index(&model)
-            .unwrap();
-
-        // Depending on tokenization, might have some common prefix from template
-        assert!(diff4.len() > 0, "Should have different content");
-
-        println!(
-            "Test 5: prefix_index={}, diff_len={}",
-            prefix_index4,
-            diff4.len()
-        );
-    }
 
     #[test]
     fn test_strftime_now() {
@@ -507,193 +375,175 @@ mod tests {
     }
 
     #[test]
-    fn test_deepseek_template_prefix_caching() {
-        let model = crate::test_utils::load_test_model();
+    fn test_render_string_llama3_template() {
+        // Llama 3.1 template from the existing test
+        let template = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}";
+        let mut chatstate = ChatState::new(
+            template.into(),
+            "<|begin_of_text|>".into(),
+            "<|end_of_text|>".into(),
+            vec![],
+        );
+
+        // Test 1: Single user message
+        chatstate.add_user_message("Hello, world!".into());
+        let rendered = chatstate.render_string().unwrap();
+
+        let expected = "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nHello, world!<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n";
+        assert_eq!(rendered, expected);
+
+        // Test 2: Add assistant response
+        chatstate.add_assistant_message("Hi there! How can I help?".into());
+        let rendered2 = chatstate.render_string().unwrap();
+
+        let expected2 = "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nHello, world!<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nHi there! How can I help?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n";
+        assert_eq!(rendered2, expected2);
+
+        // Test 3: Multi-turn conversation
+        chatstate.add_user_message("What's the weather like?".into());
+        chatstate.add_assistant_message("I don't have access to weather data.".into());
+        let rendered3 = chatstate.render_string().unwrap();
+
+        assert!(rendered3.starts_with(
+            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nHello, world!<|eot_id|>"
+        ));
+        assert!(rendered3.contains(
+            "<|start_header_id|>user<|end_header_id|>\n\nWhat's the weather like?<|eot_id|>"
+        ));
+        assert!(rendered3.contains("<|start_header_id|>assistant<|end_header_id|>\n\nI don't have access to weather data.<|eot_id|>"));
+        assert!(rendered3.ends_with("<|start_header_id|>assistant<|end_header_id|>\n\n"));
+
+        // Test 4: System message (if added first)
+        let mut chatstate_with_system = ChatState::new(
+            template.into(),
+            "<|begin_of_text|>".into(),
+            "<|end_of_text|>".into(),
+            vec![],
+        );
+        chatstate_with_system.add_system_message("You are a helpful assistant.".into());
+        chatstate_with_system.add_user_message("Hi".into());
+        let rendered4 = chatstate_with_system.render_string().unwrap();
+
+        assert!(rendered4.starts_with("<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are a helpful assistant.<|eot_id|>"));
+        assert!(rendered4.contains("<|start_header_id|>user<|end_header_id|>\n\nHi<|eot_id|>"));
+        assert!(rendered4.ends_with("<|start_header_id|>assistant<|end_header_id|>\n\n"));
+    }
+
+    #[test]
+    fn test_render_string_deepseek_template() {
+        // DeepSeek template from the existing test
         let template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}";
         let mut chatstate =
             ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
 
-        // Test 1: First message - establishes baseline cache
+        // Test 1: Single user message
         chatstate.add_user_message("Hello, world!".into());
-        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        let rendered = chatstate.render_string().unwrap();
 
-        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
+        // ChatState sets add_generation_prompt to true for user messages, so <｜Assistant｜> is added
+        let expected = "<|bos|><｜User｜>Hello, world!<｜Assistant｜>";
+        assert_eq!(rendered, expected);
+
+        // Test 2: Add assistant response
+        chatstate.add_assistant_message("Hi there! How can I help?".into());
+        let rendered2 = chatstate.render_string().unwrap();
+
+        let expected2 = "<|bos|><｜User｜>Hello, world!<｜Assistant｜>Hi there! How can I help?<｜end▁of▁sentence｜>";
+        assert_eq!(rendered2, expected2);
+
+        // Test 3: Assistant message with thinking block
+        chatstate.add_assistant_message(
+            "<think>The user is asking for help</think>I'd be happy to assist you!".into(),
+        );
+        let rendered3 = chatstate.render_string().unwrap();
+
+        // The thinking block should be stripped out, only the content after </think> should remain
         assert!(
-            diff1.len() > 0,
-            "First call should return all tokens as diff"
+            rendered3.contains("<｜Assistant｜>I'd be happy to assist you!<｜end▁of▁sentence｜>")
         );
+        assert!(!rendered3.contains("<think>"));
+        assert!(!rendered3.contains("</think>"));
 
-        let initial_cache_size = chatstate.prefix_cache.len();
-        println!("Initial cache size: {}", initial_cache_size);
+        // Test 4: System message
+        let mut chatstate_with_system =
+            ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
+        chatstate_with_system.add_system_message("You are a helpful assistant.".into());
+        chatstate_with_system.add_user_message("Hi".into());
+        let rendered4 = chatstate_with_system.render_string().unwrap();
 
-        // Test 2: Add assistant message with think block - should find common prefix
-        chatstate.add_assistant_message("<think>beep boop robot thinky</think>".into());
-        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        let expected4 = "<|bos|>You are a helpful assistant.<｜User｜>Hi<｜Assistant｜>";
+        assert_eq!(rendered4, expected4);
 
-        assert!(
-            prefix_index2 > 0,
-            "Should find some common prefix from BOS token and user message"
-        );
-        assert!(
-            diff2.len() > 0,
-            "Should have new tokens for assistant message"
-        );
-        assert!(
-            prefix_index2 < chatstate.prefix_cache.len() as u32,
-            "Prefix should be less than total cache"
-        );
+        // Test 5: Multi-turn conversation
+        let mut chatstate5 =
+            ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
+        chatstate5.add_user_message("What's 2+2?".into());
+        chatstate5.add_assistant_message("4".into());
+        chatstate5.add_user_message("Thanks!".into());
+        let rendered5 = chatstate5.render_string().unwrap();
 
-        println!(
-            "After assistant message: prefix_index={}, diff_len={}, total_cache={}",
-            prefix_index2,
-            diff2.len(),
-            chatstate.prefix_cache.len()
-        );
+        let expected5 =
+            "<|bos|><｜User｜>What's 2+2?<｜Assistant｜>4<｜end▁of▁sentence｜><｜User｜>Thanks!<｜Assistant｜>";
+        assert_eq!(rendered5, expected5);
 
-        // Test 3: Same messages again - should return empty diff
-        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        // Test 6: Empty messages (no generation prompt by default)
+        let mut chatstate6 =
+            ChatState::new(template.into(), "<|bos|>".into(), "<|eos|>".into(), vec![]);
+        let rendered6 = chatstate6.render_string().unwrap();
 
-        assert_eq!(
-            diff3.len(),
-            0,
-            "Identical template render should produce empty diff"
-        );
-        assert_eq!(
-            prefix_index3,
-            chatstate.prefix_cache.len() as u32,
-            "Should match full cache length"
-        );
-
-        // Test 4: Verify cache consistency
-        let expected_tokens = chatstate.render_tokens(&model).unwrap();
-        assert_eq!(
-            chatstate.prefix_cache, expected_tokens,
-            "Cache should exactly match rendered tokens"
-        );
-
-        // Test 5: Verify template renders correctly (basic sanity check)
-        let rendered_text = chatstate.render_string().unwrap();
-        assert!(
-            rendered_text.contains("<|bos|>"),
-            "Should contain BOS token"
-        );
-        assert!(
-            rendered_text.contains("<｜User｜>Hello, world!"),
-            "Should contain user message"
-        );
-        assert!(
-            rendered_text.contains("<｜Assistant｜>"),
-            "Should contain assistant tag (think block should be stripped)"
-        );
-
-        println!("Final rendered text length: {}", rendered_text.len());
+        let expected6 = "<|bos|>";
+        assert_eq!(rendered6, expected6);
     }
 
     #[test]
-    fn test_qwen3_template_prefix_caching() {
-        let model = crate::test_utils::load_test_model();
+    fn test_render_string_qwen3_template() {
+        // Qwen3 template from the existing test
         let template = "{%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0].role == 'system' %}\n        {{- messages[0].content + '\\n\\n' }}\n    {%- endif %}\n    {{- \"# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) %}\n        {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set content = message.content %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in message.content %}\n                {%- set content = message.content.split('</think>')[-1].lstrip('\\n') %}\n                {%- set reasoning_content = message.content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {%- if loop.last or (not loop.last and reasoning_content) %}\n                {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content.strip('\\n') + '\\n</think>\\n\\n' + content.lstrip('\\n') }}\n            {%- else %}\n                {{- '<|im_start|>' + message.role + '\\n' + content }}\n            {%- endif %}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- '\\n' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- '<tool_call>\\n{\"name\": \"' }}\n                {{- tool_call.name }}\n                {{- '\", \"arguments\": ' }}\n                {%- if tool_call.arguments is string %}\n                    {{- tool_call.arguments }}\n                {%- else %}\n                    {{- tool_call.arguments | tojson }}\n                {%- endif %}\n                {{- '}\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- message.content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- endif %}\n{%- endif %}";
         let mut chatstate = ChatState::new(template.into(), "".into(), "".into(), vec![]);
 
-        // Test 1: First message - establishes baseline cache
+        // Test 1: Single user message
         chatstate.add_user_message("Hi, robot!".into());
-        let (prefix_index1, diff1) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        let rendered = chatstate.render_string().unwrap();
 
-        assert_eq!(prefix_index1, 0, "First call should have no prefix cached");
-        assert!(
-            diff1.len() > 0,
-            "First call should return all tokens as diff"
-        );
+        let expected = "<|im_start|>user\nHi, robot!<|im_end|>\n<|im_start|>assistant\n";
+        assert_eq!(rendered, expected);
 
-        let initial_cache_size = chatstate.prefix_cache.len();
-        println!("Initial cache size: {}", initial_cache_size);
-
-        // Test 2: Add assistant message with thinking - should find common prefix
+        // Test 2: Add assistant response with thinking
         chatstate.add_assistant_message("<think>\nHm... That's a tough cookie. I think the answer is probably 42.\nCould it be something else?\nNah... It's 42!\n</think>\nThe answer is 42!".into());
-        let (prefix_index2, diff2) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        let rendered2 = chatstate.render_string().unwrap();
 
-        assert!(
-            prefix_index2 > 0,
-            "Should find some common prefix from user message"
-        );
-        assert!(
-            diff2.len() > 0,
-            "Should have new tokens for assistant message"
-        );
-        assert!(
-            prefix_index2 < chatstate.prefix_cache.len() as u32,
-            "Prefix should be less than total cache"
-        );
+        // The thinking block should be included in the output for Qwen3
+        let expected2 = "<|im_start|>user\nHi, robot!<|im_end|>\n<|im_start|>assistant\n<think>\nHm... That's a tough cookie. I think the answer is probably 42.\nCould it be something else?\nNah... It's 42!\n</think>\n\nThe answer is 42!<|im_end|>\n";
+        assert_eq!(rendered2, expected2);
 
-        println!(
-            "After assistant message: prefix_index={}, diff_len={}, total_cache={}",
-            prefix_index2,
-            diff2.len(),
-            chatstate.prefix_cache.len()
-        );
+        // Test 3: System message
+        let mut chatstate_with_system =
+            ChatState::new(template.into(), "".into(), "".into(), vec![]);
+        chatstate_with_system.add_system_message("You are a helpful assistant.".into());
+        chatstate_with_system.add_user_message("Hello".into());
+        let rendered3 = chatstate_with_system.render_string().unwrap();
 
-        // Test 3: Same messages again - should return empty diff
-        let (prefix_index3, diff3) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        let expected3 = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n";
+        assert_eq!(rendered3, expected3);
 
-        assert_eq!(
-            diff3.len(),
-            0,
-            "Identical template render should produce empty diff"
-        );
-        assert_eq!(
-            prefix_index3,
-            chatstate.prefix_cache.len() as u32,
-            "Should match entire cache"
-        );
+        // Test 4: Multi-turn conversation
+        let mut chatstate4 = ChatState::new(template.into(), "".into(), "".into(), vec![]);
+        chatstate4.add_user_message("What's 2+2?".into());
+        chatstate4.add_assistant_message("4".into());
+        chatstate4.add_user_message("Thanks!".into());
+        let rendered4 = chatstate4.render_string().unwrap();
 
-        println!(
-            "Same render: prefix_index={}, diff_len={}",
-            prefix_index3,
-            diff3.len()
-        );
+        let expected4 = "<|im_start|>user\nWhat's 2+2?<|im_end|>\n<|im_start|>assistant\n4<|im_end|>\n<|im_start|>user\nThanks!<|im_end|>\n<|im_start|>assistant\n";
+        assert_eq!(rendered4, expected4);
 
-        // Test 4: Add another user message - should reuse existing conversation prefix
-        chatstate.add_user_message("What are you on about? I need the real answer.".into());
-        let (prefix_index4, diff4) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
+        // Test 5: Assistant message without thinking
+        let mut chatstate5 = ChatState::new(template.into(), "".into(), "".into(), vec![]);
+        chatstate5.add_user_message("Hello".into());
+        chatstate5.add_assistant_message("Hi there!".into());
+        let rendered5 = chatstate5.render_string().unwrap();
 
-        assert!(prefix_index4 > 0, "Should reuse some conversation history");
-        assert!(
-            diff4.len() > 0,
-            "Should have tokens for new user message + generation prompt"
-        );
-        assert!(
-            prefix_index4 < chatstate.prefix_cache.len() as u32,
-            "Should not match entire cache"
-        );
-
-        println!(
-            "New user message: prefix_index={}, diff_len={}, total_cache={}",
-            prefix_index4,
-            diff4.len(),
-            chatstate.prefix_cache.len()
-        );
-
-        // Test 5: Add final assistant message - comprehensive conversation test
-        chatstate.add_assistant_message("<think>\nI already told the user that the real answer is 42.\nI guess I'll just tell them again. What an idiot...\n</think>\nThe answer is 42!".into());
-        let (prefix_index5, diff5) = chatstate.find_token_diff_and_prefix_index(&model).unwrap();
-
-        assert!(prefix_index5 > 0, "Should reuse conversation history");
-        assert!(
-            diff5.len() > 0,
-            "Should have tokens for final assistant response"
-        );
-
-        println!(
-            "Final assistant message: prefix_index={}, diff_len={}, total_cache={}",
-            prefix_index5,
-            diff5.len(),
-            chatstate.prefix_cache.len()
-        );
-
-        // Verify cache consistency
-        assert!(
-            chatstate.prefix_cache.len() > initial_cache_size,
-            "Cache should have grown with conversation"
-        );
+        // The template now includes empty thinking blocks for assistant messages
+        let expected5 = "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\nHi there!<|im_end|>\n";
+        assert_eq!(rendered5, expected5);
     }
 }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -116,8 +116,6 @@ fn apply_context_shifting(
         -n_discard,
     )?;
 
-    ctx.kv_cache_update();
-
     debug!(target: "Context shifted", ?n_discard);
 
     Ok(n_discard)
@@ -488,7 +486,6 @@ where
         }
 
         self.ctx.clear_kv_cache_seq(Some(0), Some(index), None)?;
-        self.ctx.kv_cache_update();
         self.n_past = index as i32;
         return Ok(());
     }

--- a/nobodywho/godot/default.nix
+++ b/nobodywho/godot/default.nix
@@ -38,9 +38,7 @@ rec {
     ];
     cargoLock = {
       lockFile = ../Cargo.lock;
-      outputHashes = {
-        "llama-cpp-2-0.1.120" = "sha256-S3KcVzmvRLXWcY/nqUoBg+G7npTUDO5BnypUbtRlCjI=";
-      };
+      outputHashes = { };
     };
     env.TEST_MODEL = fetchurl {
       name = "Qwen_Qwen3-0.6B-Q4_K_M.gguf";


### PR DESCRIPTION
Updated our inference flow to use prefix caching as a way to save computation. This was done to fix a bug with the current diffing logic that removed think blocks. 
The tests in chat_state were also updated to test the functions. This were created with claude, so there might be room for improvement here. 

Still need to test if the tokenizer can be used without a global inference lock. 
Also need to update the context shifting as the current prefix caching will break with the way context shifting is currently.