### PR TITLE
feat: Add rank_sync to NobodyWhoCrossEncoder Godot bindings

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2408,6 +2408,7 @@ dependencies = [
 name = "nobodywho-godot"
 version = "8.2.0"
 dependencies = [
+ "futures",
  "godot",
  "nobodywho",
  "serde_json",

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -7630,6 +7630,10 @@ rec {
         libName = "nobodywho_godot";type = [ "cdylib" ];
         dependencies = [
           {
+            name = "futures";
+            packageId = "futures";
+          }
+          {
             name = "godot";
             packageId = "godot";
             features = [ "register-docs" "experimental-threads" ];

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -1,0 +1,11 @@
+{
+  "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_ast@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
+  "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_parser@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
+  "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_trivia@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
+  "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_source_file@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
+  "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
+  "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
+  "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa",
+  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-2@0.1.143": "1n31sld7wiqsw9k1c7ncwnc1c53sysz8bsvraxc4fqhqzw1zxdzy",
+  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.143": "1n31sld7wiqsw9k1c7ncwnc1c53sysz8bsvraxc4fqhqzw1zxdzy"
+}

--- a/nobodywho/godot/Cargo.toml
+++ b/nobodywho/godot/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 nobodywho = { path = "../core" }
 godot = { version = "0.4.5", features = [ "register-docs", "experimental-threads" ] }
 tokio = "1.44.0"
+futures = "0.3.31"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 serde_json = { version = "1.0.140", features = [ "preserve_order" ] }

--- a/nobodywho/godot/integration-test/crossencoder_test.gd
+++ b/nobodywho/godot/integration-test/crossencoder_test.gd
@@ -33,5 +33,11 @@ func run_test():
 	print("✨ Got all ranked documents: " + str(all_ranked_docs))
 	
 	assert(all_ranked_docs.size() == documents.size(), "Should return all documents when limit is -1")
-	
-	return true 
+
+	# Test synchronous ranking (rank_sync) - used by tool functions which cannot use await
+	var sync_ranked_docs: PackedStringArray = rank_sync(query, documents, 4)
+	print("✨ Got sync ranked documents: " + str(sync_ranked_docs))
+	assert(sync_ranked_docs.size() == 4, "rank_sync should return exactly 4 documents")
+	assert("".join(sync_ranked_docs).contains("Paris is the capital of France"), "rank_sync: Paris is the capital of France should be in the top 4")
+
+	return true

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -1305,6 +1305,36 @@ impl NobodyWhoCrossEncoder {
         godot::builtin::Signal::from_object_signal(&self.base_mut(), "ranking_finished")
     }
 
+    #[func]
+    /// Synchronous version of `rank`. Blocks until the ranking is complete and returns the result directly.
+    /// This is useful for tool functions, which cannot use `await`.
+    ///
+    /// Parameters:
+    /// - query: The question or query to rank documents against
+    /// - documents: Array of document strings to rank
+    /// - limit: Maximum number of documents to return (-1 for all documents)
+    fn rank_sync(&mut self, query: String, documents: PackedStringArray, limit: i32) -> PackedStringArray {
+        let Some(crossencoder_handle) = &self.crossencoder_handle else {
+            godot_warn!("Worker was not started yet, starting now... You may want to call `start_worker()` ahead of time to avoid waiting.");
+            self.start_worker();
+            return self.rank_sync(query, documents, limit);
+        };
+
+        let docs_vec: Vec<String> = documents
+            .to_vec()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        match futures::executor::block_on(crossencoder_handle.rank(query, docs_vec.clone())) {
+            Ok(scores) => Self::_to_sorted_string_array(docs_vec, scores, limit),
+            Err(err) => {
+                godot_error!("Failed generating ranking: {err}");
+                PackedStringArray::new()
+            }
+        }
+    }
+
     /// takes a list of scores and documents and returns a sorted packedstring array
     fn _to_sorted_string_array(
         documents: Vec<String>,

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -1313,7 +1313,12 @@ impl NobodyWhoCrossEncoder {
     /// - query: The question or query to rank documents against
     /// - documents: Array of document strings to rank
     /// - limit: Maximum number of documents to return (-1 for all documents)
-    fn rank_sync(&mut self, query: String, documents: PackedStringArray, limit: i32) -> PackedStringArray {
+    fn rank_sync(
+        &mut self,
+        query: String,
+        documents: PackedStringArray,
+        limit: i32,
+    ) -> PackedStringArray {
         let Some(crossencoder_handle) = &self.crossencoder_handle else {
             godot_warn!("Worker was not started yet, starting now... You may want to call `start_worker()` ahead of time to avoid waiting.");
             self.start_worker();


### PR DESCRIPTION
## Description

Implements the synchronous `rank_sync` method referenced in the RAG docs but never implemented. Tool callback functions run synchronously and cannot use `await`, so the async `rank()` method fails when called from a tool. `rank_sync` uses `futures::executor::block_on` to block until ranking completes, matching the pattern in the core library.

Fixes # (issue)

#411

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Added rank_sync test to crossencoder_test.gd that verifies correct result count and content                                                                                                                                                                                                                                                                         
- cargo check -p nobodywho-godot passes with only a pre-existing deprecation warning
- Godot integration tests pass headlessly (godot --headless) 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 