### PR TITLE
build for manylinux 2_34

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install build dependencies
         run: |
           # Install basic build tools
-          yum install -y clang cmake wget tar gzip
+          yum install -y clang cmake wget tar gzip python3-pip
 
           # Download and install Vulkan SDK
           export VULKAN_VERSION=1.3.296.0


### PR DESCRIPTION
This is an attempt to make distro support a bit broader.

We found that when installing nobodywho in a miniconda environment (reproducible with docker image `continuumio/miniconda3`), it would fail because of libstdc++ incompatibility.

~~Reducing the manylinux version a bit may help.~~

EDIT: it did help. `continuumio/miniconda3:4f7df8586b44` (aka `latest`) can import this version of the nobodywho wheel without crapping out on libstdc++ versioning