### PR TITLE
Python: @tool decorator

### DIFF
--- a/nobodywho/python/tests/test_nobodywho.py
+++ b/nobodywho/python/tests/test_nobodywho.py
@@ -211,6 +211,8 @@ def sparklify(text: str) -> str:
 
 def test_tool_construction():
     assert sparklify is not None
+    assert isinstance(sparklify, nobodywho.Tool)
+    assert sparklify("foobar") == "✨FOOBAR✨"
 
 
 def test_tool_calling(model):


### PR DESCRIPTION
Replaces the existing class-style constructor for tools to instead be a decorator, that's used like this:

```python
@tool(description="Add two to a given number")
def add_two(num: int) -> str:
  return str(num * 2)
```

A `@tool(...)`-decorated function is replaced by a `Tool` object, that is still callable - so the original behavior of the function is preserved (although typing may not be). 