### PR TITLE
fix flutter xcframework build by zipping first

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,11 +290,14 @@ jobs:
                   -headers "headers" \
                   -output NobodyWhoFlutter.xcframework
 
+      - name: "Zip XCFramework"
+        run: zip -r NobodyWhoFlutter.xcframework.zip NobodyWhoFlutter.xcframework
+
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v4
         with:
           name: nobodywho-flutter-xcframework
-          path: ./NobodyWhoFlutter.xcframework
+          path: ./NobodyWhoFlutter.xcframework.zip
 
   cargo-build-android:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,14 @@ jobs:
       - name: "List artifacts to include in release"
         run: ls -la ./nobodywho-flutter-release/
 
-      - name: "Zip XCFramework for release"
+      - name: "Verify XCFramework zip is present"
         working-directory: ./nobodywho-flutter-release
         run: |
-          if [ -d "NobodyWhoFlutter.xcframework" ]; then
-            zip -r "NobodyWhoFlutter.xcframework.zip" NobodyWhoFlutter.xcframework
-            rm -rf NobodyWhoFlutter.xcframework
+          if [ ! -f "NobodyWhoFlutter.xcframework.zip" ]; then
+            echo "ERROR: NobodyWhoFlutter.xcframework.zip not found!"
+            echo "Contents of release directory:"
+            ls -la .
+            exit 1
           fi
 
       - name: "Create GitHub Release"


### PR DESCRIPTION
So the xcframework artifact wasn't being passed through properly at all.
This changes the xcframework job to output a zip file, instead of the contents of the xcframework folder.
We also now fail hard in the release step, if that zip file does not exist.