### PR TITLE
Flutter: Find the dart executable path on Windows

### DIFF
--- a/nobodywho/flutter/nobodywho/windows/CMakeLists.txt
+++ b/nobodywho/flutter/nobodywho/windows/CMakeLists.txt
@@ -17,9 +17,20 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # Windows only supports x86_64 currently
 set(WINDOWS_ARCH "x86_64")
 
+# Find dart executable - Flutter sets FLUTTER_ROOT during builds
+# On Windows, bin/dart is a .bat file; the real executable is in the bundled dart-sdk
+if(DEFINED ENV{FLUTTER_ROOT})
+  set(DART_EXECUTABLE "$ENV{FLUTTER_ROOT}/bin/cache/dart-sdk/bin/dart.exe")
+else()
+  find_program(DART_EXECUTABLE NAMES dart.exe dart)
+  if(NOT DART_EXECUTABLE)
+    message(FATAL_ERROR "Could not find 'dart' executable. Ensure Flutter is in your PATH or FLUTTER_ROOT is set.")
+  endif()
+endif()
+
 # Resolve binary using Dart script
 execute_process(
-  COMMAND dart run "${CMAKE_CURRENT_SOURCE_DIR}/../tool/resolve_binary.dart"
+  COMMAND ${DART_EXECUTABLE} run "${CMAKE_CURRENT_SOURCE_DIR}/../tool/resolve_binary.dart"
           --platform=windows
           --arch=${WINDOWS_ARCH}
           --build-type=release


### PR DESCRIPTION
## Description
Changed CMakeList.txt for Flutter Windows to not rely on a dart executable being available to the cmake process. Try to find dart.exe in FLUTTER_ROOT or through "find_program".

Fixes #418 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
The change has been tested on 2 Windows 11 machines with the latest version of Flutter installed. Both have a link to the flutter/bin directory on their path.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 