### PR TITLE
feat: Add feat to Chat to download huggingface models automatically

### DIFF
--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.140"
 gbnf = "0.2.5"
 rand = "0.9.2"
 futures = "0.3.31"
+hf-hub = "0.4.3"
 
 # Enable Vulkan for x86_64 and x86 targets (excluding macOS, iOS, Android)
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -1,4 +1,20 @@
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
+use hf_hub::api::sync::ApiError;
+
+
+// TODO: Likely fits under something else... Hf-Hub being used for one thing... doesn't warrent its own error type-type?
+// Hf-Hub errors
+
+#[derive(Debug, thiserror::Error)]
+pub enum HfHubError {
+    #[error("Error calling HfHub: {0}")]
+    ApiCreationError(#[from] hf_hub::api::sync::ApiError ),
+    #[error("No .gguf file found in given HuggingFace repository")]
+    NoGgufError(),
+    // TODO: Consider if we should pass debug string here or something...
+    #[error("Could not get name of downloaded .gguf file")]
+    StrCreationError(),
+}
 
 // Model errors
 
@@ -8,6 +24,8 @@ pub enum LoadModelError {
     ModelNotFound(String),
     #[error("Invalid or unsupported GGUF model: {0}")]
     InvalidModel(String),
+    #[error("Hf-Hub download failed")]
+    HfHubDownloadFailed(#[from] HfHubError),
 }
 
 // Worker errors


### PR DESCRIPTION
What it says on the tin; when creating Chat, if no model is available locally, will check if huggingface repo exists and download a model from there if possible.

## Description

No existing issue. Feature to download models using [hf-hub](https://github.com/huggingface/hf-hub) in case user creates a chat context with a model name that doesn't correspond to a local file. If this doesn't correspond to a huggingface model, will throw same error as before (model not found). 

Right now, seemingly downloads a RANDOM .gguf file from the given huggingface repo... Obviously not good, should fix before merge. If the huggingface model has been downloaded before, however (and it chooses the same .gguf file), it won't download it again.

Hf-hub is obviously added as a dependency

Also added relevant error enums to correspond to new hf-hub functionality added.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce or add a test to the example game.

I ran it, and _iT wOrKs On My MaChInE_

```
chat = Chat("ggml-org/gemma-3-4b"
response = chat.ask('Do all people who shave themselves, shave themselves?'')

for token in response:
    print(token, end="", flush=True)

```

No tests beyond this.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 