### PR TITLE
Change docs url back to github.io

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: NobodyWho
-site_url: https://docs.nobodywho.ooo
+site_url: https://nobodywho-ooo.github.io/nobodywho/
 
 docs_dir: ./markdown
 


### PR DESCRIPTION
TLS configuration stuff was being weird, so lets postpone setting up a proper domain for this.