### PR TITLE
Fix: Remove minimum macos version for flutter podspec

### DIFF
--- a/nobodywho/flutter/nobodywho/macos/nobodywho.podspec
+++ b/nobodywho/flutter/nobodywho/macos/nobodywho.podspec
@@ -69,7 +69,7 @@ Flutter FFI plugin for NobodyWho - local LLM inference with tool calling, embedd
 
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx, '15.5'
+  s.platform = :osx
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 


### PR DESCRIPTION
## Description
Cannot run flutter on macos unless manually bumping the macos podfile of the project to platform :osx, '15.5'.
Since we don't need to inforce a minimum version, we can safely remove it

Fixes #
Remove minimum macos version for flutter

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)