### PR TITLE
Removed unnecessary trigger word from lazy_grammar sampling

### DIFF
--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -204,7 +204,7 @@ impl SamplerConfig {
             model,
             grammar,
             root,
-            vec![trigger],
+            Vec::<&str>::new(),
             &[token],
         )?)
     }


### PR DESCRIPTION
Removed duplicate triggers for lazy_grammar sampler. Now we only pass a trigger token.

We currently only support trigger tokens for our lazy_grammar sampling, but we supply the token as both a trigger word and trigger token to the backend. This is bad as trigger words are currently very slow in llama.cpp. We might want to add trigger words as an option later, but while we aren't supporting it we should only use trigger tokens.

