### PR TITLE
Send tracing logs to python's `logging`

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -123,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1561,7 @@ dependencies = [
  "futures",
  "nobodywho",
  "pyo3",
+ "pyo3-log",
  "rand",
  "serde_json",
  "tokio",
@@ -1791,6 +1798,17 @@ checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8bae9ad5ba08b0b0ed2bb9c2bdbaeccc69cafca96d78cf0fbcea0d45d122bb"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]
@@ -2368,6 +2386,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -14,7 +14,7 @@ llama-cpp-2 = { version = "0.1.129" }
 lazy_static = "1.5.0"
 tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.17"
-tracing = "0.1.41"
+tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = "0.3.19"
 regex = "1.11.1"
 serde_json = "1.0.140"

--- a/nobodywho/python/Cargo.toml
+++ b/nobodywho/python/Cargo.toml
@@ -14,9 +14,10 @@ nobodywho = { path = "../core" }
 #pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
 tokio = { version = "1.0", features = ["full"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
-tracing = "0.1.41"
+tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = "0.3.19"
 futures = "0.3.31"
+pyo3-log = "0.13.2"
 
 
 [dependencies.pyo3]


### PR DESCRIPTION
This PR supersedes #265 - it's actually the exact same changes, except I just did it on main instead of the python sampling branch. This lets me merge it sooner and move on.

The TL;DR is that logs from nobodywho are now sent to python's [logging](https://docs.python.org/3/library/logging.html) module.

It integrates nicely with a bunch of tools, e.g. loguru, or to use with pytest: `python3 -m pytest --log-cli-level=DEBUG`

The main UX difference is that nobodywho's internal logs (including llama.cpp logs) are now hidden by default.