### PR TITLE
Improve worker initialization error logging

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -254,9 +254,12 @@ impl ChatHandle {
         let should_stop_clone = Arc::clone(&should_stop);
 
         std::thread::spawn(move || {
-            let Ok(mut worker_state) = Worker::new_chat_worker(&model, config, should_stop_clone)
-            else {
-                return error!("Could not set up the worker initial state");
+            let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!("Could not set up the worker initial state: {errmsg}")
+                }
             };
 
             while let Ok(msg) = msg_rx.recv() {
@@ -422,9 +425,12 @@ impl ChatHandleAsync {
         let should_stop_clone = Arc::clone(&should_stop);
 
         std::thread::spawn(move || {
-            let Ok(mut worker_state) = Worker::new_chat_worker(&model, config, should_stop_clone)
-            else {
-                return error!("Could not set up the worker initial state");
+            let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!("Could not set up the worker initial state: {errmsg}")
+                }
             };
 
             while let Ok(msg) = msg_rx.recv() {

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -51,8 +51,12 @@ impl CrossEncoderAsync {
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            let Ok(mut worker_state) = Worker::new_crossencoder_worker(&model, n_ctx) else {
-                return error!("Could not set up the worker initial state");
+            let worker = Worker::new_crossencoder_worker(&model, n_ctx);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!("Could not set up the worker initial state: {errmsg}")
+                }
             };
 
             while let Ok(msg) = msg_rx.recv() {

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -37,8 +37,12 @@ impl EncoderAsync {
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            let Ok(mut worker_state) = Worker::new_encoder_worker(&model, n_ctx) else {
-                return error!("Could not set up the worker initial state");
+            let worker = Worker::new_encoder_worker(&model, n_ctx);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!("Could not set up the worker initial state: {errmsg}")
+                }
             };
 
             while let Ok(msg) = msg_rx.recv() {


### PR DESCRIPTION
A user sent this error in the discord chat:

```
E 0:00:02:446   <nobodywho_godot::GodotWriter as std::io::Write>::write: 2026-01-12T09:35:15.051134Z ERROR nobodywho::chat: Could not set up the worker initial state
  <C++ Source>  godot\src\lib.rs:1241 @ <nobodywho_godot::GodotWriter as std::io::Write>::write()
```

It's a damn shame that we're not providing a better error message than that. There are several things that might have gone wrong, and we don't know which one.

With this PR, we'll preserve the full error message in the logging.