### PR TITLE
Fix: bad flutter/android cache invalidation

### DIFF
--- a/nobodywho/flutter/nobodywho/android/build.gradle.kts
+++ b/nobodywho/flutter/nobodywho/android/build.gradle.kts
@@ -51,6 +51,11 @@ val resolveNativeLibraries by tasks.registering {
     val jniLibsDir = layout.buildDirectory.dir("jniLibs")
     val cacheDir = layout.buildDirectory.dir("nobodywho-cache")
 
+    // Declare inputs so Gradle re-runs this task when the version or resolve logic changes.
+    // Without these, Gradle considers the task UP-TO-DATE after the first run, causing stale
+    // .so files from a previous plugin version to persist across upgrades.
+    inputs.file("${projectDir}/../pubspec.yaml")
+    inputs.file("${projectDir}/../tool/resolve_binary.dart")
     outputs.dir(jniLibsDir)
 
     doLast {


### PR DESCRIPTION
When upgrading the version of nobodywho, android builds would fail with a hash mismatch between the dart code and the associated .so files.

Turns out this is because the gradle script doesn't declare any inputs, so it doesn't rerun the task if the outputs exist. This means that it would use new dart files, but the old dynamic lib in the old jniLibs folder. This breaks upgrades.

A quick workaround is to do `flutter clean`, which will remove the old build dir (including jniLibs), causing a re-download of the dynamic libs- but this is awkward and not what flutter devs expect.

This PR adds inputs to the kotlin gradle script, so that when the pubspec.yaml is updated (as it is when updating nobodywho versions) it will invalidate the old jniLibs and download a new .so file from github releases to put into a new jniLibs thing.

I have convinced myself that this is a correct solution, but it is still pending a rc to test that it *actually* fixes the issue end-to-end. TBD.