### PR TITLE
Bump upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: ./docs
         run: uv run mkdocs build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           name: docs
           path: docs/site


### PR DESCRIPTION
Deploying docs to github pages failed. It gave this helpful error message, which told me what to do:

```
Error: Fetching artifact metadata failed. Is githubstatus.com reporting issues with API requests, Pages, or Actions? Please re-run the deployment at a later time.
Error: Error: No artifacts named "docs" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
    at getArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:85:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:66:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: No artifacts named "docs" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
```