### PR TITLE
fix: warmup encoder worker to prevent non-deterministic embeddings during boot

### DIFF
--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -3,7 +3,7 @@ use crate::llm;
 use crate::llm::{Worker, WorkerGuard};
 use llama_cpp_2::context::params::LlamaPoolingType;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, warn};
 
 #[derive(Clone)]
 pub struct Encoder {
@@ -38,6 +38,9 @@ impl EncoderAsync {
                     return error!(error=%errmsg, "Could not set up the worker initial state")
                 }
             };
+
+            // Warmup: force lazy backend initialization before real messages.
+            warmup_encode(&mut worker_state);
 
             while let Ok(msg) = msg_rx.recv() {
                 if let Err(e) = process_worker_msg(&mut worker_state, msg) {
@@ -78,6 +81,16 @@ fn process_worker_msg(
     }
 
     Ok(())
+}
+
+fn warmup_encode(worker_state: &mut Worker<'_, EncoderWorker>) {
+    match worker_state.read_string(" ".to_string()) {
+        Ok(w) => {
+            let _ = w.get_embedding();
+        }
+        Err(e) => warn!(error=%e, "Encoder warmup failed"),
+    }
+    worker_state.reset_context();
 }
 
 struct EncoderWorker {}

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -1,4 +1,10 @@
 {
+  "git+https://github.com/PyO3/pyo3?branch=main#0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
+  "git+https://github.com/PyO3/pyo3?branch=main#pyo3-build-config@0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
+  "git+https://github.com/PyO3/pyo3?branch=main#pyo3-ffi@0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
+  "git+https://github.com/PyO3/pyo3?branch=main#pyo3-introspection@0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
+  "git+https://github.com/PyO3/pyo3?branch=main#pyo3-macros-backend@0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
+  "git+https://github.com/PyO3/pyo3?branch=main#pyo3-macros@0.28.3": "1gpfpladcsvq180n0c0v3h354vbiiwv8m2khp9wrx7v3py1pcwkd",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_ast@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_parser@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_python_trivia@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
@@ -6,6 +12,6 @@
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
   "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-2@0.1.143": "1n31sld7wiqsw9k1c7ncwnc1c53sysz8bsvraxc4fqhqzw1zxdzy",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.143": "1n31sld7wiqsw9k1c7ncwnc1c53sysz8bsvraxc4fqhqzw1zxdzy"
+  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-2@0.1.144": "1jks316k863rjbbh2nm1fq0k3gs3f4jaaac275297l8qyp2060yl",
+  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.144": "1jks316k863rjbbh2nm1fq0k3gs3f4jaaac275297l8qyp2060yl"
 }


### PR DESCRIPTION
## Description

Add a dummy encode-decode-read cycle in the encoder worker thread before processing real messages. This forces lazy backend initialization (GPU kernel compilation, async transfer paths) to complete, preventing non-deterministic embeddings when encode() calls are chained rapidly after creating the encoder.

`llama_decode()` uses `ggml_backend_tensor_get_async()` for the GPU→CPU embedding transfer and returns without synchronizing. During the boot phase, this async transfer may not fully complete before the next encode reads the embedding buffer, producing non-deterministic results. The reporter's 100ms delay workaround confirms that exercising the backend once before real encodes makes them deterministic — this fix does the same thing by running a single-token warmup encode in the worker thread before processing real messages.      

Fixes #470                                                                                                                                                                                 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Ran all existing encoder tests with `bge-small-en-v1.5-q8_0.gguf` — all pass. The fix needs to be verified on a Windows/Vulkan machine to confirm it resolves the reporter's exact scenario.
Luckily I like Age of Empires so I have Windows PC to test this out soon, if maintainers like the this approach

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 