### PR TITLE
feat: exclude x86

### DIFF
--- a/nobodywho/flutter/example_app/ios/Podfile
+++ b/nobodywho/flutter/example_app/ios/Podfile
@@ -39,5 +39,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'i386 x86_64'
+    end
   end
 end


### PR DESCRIPTION
The nobodywho_flutter.xcframework only ships an ios-arm64-simulator slice. CocoaPods
generates the nobodywho aggregate target with ONLY_ACTIVE_ARCH = NO, causing its
xcframework copy script to run with ARCHS = arm64 x86_64 for simulator builds. The
script requires all requested architectures to be present in a single xcframework
slice — since no ios-arm64_x86_64-simulator combined slice exists, no slice matches,
the copy is silently skipped, and the framework is never placed where the linker
looks for it. The fix excludes x86_64 from simulator builds in the Podfile's
post_install hook, reducing effective ARCHS to arm64 only, which matches the
available slice.