### PR TITLE
fix nix build: deref symlinks when including dynamic libraries in flutter example app

### DIFF
--- a/nobodywho/flutter/example_app/linux/CMakeLists.txt
+++ b/nobodywho/flutter/example_app/linux/CMakeLists.txt
@@ -101,9 +101,12 @@ install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)
 
 foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
-  install(FILES "${bundled_library}"
-    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-    COMPONENT Runtime)
+  # Dereference symlinks for Nix builds by using file(INSTALL) with FOLLOW_SYMLINK_CHAIN
+  install(CODE "
+    file(INSTALL \"${bundled_library}\"
+      DESTINATION \"${INSTALL_BUNDLE_LIB_DIR}\"
+      FOLLOW_SYMLINK_CHAIN)
+    " COMPONENT Runtime)
 endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.


### PR DESCRIPTION
The nix build of the flutter example app was broken with #274 because crate2nix makes libnododywho_flutter.so a symlink.

This is likely only a problem with nix-builds, which we rn only do for x86_64-linux. So I just fixed it by following symlinks in the linux CMakeLists file. We might need to revisit it if we start doing flutter builds for darwin with nix.