### PR TITLE
Move generation capability into chat.rs and implement context shifting.

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1017,8 +1017,6 @@ impl<'a> Worker<'_, ChatWorker> {
     where
         F: Fn(llm::WriteOutput) + Clone,
     {
-        let _gil_guard = GLOBAL_INFERENCE_LOCK.lock();
-
         // reset the stop flag
         self.extra
             .should_stop
@@ -1118,9 +1116,9 @@ impl<'a> Worker<'_, ChatWorker> {
         stop_words: Vec<String>,
         wrapped_respond: impl FnMut(WriteOutput),
     ) -> Result<&mut Self, SayError> {
-        let tokens_have_been_read = self.read_tokens(tokens)?;
+        let _gil_guard = GLOBAL_INFERENCE_LOCK.lock();
 
-        Ok(tokens_have_been_read.write_until_done(
+        Ok(self.read_tokens(tokens)?.write_until_done(
             sampler.clone(),
             stop_words.clone(),
             wrapped_respond,

--- a/nobodywho/core/src/chat_state.rs
+++ b/nobodywho/core/src/chat_state.rs
@@ -1,11 +1,11 @@
 use std::sync::LazyLock;
 
+use crate::errors::FromModelError;
 use llama_cpp_2::token::LlamaToken;
 use minijinja::{context, Environment};
 use serde::{self, Deserialize, Serialize};
 use serde_json;
 use tracing::{trace, warn};
-use tracing_subscriber::field::display::Messages;
 
 static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| {
     let mut env = Environment::new();
@@ -147,30 +147,6 @@ fn concat_system_and_first_user_messages(
             ))
         }
     }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum FromModelError {
-    #[error("Lama.cpp failed fetching chat template from the model file. This is likely because you're using an older GGUF file, which might not include a chat template. For example, this is the case for most LLaMA2-based GGUF files. Try using a more recent GGUF model file. If you want to check if a given model includes a chat template, you can use the gguf-dump script from llama.cpp. Here is a more technical detailed error: {0}")]
-    ChatTemplateError(#[from] llama_cpp_2::ChatTemplateError),
-
-    #[error("Could not parse chat template as UTF8: {0}")]
-    TemplateUtf8Error(#[from] std::str::Utf8Error),
-
-    #[error("Could not detokenize string: {0}")]
-    Detokenize(#[from] llama_cpp_2::TokenToStringError),
-
-    #[error("Tools were provided, but it looks like this model doesn't support tool calling.")]
-    NoToolTemplateError,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum RenderError {
-    #[error("Template failed to render: {0}")]
-    MiniJinjaError(#[from] minijinja::Error),
-
-    #[error("Could not tokenize string: {0}")]
-    CreateContextError(#[from] llama_cpp_2::StringToTokenError),
 }
 
 impl ChatState {

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -1,9 +1,10 @@
+use crate::errors::{CrossEncoderWorkerError, InitWorkerError};
 use crate::llm;
 use crate::llm::Worker;
 use llama_cpp_2::context::params::LlamaPoolingType;
 use llama_cpp_2::model::LlamaModel;
-use tracing::error;
 use std::sync::Arc;
+use tracing::error;
 
 pub struct CrossEncoderHandle {
     msg_tx: std::sync::mpsc::Sender<CrossEncoderMsg>,
@@ -22,27 +23,21 @@ impl CrossEncoderHandle {
         Self { msg_tx }
     }
 
-    pub fn rank(&self, query: String, documents: Vec<String>) -> tokio::sync::mpsc::Receiver<Vec<f32>> {
+    pub fn rank(
+        &self,
+        query: String,
+        documents: Vec<String>,
+    ) -> tokio::sync::mpsc::Receiver<Vec<f32>> {
         let (scores_tx, scores_rx) = tokio::sync::mpsc::channel(1);
-        let _ = self.msg_tx.send(CrossEncoderMsg::Rank(query, documents, scores_tx));
+        let _ = self
+            .msg_tx
+            .send(CrossEncoderMsg::Rank(query, documents, scores_tx));
         scores_rx
     }
 }
 
 enum CrossEncoderMsg {
     Rank(String, Vec<String>, tokio::sync::mpsc::Sender<Vec<f32>>),
-}
-
-#[derive(Debug, thiserror::Error)]
-enum CrossEncoderWorkerError {
-    #[error("Error initializing worker: {0}")]
-    InitWorkerError(#[from] llm::InitWorkerError),
-
-    #[error("Error reading string: {0}")]
-    ReadError(#[from] llm::ReadError),
-
-    #[error("Error getting classification score: {0}")]
-    ClassificationError(String),
 }
 
 fn run_worker(
@@ -58,7 +53,7 @@ fn run_worker(
                 worker_state.reset_context();
 
                 let scores = worker_state.rank(query, documents)?;
-                
+
                 let _ = respond.blocking_send(scores);
             }
         }
@@ -78,7 +73,7 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
     pub fn new_crossencoder_worker(
         model: &Arc<LlamaModel>,
         n_ctx: u32,
-    ) -> Result<Worker<'_, CrossEncoderWorker>, llm::InitWorkerError> {
+    ) -> Result<Worker<'_, CrossEncoderWorker>, InitWorkerError> {
         Worker::new_with_type(model, n_ctx, true, CrossEncoderWorker {})
     }
 
@@ -87,16 +82,25 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         // For crossencodering, all tokens have embeddings enabled (logits=true) but only the final token's
         // embedding contains the relevance score. embeddings_seq_ith(0) gets the sequence's embedding
         // vector, and embeddings[0] extracts the classification score from the final token.
-        let embeddings = self.ctx.embeddings_seq_ith(0).map_err(|e| CrossEncoderWorkerError::ClassificationError(e.to_string()))?;
-        
+        let embeddings = self
+            .ctx
+            .embeddings_seq_ith(0)
+            .map_err(|e| CrossEncoderWorkerError::ClassificationError(e.to_string()))?;
+
         if embeddings.len() >= 1 {
             Ok(embeddings[0])
         } else {
-            Err(CrossEncoderWorkerError::ClassificationError("classification head is empty".to_string()))
+            Err(CrossEncoderWorkerError::ClassificationError(
+                "classification head is empty".to_string(),
+            ))
         }
     }
 
-    pub fn rank(&mut self, query: String, documents: Vec<String>) -> Result<Vec<f32>, CrossEncoderWorkerError> {
+    pub fn rank(
+        &mut self,
+        query: String,
+        documents: Vec<String>,
+    ) -> Result<Vec<f32>, CrossEncoderWorkerError> {
         let mut scores = Vec::new();
         for document in documents {
             self.reset_context();
@@ -113,7 +117,7 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
 mod tests {
     use super::*;
     use crate::test_utils;
-    use rand::{seq::SliceRandom};
+    use rand::seq::SliceRandom;
 
     #[test]
     fn test_crossencoder() -> Result<(), Box<dyn std::error::Error>> {
@@ -141,9 +145,11 @@ mod tests {
 
         let scores = worker.rank(query, documents.clone())?;
         // The highest score for this should be the phrase  Paris is the capital of France.
-        let mut docs_with_scores: Vec<(String, f32)> = documents.iter().zip(scores.iter()).map(
-            |(doc, score)| (doc.clone(), *score)
-        ).collect();
+        let mut docs_with_scores: Vec<(String, f32)> = documents
+            .iter()
+            .zip(scores.iter())
+            .map(|(doc, score)| (doc.clone(), *score))
+            .collect();
 
         docs_with_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
@@ -153,11 +159,11 @@ mod tests {
                 seen_paris = true;
             }
         }
-        assert!(seen_paris, "`Paris is the capital of France.` is not in top three");
+        assert!(
+            seen_paris,
+            "`Paris is the capital of France.` is not in top three"
+        );
 
         Ok(())
     }
-
-
-    
-} 
+}

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -63,9 +63,6 @@ pub enum ReadError {
 
     #[error("Llama.cpp failed decoding: {0}")]
     DecodeError(#[from] llama_cpp_2::DecodeError),
-
-    #[error("Function was called without an inference lock")]
-    NoInferenceLockError,
 }
 
 // CrossEncoderWorker errors
@@ -153,9 +150,6 @@ pub enum InferenceError {
 #[derive(Debug, thiserror::Error)]
 
 pub enum GenerateResponseError {
-    #[error("Function was called without an inference lock")]
-    NoInferenceLockError,
-
     #[error("Error removing tokens from context after context shift")]
     KVCacheUpdateError(#[from] KvCacheConversionError),
 

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -1,0 +1,219 @@
+// Model errors
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadModelError {
+    #[error("Model not found: {0}")]
+    ModelNotFound(String),
+    #[error("Invalid or unsupported GGUF model: {0}")]
+    InvalidModel(String),
+}
+
+// Worker errors
+
+// Generic worker errors
+
+#[derive(Debug, thiserror::Error)]
+pub enum InitWorkerError {
+    #[error("Could not determine number of threads available: {0}")]
+    ThreadCountError(#[from] std::io::Error),
+
+    #[error("Could not create context: {0}")]
+    CreateContextError(#[from] llama_cpp_2::LlamaContextLoadError),
+
+    #[error("Failed getting chat template from model: {0}")]
+    ChatTemplateError(#[from] FromModelError),
+
+    #[error("Got no response after initializing worker.")]
+    NoResponse,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkerError {
+    #[error("Could not determine number of threads available: {0}")]
+    ThreadCountError(#[from] std::io::Error),
+
+    #[error("Could not create context: {0}")]
+    CreateContextError(#[from] llama_cpp_2::LlamaContextLoadError),
+
+    #[error("Could not initialize worker: {0}")]
+    InitWorkerError(#[from] InitWorkerError),
+
+    #[error("Error reading string: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error getting embeddings: {0}")]
+    EmbeddingsError(#[from] llama_cpp_2::EmbeddingsError),
+
+    #[error("Could not send newly generated token out to the game engine.")]
+    SendError, // this is actually a SendError<LLMOutput>, but that becomes recursive and weird
+
+    #[error("Global Inference Lock was poisoned.")]
+    GILPoisonError, // this is actually a std::sync::PoisonError<std::sync::MutexGuard<'static, ()>>, but that doesn't implement Send, so we do this
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReadError {
+    #[error("Could not tokenize string: {0}")]
+    TokenizerError(#[from] llama_cpp_2::StringToTokenError),
+
+    #[error("Could not add to batch: {0}")]
+    BatchAddError(#[from] llama_cpp_2::llama_batch::BatchAddError),
+
+    #[error("Llama.cpp failed decoding: {0}")]
+    DecodeError(#[from] llama_cpp_2::DecodeError),
+
+    #[error("Could not apply context shifting: {0}")]
+    ContextShiftError(#[from] llama_cpp_2::context::kv_cache::KvCacheConversionError),
+
+    #[error("Function was called without an inference lock")]
+    NoInferenceLockError,
+}
+
+// CrossEncoderWorker errors
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CrossEncoderWorkerError {
+    #[error("Error initializing worker: {0}")]
+    InitWorkerError(#[from] InitWorkerError),
+
+    #[error("Error reading string: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error getting classification score: {0}")]
+    ClassificationError(String),
+}
+
+// EmbeddingWorker errors
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EmbeddingsWorkerError {
+    #[error("Error initializing worker: {0}")]
+    InitWorkerError(#[from] InitWorkerError),
+
+    #[error("Error reading string: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error generating text: {0}")]
+    EmbeddingsError(#[from] llama_cpp_2::EmbeddingsError),
+}
+
+// ChatWorker errors
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum ChatWorkerError {
+    #[error("Error initializing worker: {0}")]
+    InitWorkerError(#[from] InitWorkerError),
+
+    #[error("Error reading string: {0}")]
+    SayError(#[from] SayError),
+
+    #[error("Init template error: {0}")]
+    TemplateError(#[from] FromModelError),
+
+    #[error("Error rendering template: {0}")]
+    TemplateRenderError(#[from] minijinja::Error),
+
+    #[error("Read error: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error getting token difference: {0}")]
+    RenderError(#[from] RenderError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WriteError {
+    #[error("Could not apply context shifting: {0}")]
+    ContextShiftError(#[from] llama_cpp_2::context::kv_cache::KvCacheConversionError),
+
+    #[error("Could not add token to batch: {0}")]
+    BatchAddError(#[from] llama_cpp_2::llama_batch::BatchAddError),
+
+    #[error("Llama.cpp failed decoding: {0}")]
+    DecodeError(#[from] llama_cpp_2::DecodeError),
+
+    #[error("Error sending message")]
+    SendError,
+
+    #[error("Error converting token to bytes: {0}")]
+    TokenToStringError(#[from] llama_cpp_2::TokenToStringError),
+
+    #[error("Invalid sampler configuration")]
+    InvalidSamplerConfig,
+
+    #[error("Error during context shift: {0}")]
+    ShiftError(#[from] ShiftError),
+
+    #[error("Error reading in context after context shift: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error rendering template after context shift: {0}")]
+    RenderError(#[from] RenderError),
+
+    #[error("Function was called without an inference lock")]
+    NoInferenceLockError,
+
+    #[error("Context size to small to contain generated respone!")]
+    ContextSizeError,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SayError {
+    #[error("Error generating text: {0}")]
+    WriteError(#[from] WriteError),
+
+    #[error("Error reading string: {0}")]
+    ReadError(#[from] ReadError),
+
+    #[error("Error getting response: {0}")]
+    ResponseError(#[from] std::sync::mpsc::RecvError),
+
+    #[error("Error rendering chat template: {0}")]
+    ChatTemplateRenderError(#[from] minijinja::Error),
+
+    #[error("Error finding token difference: {0}")]
+    RenderError(#[from] RenderError),
+
+    #[error("Error during context shift {0}")]
+    ShiftError(#[from] ShiftError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ShiftError {
+    #[error("Missing expected message {0}")]
+    MessageError(String),
+
+    #[error("Could not tokenize template render {0}")]
+    StringToTokenError(#[from] llama_cpp_2::StringToTokenError),
+
+    #[error("Could not render messages with template {0}")]
+    TemplateRenderError(#[from] minijinja::Error),
+
+    #[error("Error reading token render into model {0}")]
+    KVCacheUpdateError(#[from] ReadError),
+}
+
+// ChatState errors
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("Template failed to render: {0}")]
+    MiniJinjaError(#[from] minijinja::Error),
+
+    #[error("Could not tokenize string: {0}")]
+    CreateContextError(#[from] llama_cpp_2::StringToTokenError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FromModelError {
+    #[error("Lama.cpp failed fetching chat template from the model file. This is likely because you're using an older GGUF file, which might not include a chat template. For example, this is the case for most LLaMA2-based GGUF files. Try using a more recent GGUF model file. If you want to check if a given model includes a chat template, you can use the gguf-dump script from llama.cpp. Here is a more technical detailed error: {0}")]
+    ChatTemplateError(#[from] llama_cpp_2::ChatTemplateError),
+
+    #[error("Could not parse chat template as UTF8: {0}")]
+    TemplateUtf8Error(#[from] std::str::Utf8Error),
+
+    #[error("Could not detokenize string: {0}")]
+    Detokenize(#[from] llama_cpp_2::TokenToStringError),
+
+    #[error("Tools were provided, but it looks like this model doesn't support tool calling.")]
+    NoToolTemplateError,
+}

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -117,6 +117,9 @@ pub(crate) enum ChatWorkerError {
 
     #[error("Error getting token difference: {0}")]
     RenderError(#[from] RenderError),
+
+    #[error("Error removing tokens from KvCache: {0}")]
+    KvCacheConversionError(#[from] KvCacheConversionError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod chat_state;
 pub mod crossencoder;
 pub mod embed;
+pub mod errors;
 pub mod llm;
 pub mod sampler_config;
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use tracing::{debug, debug_span, error, info, info_span, trace, trace_span, warn};
 
 lazy_static! {
-    static ref GLOBAL_INFERENCE_LOCK: Mutex<()> = Mutex::new(());
+    pub(crate) static ref GLOBAL_INFERENCE_LOCK: Mutex<()> = Mutex::new(());
 }
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
@@ -138,10 +138,10 @@ pub enum InitWorkerError {
 
 #[derive(Debug)]
 pub(crate) struct Worker<'a, S> {
-    n_past: i32,
+    pub(crate) n_past: i32,
     pub(crate) ctx: LlamaContext<'a>,
-    big_batch: LlamaBatch,
-    small_batch: LlamaBatch,
+    pub(crate) big_batch: LlamaBatch,
+    pub(crate) small_batch: LlamaBatch,
 
     pub(crate) extra: S,
 }
@@ -170,9 +170,6 @@ pub enum WorkerError {
     #[error("Error reading string: {0}")]
     ReadError(#[from] ReadError),
 
-    #[error("Error generating text: {0}")]
-    WriteError(#[from] WriteError),
-
     #[error("Error getting embeddings: {0}")]
     EmbeddingsError(#[from] llama_cpp_2::EmbeddingsError),
 
@@ -181,15 +178,6 @@ pub enum WorkerError {
 
     #[error("Global Inference Lock was poisoned.")]
     GILPoisonError, // this is actually a std::sync::PoisonError<std::sync::MutexGuard<'static, ()>>, but that doesn't implement Send, so we do this
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum GenerateResponseError {
-    #[error("Error reading string: {0}")]
-    ReadError(#[from] ReadError),
-
-    #[error("Error generating text: {0}")]
-    WriteError(#[from] WriteError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -213,43 +201,7 @@ pub enum WriteOutput {
     Done(String),
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum WriteError {
-    #[error("Could not apply context shifting: {0}")]
-    ContextShiftError(#[from] llama_cpp_2::context::kv_cache::KvCacheConversionError),
-
-    #[error("Could not add token to batch: {0}")]
-    BatchAddError(#[from] llama_cpp_2::llama_batch::BatchAddError),
-
-    #[error("Llama.cpp failed decoding: {0}")]
-    DecodeError(#[from] llama_cpp_2::DecodeError),
-
-    #[error("Error sending message")]
-    SendError,
-
-    #[error("Error converting token to bytes:  {0}")]
-    TokenToStringError(#[from] llama_cpp_2::TokenToStringError),
-
-    #[error("Invalid sampler configuration")]
-    InvalidSamplerConfig,
-}
-
-pub trait GenerationCapability {}
-pub trait Stoppable {
-    fn stop(&self) -> bool;
-}
-// Type state markers
-pub struct GenerationWorker {
-    should_stop: Arc<AtomicBool>,
-}
-
-impl GenerationCapability for GenerationWorker {}
-impl Stoppable for GenerationWorker {
-    fn stop(&self) -> bool {
-        self.should_stop.load(std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
+/*
 #[cfg(test)]
 impl<'a> Worker<'_, GenerationWorker> {
     fn new_generation_worker(
@@ -266,119 +218,7 @@ impl<'a> Worker<'_, GenerationWorker> {
         )
     }
 }
-
-impl PoolingType for GenerationWorker {
-    fn pooling_type(&self) -> LlamaPoolingType {
-        LlamaPoolingType::None
-    }
-}
-
-impl<'a, T> Worker<'a, T>
-where
-    T: GenerationCapability + Stoppable,
-{
-    #[tracing::instrument(level = "info", skip(self, sampler_config, stop_words, respond))]
-    pub fn write_until_done<F>(
-        &mut self,
-        sampler_config: SamplerConfig,
-        stop_words: Vec<String>,
-        mut respond: F,
-    ) -> Result<&mut Self, WriteError>
-    where
-        F: FnMut(WriteOutput),
-    {
-        let _gil_guard = GLOBAL_INFERENCE_LOCK.lock();
-        // Token generation loop
-        info!("Worker writing until done");
-
-        // pre-allocating 4096 bytes for the response string
-        // 4096 is a very randomly chosen number. how does this affect performance?
-        let mut full_response: String = String::with_capacity(4096);
-
-        // initialize sampler
-        // stateful samplers only live for one response
-        let mut sampler = make_sampler(&self.ctx.model, sampler_config)
-            .ok_or(WriteError::InvalidSamplerConfig)?;
-
-        let mut token_bytes_vec = Vec::new();
-
-        while !self.extra.stop() {
-            // Check for context window overflow (it was in the end before)
-            if self.n_past >= self.ctx.n_ctx() as i32 {
-                self.n_past -= apply_context_shifting(&mut self.ctx, self.n_past)?;
-            }
-
-            // Sample next token, no need to use sampler.accept as sample already accepts the token.
-            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
-            // https://github.com/utilityai/llama-cpp-rs/issues/604
-            trace!("Applying sampler...");
-            let new_token: LlamaToken = sampler.sample(&self.ctx, -1);
-
-            // batch of one
-            self.small_batch.clear();
-            self.small_batch.add(new_token, self.n_past, &[0], true)?;
-
-            // llm go brr
-            let decode_span = trace_span!("write decode", n_past = self.n_past);
-            let decode_guard = decode_span.enter();
-            self.ctx.decode(&mut self.small_batch)?;
-            drop(decode_guard);
-            self.n_past += 1; // keep count
-
-            // Attempt to convert token(s) to bytes
-            let token_bytes = self
-                .ctx
-                .model
-                .token_to_bytes(new_token, Special::Tokenize)?;
-
-            token_bytes_vec.extend(token_bytes);
-
-            // Attempt to convert bytes to utf8 string.
-
-            let token_str = match std::str::from_utf8(&token_bytes_vec) {
-                Ok(str) => str,
-                Err(_) => {
-                    if token_bytes_vec.len() > 4 {
-                        "�"
-                    } else {
-                        continue;
-                    }
-                }
-            };
-
-            // Basic solution to split up graphemes. If the current token bytes cannot
-            // be converted into a string then we try to read more tokens till we have
-            // at least four bytes. If these still cannot be converted into a string,
-            // we assume that the model/sampler has produced a useless token somewhere.
-            // This we currently handle by discarding all of the current bytes, but more
-            // intelligent solutions could be a good idea.
-
-            trace!(?new_token, ?token_str);
-            let has_eog = self.ctx.model.is_eog_token(new_token);
-
-            if !has_eog {
-                full_response.push_str(token_str);
-                trace!("Sending out token: {token_str}");
-                respond(WriteOutput::Token(token_str.to_string()));
-            }
-
-            // done using token_str, so now we can clear token_bytes_vec
-            token_bytes_vec.clear();
-
-            let has_stop_words = stop_words
-                .iter()
-                .any(|stop_word| full_response.contains(stop_word));
-            if has_eog || has_stop_words {
-                break;
-            }
-        }
-
-        // we're done!
-        debug!("Sending out response: {full_response}");
-        respond(WriteOutput::Done(full_response));
-        Ok(self)
-    }
-}
+*/
 
 // Common methods for any workstate type
 impl<'a, T> Worker<'a, T>
@@ -493,6 +333,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    /*
     use super::*;
     use crate::test_utils;
 
@@ -686,4 +527,5 @@ mod tests {
         worker.read_string("1, 2, 3,".to_string())?;
         Ok(())
     }
+     */
 }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,5 +1,6 @@
 use crate::errors::{InitWorkerError, LoadModelError, ReadError};
 use lazy_static::lazy_static;
+use llama_cpp_2::context::kv_cache::KvCacheConversionError;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaPoolingType};
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_backend::LlamaBackend;
@@ -201,7 +202,10 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn remove_all_tokens_after_index_from_ctx(&mut self, index: u32) -> Result<(), ReadError> {
+    pub fn remove_all_tokens_after_index_from_ctx(
+        &mut self,
+        index: u32,
+    ) -> Result<(), KvCacheConversionError> {
         if self.n_past <= index as i32 {
             return Ok(());
         }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -169,11 +169,6 @@ where
         tokens: Vec<LlamaToken>,
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<&mut Self, ReadError> {
-        // Should only be called with an inference lock
-        if let Ok(_) = GLOBAL_INFERENCE_LOCK.try_lock() {
-            return Err(ReadError::NoInferenceLockError);
-        }
-
         let n_tokens = tokens.len();
         debug!("Reading {n_tokens} tokens.");
 

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -2,11 +2,11 @@ mod sampler_resource;
 
 use godot::classes::{INode, ProjectSettings};
 use godot::prelude::*;
-use nobodywho::{chat_state, llm, sampler_config};
+use nobodywho::{chat_state, errors, llm, sampler_config};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{debug, error, info, trace, warn};
-use tracing_subscriber::prelude::*;
 use tracing_subscriber::filter::{LevelFilter, Targets};
+use tracing_subscriber::prelude::*;
 
 use crate::sampler_resource::NobodyWhoSampler;
 
@@ -57,7 +57,7 @@ impl INode for NobodyWhoModel {
 #[godot_api]
 impl NobodyWhoModel {
     // memoized model loader
-    fn get_model(&mut self) -> Result<llm::Model, llm::LoadModelError> {
+    fn get_model(&mut self) -> Result<llm::Model, errors::LoadModelError> {
         if let Some(model) = &self.model {
             return Ok(model.clone());
         }
@@ -471,9 +471,9 @@ impl NobodyWhoChat {
             // TODO: if arguments are incorrect here, the callable returns null
             let res: Variant = callable.call(&args);
 
-            // Handling of async methods, 
-            // as soon as you use await in godot, the will return GDScriptState, which contains a signal. 
-            // signal cannot be emitted from non mainthreads, so we throw an 
+            // Handling of async methods,
+            // as soon as you use await in godot, the will return GDScriptState, which contains a signal.
+            // signal cannot be emitted from non mainthreads, so we throw an
             if res.get_type() == VariantType::OBJECT {
                 if let Ok(obj) = res.try_to::<Gd<RefCounted>>() {
                     let class_name = obj.get_class();
@@ -812,10 +812,12 @@ impl NobodyWhoCrossEncoder {
             let model = self.get_model()?;
 
             // TODO: configurable n_ctx liek with the embeddings node
-            self.crossencoder_handle = Some(nobodywho::crossencoder::CrossEncoderHandle::new(model, 4096));
+            self.crossencoder_handle = Some(nobodywho::crossencoder::CrossEncoderHandle::new(
+                model, 4096,
+            ));
             Ok(())
         };
-        
+
         if let Err(msg) = result() {
             godot_error!("Error running model: {}", msg);
         }
@@ -825,7 +827,7 @@ impl NobodyWhoCrossEncoder {
     /// Ranks documents based on their relevance to the query.
     /// Returns a signal that you can use to wait for the ranking.
     /// The signal will return a PackedStringArray of ranked documents.
-    /// 
+    ///
     /// Parameters:
     /// - query: The question or query to rank documents against
     /// - documents: Array of document strings to rank
@@ -837,10 +839,14 @@ impl NobodyWhoCrossEncoder {
             return self.rank(query, documents, limit);
         };
 
-        let docs_vec: Vec<String> = documents.to_vec().into_iter().map(|s| s.to_string()).collect();
+        let docs_vec: Vec<String> = documents
+            .to_vec()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let mut ranking_channel = crossencoder_handle.rank(query, docs_vec.clone());
         let emit_node = self.to_gd();
-        
+
         godot::task::spawn(async move {
             match ranking_channel.recv().await {
                 Some(scores) => {
@@ -855,16 +861,25 @@ impl NobodyWhoCrossEncoder {
     }
 
     #[func]
-    fn rank_sync(&mut self, query: String, documents: PackedStringArray, limit: i32) -> PackedStringArray {
+    fn rank_sync(
+        &mut self,
+        query: String,
+        documents: PackedStringArray,
+        limit: i32,
+    ) -> PackedStringArray {
         let Some(crossencoder_handle) = &self.crossencoder_handle else {
             godot_warn!("Worker was not started yet, starting now... You may want to call `start_worker()` ahead of time to avoid waiting.");
             self.start_worker();
             return self.rank_sync(query, documents, limit);
         };
 
-        let docs_vec: Vec<String> = documents.to_vec().into_iter().map(|s| s.to_string()).collect();
+        let docs_vec: Vec<String> = documents
+            .to_vec()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let mut ranking_channel = crossencoder_handle.rank(query, docs_vec.clone());
-        
+
         match ranking_channel.blocking_recv() {
             Some(scores) => Self::_to_sorted_string_array(docs_vec, scores, limit),
             None => {
@@ -875,16 +890,24 @@ impl NobodyWhoCrossEncoder {
     }
 
     /// takes a list of scores and documents and returns a sorted packedstring array
-    fn _to_sorted_string_array(documents: Vec<String>, scores: Vec<f32>, limit: i32) -> PackedStringArray {
+    fn _to_sorted_string_array(
+        documents: Vec<String>,
+        scores: Vec<f32>,
+        limit: i32,
+    ) -> PackedStringArray {
         let mut docs_with_scores: Vec<(String, f32)> = documents.into_iter().zip(scores).collect();
         docs_with_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        
+
         let ranked_docs: Vec<String> = docs_with_scores
             .into_iter()
             .map(|(doc, _)| doc)
-            .take(if limit > 0 { limit as usize } else { usize::MAX })
+            .take(if limit > 0 {
+                limit as usize
+            } else {
+                usize::MAX
+            })
             .collect();
-            
+
         let gstring_array: Vec<GString> = ranked_docs.into_iter().map(GString::from).collect();
         PackedStringArray::from(gstring_array)
     }
@@ -1006,7 +1029,8 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for GodotWriter {
 
 static INIT: std::sync::Once = std::sync::Once::new();
 
-static LEVEL_HANDLE: std::sync::Mutex<Option<tracing_subscriber::reload::Handle<Targets, tracing_subscriber::Registry>>,
+static LEVEL_HANDLE: std::sync::Mutex<
+    Option<tracing_subscriber::reload::Handle<Targets, tracing_subscriber::Registry>>,
 > = std::sync::Mutex::new(None);
 
 fn base_directive(level: tracing::Level) -> LevelFilter {
@@ -1019,7 +1043,7 @@ fn base_directive(level: tracing::Level) -> LevelFilter {
     }
 }
 
-// Llama logs are noisy and verbose, this works by setting a higher required log level before showing 
+// Llama logs are noisy and verbose, this works by setting a higher required log level before showing
 // At app DEBUG, a llama DEBUG message is not shown because only traces with INFO or higher is allowed through
 fn llama_log_threshold(level: tracing::Level) -> LevelFilter {
     match level {
@@ -1056,7 +1080,10 @@ pub fn set_log_level(level_str: &str) {
             .with_level(true)
             .compact();
 
-        tracing_subscriber::registry().with(filter).with(fmt_layer).init();
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .init();
     });
 
     if let Some(handle) = &*LEVEL_HANDLE.lock().unwrap() {

--- a/nobodywho/unity/src/lib.rs
+++ b/nobodywho/unity/src/lib.rs
@@ -2,12 +2,12 @@ use interoptopus::patterns::result::FFIError;
 use interoptopus::patterns::slice::FFISlice;
 use interoptopus::patterns::string::AsciiPointer;
 use interoptopus::{
-    callback, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_type, function, pattern, Inventory, InventoryBuilder
+    callback, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_type, function,
+    pattern, Inventory, InventoryBuilder,
 };
-use tracing::{debug, error, warn};
-use std::sync::Arc;
 use std::ffi::c_char;
-
+use std::sync::Arc;
+use tracing::{debug, error, warn};
 
 /// TRACING
 static INIT: std::sync::Once = std::sync::Once::new();
@@ -93,7 +93,7 @@ impl ModelWrapper {
         Ok(())
     }
 
-    fn get_model(&mut self) -> Result<nobodywho::llm::Model, nobodywho::llm::LoadModelError> {
+    fn get_model(&mut self) -> Result<nobodywho::llm::Model, nobodywho::errors::LoadModelError> {
         if let Some(ref model) = self.model {
             return Ok(model.clone());
         }
@@ -102,7 +102,9 @@ impl ModelWrapper {
             Ok(s) => s,
             Err(e) => {
                 error!("Model path contained invalid UTF-8.");
-                return Err(nobodywho::llm::LoadModelError::InvalidModel(format!("{e}")));
+                return Err(nobodywho::errors::LoadModelError::InvalidModel(format!(
+                    "{e}"
+                )));
             }
         };
 
@@ -118,7 +120,6 @@ impl ModelWrapper {
         }
     }
 }
-
 
 callback!(ToolCallback(input: *const std::ffi::c_void) -> *const std::ffi::c_void);
 
@@ -269,19 +270,27 @@ impl ChatWrapper {
     ) -> Result<(), ChatError> {
         if let Some(ref mut _handle) = self.handle {
             let name = name.as_str().map_err(|_| ChatError::BadName)?;
-            let description = description.as_str().map_err(|_| ChatError::BadDescription)?;
-            let json_schema: serde_json::Value = serde_json::from_str(
-                json_schema.as_str().map_err(|_| ChatError::BadJsonSchema)?
-            ).map_err(|_| ChatError::BadJsonSchema)?;
-        
+            let description = description
+                .as_str()
+                .map_err(|_| ChatError::BadDescription)?;
+            let json_schema: serde_json::Value =
+                serde_json::from_str(json_schema.as_str().map_err(|_| ChatError::BadJsonSchema)?)
+                    .map_err(|_| ChatError::BadJsonSchema)?;
+
             let callback_wrapper = Arc::new(move |json: serde_json::Value| -> String {
                 let json_str = std::ffi::CString::new(json.to_string()).unwrap();
-                let res: *const std::ffi::c_void = callback.call(json_str.as_ptr() as *const std::ffi::c_void);
-                // Cast back to str 
+                let res: *const std::ffi::c_void =
+                    callback.call(json_str.as_ptr() as *const std::ffi::c_void);
+                // Cast back to str
                 let res_str = unsafe { std::ffi::CStr::from_ptr(res as *const c_char) };
                 res_str.to_str().unwrap().to_string()
             });
-            let tool = nobodywho::chat::Tool::new( name.to_string(), description.to_string(), json_schema, callback_wrapper);
+            let tool = nobodywho::chat::Tool::new(
+                name.to_string(),
+                description.to_string(),
+                json_schema,
+                callback_wrapper,
+            );
             self.tools.push(tool);
             Ok(())
         } else {
@@ -313,9 +322,14 @@ impl ChatWrapper {
 
     pub fn set_chat_history(&mut self, chat_history: AsciiPointer) -> Result<(), ChatError> {
         if let Some(ref handle) = self.handle {
-            let string = chat_history.as_str().map_err(|_| ChatError::BadJsonSchema)?;
-            let json: serde_json::Value = serde_json::from_str(string).map_err(|_| ChatError::BadJsonSchema)?;
-            let messages: Vec<nobodywho::chat_state::Message> = serde_json::from_value(json["messages"].clone()).map_err(|_| ChatError::BadJsonSchema)?;
+            let string = chat_history
+                .as_str()
+                .map_err(|_| ChatError::BadJsonSchema)?;
+            let json: serde_json::Value =
+                serde_json::from_str(string).map_err(|_| ChatError::BadJsonSchema)?;
+            let messages: Vec<nobodywho::chat_state::Message> =
+                serde_json::from_value(json["messages"].clone())
+                    .map_err(|_| ChatError::BadJsonSchema)?;
 
             handle.set_chat_history(messages);
             Ok(())
@@ -323,7 +337,6 @@ impl ChatWrapper {
             Err(ChatError::WorkerNotStarted)
         }
     }
-
 
     pub fn stop(&mut self) -> Result<(), ChatError> {
         if let Some(ref mut handle) = self.handle {
@@ -554,11 +567,10 @@ fn bindings_csharp() -> Result<(), interoptopus::Error> {
         param_slice_type: ParamSliceType::Array,
         ..Config::default()
     };
-    
+
     // Generate the bindings
-    Generator::new(config, my_inventory())
-        .write_file("./src/Runtime/NobodyWhoBindings.cs")?;
-    
+    Generator::new(config, my_inventory()).write_file("./src/Runtime/NobodyWhoBindings.cs")?;
+
     // This is kind of ugly but i dont see a better way (unless we overwrite the config).
     // Post-process the generated file to add version logging
     let mut content = std::fs::read_to_string("./src/Runtime/NobodyWhoBindings.cs")?;
@@ -570,6 +582,6 @@ fn bindings_csharp() -> Result<(), interoptopus::Error> {
         )
     );
     std::fs::write("./src/Runtime/NobodyWhoBindings.cs", content)?;
-    
+
     Ok(())
 }


### PR DESCRIPTION
Quite big updates. Removed the generation worker abstraction and moved this capability from llm.rs to chat.rs. Updated the tests accordingly. This was done for multiple reasons, but the main one is to facilitate the new context shifting. 

Basic context shifting now works and is tested. It stills needs to be made part of the read and write flow.
The context shift currently makes the following assumptions.

1. There is at least 3 user messages in the chat history. 
2. The first and two last user messages, their responses and the system prompt should never be deleted.
3. The resulting chat history should follow the same message structure as before with user -> assistant.