### PR TITLE
fix: MacOS pipeline xcframework builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       upload_artifacts: true
-      full_macos_build: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/nobodywho-flutter-') }}
+      full_macos_build: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/nobodywho-') }}
     needs: [linting]
 
   test:


### PR DESCRIPTION
### Description
We have been accidentally not building the `.xcframework` upon flutter release.