### PR TITLE
chore: update pytests to have correct use of allow_thinking to preven…

### DIFF
--- a/nobodywho/python/tests/test_multimodal.py
+++ b/nobodywho/python/tests/test_multimodal.py
@@ -20,7 +20,7 @@ def vision_model():
 @pytest.fixture
 def vision_chat(vision_model):
     return nobodywho.Chat(
-        vision_model, system_prompt="You are a helpful assistant.", allow_thinking=False
+        vision_model, system_prompt="You are a helpful assistant.", template_variables={"enable_thinking": False}
     )
 
 

--- a/nobodywho/python/tests/test_tool_calling.py
+++ b/nobodywho/python/tests/test_tool_calling.py
@@ -108,14 +108,14 @@ def chat(model):
         c = nobodywho.Chat(
             model,
             system_prompt="You are a helpful assistant",
-            allow_thinking=False,
+            template_variables={"enable_thinking": False},
             tools=[sparklify],
         )
     else:
         c = nobodywho.Chat(
             model,
             system_prompt="You are a helpful assistant",
-            allow_thinking=False,
+            template_variables={"enable_thinking": False},
             tools=[
                 set_intersection,
                 multiply_strings,
@@ -201,7 +201,7 @@ def test_set_tools(model):
     chat = nobodywho.Chat(
         model,
         system_prompt="You are a helpful assistant",
-        allow_thinking=False,
+        template_variables={"enable_thinking": False},
         tools=[sparklify],
     )
     # Use initial tool
@@ -252,7 +252,7 @@ def test_tool_calling_with_custom_sampler(model):
         .top_p(0.95, min_keep=2)
         .temperature(0.8)
         .dist(),
-        allow_thinking=False,
+        template_variables={"enable_thinking": False},
     )
 
     chat.ask(
@@ -378,7 +378,7 @@ def test_python_tool(model):
                 max_recursion_depth=1000,
             )
         ],
-        allow_thinking=False,
+        template_variables={"enable_thinking": False},
     )
 
     chat.ask("Use python tool to compute and print what is 42 * 42").completed()
@@ -399,7 +399,7 @@ def test_bash_tool(model):
     chat = nobodywho.Chat(
         model,
         tools=[nobodywho.bash_tool(max_commands=1000)],
-        allow_thinking=False,
+        template_variables={"enable_thinking": False},
     )
 
     # We have to be nice to the model, as it is dumb to write bash.


### PR DESCRIPTION
Change pytests to correctly use `template_variables={"enable_thinking": False}`, so we won't have to look at like 14+ warnings everytime they run

... that's it
