### PR TITLE
Feat: lower dart sdk version to minimum possible

### DIFF
--- a/nobodywho/flutter/nobodywho/pubspec.yaml
+++ b/nobodywho/flutter/nobodywho/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - local-ai
 
 environment:
-  sdk: ^3.9.2
+  sdk: '>=3.8.0'
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
## Description
Lower dart sdk version to minimum possible.
3.8.0 is the lowest possible because of `ffigen` 19.1.0 (see on [pub.dev](https://pub.dev/packages/ffigen/versions))

Fixes [432](https://github.com/nobodywho-ooo/nobodywho/issues/432)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update