### PR TITLE
Specify godot version 4.5 required

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment:**
  - OS: [e.g. Windows, Linux, macOS]
- - Godot Version: [e.g. 4.2]
+ - Godot Version: [e.g. 4.5]
  - Nobodywho Version: [e.g. 4.4.0] (should be logged as `NobodyWho Library Version: x.x.x` )
  - LLM Model: [e.g. Gemma 2B]
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There plenty of things you can do with tools and many of these are coverend in o
 
 ## Godot
 
-You can install it from inside the Godot editor: In Godot 4.4+, go to AssetLib and search for "NobodyWho".
+You can install it from inside the Godot editor: In Godot 4.5+, go to AssetLib and search for "NobodyWho".
 
 ...or you can grab a specific version from our [github releases page.](https://github.com/nobodywho-ooo/nobodywho/releases) You can install these zip files by going to the "AssetLib" tab in Godot and selecting "Import".
 

--- a/docs/markdown/godot/install.md
+++ b/docs/markdown/godot/install.md
@@ -5,7 +5,7 @@ _How to install NobodyWho and start building._
 
 ### Via Asset Library
 
-- **Open Godot 4.4** (or any newer 4.x release).
+- **Open Godot 4.5** (or any newer 4.x release).
 - Switch to the **Asset Library** tab.
 - Search for **“NobodyWho”** and select the entry.
 - Click **Download**, tick **Ignore asset root**, then choose **Install**.

--- a/nobodywho/godot/integration-test/nobodywho.gdextension
+++ b/nobodywho/godot/integration-test/nobodywho.gdextension
@@ -1,6 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.3
+compatibility_minimum = 4.5
 reloadable = true
 
 [libraries]

--- a/nobodywho/godot/nobodywho.gdextension
+++ b/nobodywho/godot/nobodywho.gdextension
@@ -1,6 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.3
+compatibility_minimum = 4.5
 reloadable = true
 
 [libraries]


### PR DESCRIPTION
From nobodywho-godot v7.0.0, Godot version 4.5 is required. This should be documented.