### PR TITLE
Reduce number of macOS jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,26 @@ on:
       upload_artifacts:
         type: boolean
         default: true
+      full_macos_build:
+        description: "Run full macOS matrix (all targets, profiles). If false, only builds aarch64-darwin-release."
+        type: boolean
+        default: false
 
 jobs:
+  # Dynamically compute macOS matrix based on full_macos_build input
+  setup-macos-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "${{ inputs.full_macos_build }}" == "true" ]; then
+            echo 'matrix={"target":["x86_64-apple-darwin","aarch64-apple-darwin","aarch64-apple-ios","aarch64-apple-ios-sim"],"profile":["debug","release"],"integration":["godot","flutter"]}' >> $GITHUB_OUTPUT
+          else
+            echo 'matrix={"target":["aarch64-apple-darwin","aarch64-apple-ios"],"profile":["release"],"integration":["godot","flutter"]}' >> $GITHUB_OUTPUT
+          fi
+
   cargo-build-linux:
     strategy:
       fail-fast: false
@@ -169,22 +187,11 @@ jobs:
             ./nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.pdb
 
   cargo-build-macos:
+    needs: setup-macos-matrix
     runs-on: macos-15
     strategy:
       fail-fast: false
-      matrix:
-        target:
-          - "x86_64-apple-darwin"
-          - "aarch64-apple-darwin"
-          - "aarch64-apple-ios"
-            # for running in an ios simulator
-          - "aarch64-apple-ios-sim"
-        profile:
-          - "debug"
-          - "release"
-        integration:
-          - "godot"
-          - "flutter"
+      matrix: ${{ fromJSON(needs.setup-macos-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -230,6 +237,7 @@ jobs:
   # builds an "xcframework"
   # which is an apple thing that contains binaries for multiple systems
   build-flutter-xcframework:
+    if: inputs.full_macos_build
     runs-on: macos-15
     needs: [cargo-build-macos]
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       upload_artifacts: true
+      full_macos_build: ${{ github.ref == 'refs/heads/main' }}
     needs: [linting]
 
   test:


### PR DESCRIPTION
By far the slowest thing in our GH Actions CI is waiting for new macOS runners to be available.

This should reduce number of macOS builds ~~by 4~~ by a lot.

I removed building ios stuff for x86. The only real use-case is when downstream developers want to run an ios emulator on an unusually old macbook (I think the last x86 macbook was from like 2019, 7 years ago?). We still build ios-sim stuff for aarch64.

Also cleaned up the xcframework build a little. Some stuff was not used, and no we no longer need to make a lipo for ios-sim, since we're only targeting one architecture.

I also added some fugly yaml to run the majority of macOS builds only on pipelines started from main. On non-main workflow runs, it only runs release builds on aarch64 targets (ios and macos, godot and flutter, release only, aarch64 only). This should remove like at least ten more macos jobs on each push.