### PR TITLE
feat: Load sampler from GGUF

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -28,7 +28,8 @@ use crate::errors::{
     MultimodalError, RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError,
     WrappedResponseError,
 };
-use crate::llm::{self, read_sampler_from_metadata};
+use crate::llm;
+use crate::sampler_config::read_sampler_from_metadata;
 use crate::llm::{GlobalInferenceLockToken, GLOBAL_INFERENCE_LOCK};
 use crate::llm::{Worker, WorkerGuard, WriteOutput};
 use crate::sampler_config::{SamplerConfig, ShiftStep};

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -29,9 +29,9 @@ use crate::errors::{
     WrappedResponseError,
 };
 use crate::llm;
-use crate::sampler_config::read_sampler_from_metadata;
 use crate::llm::{GlobalInferenceLockToken, GLOBAL_INFERENCE_LOCK};
 use crate::llm::{Worker, WorkerGuard, WriteOutput};
+use crate::sampler_config::read_sampler_from_metadata;
 use crate::sampler_config::{SamplerConfig, ShiftStep};
 use crate::template::{select_template, ChatTemplate, ChatTemplateContext};
 use crate::tokenizer::{

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -183,7 +183,6 @@ fn read_add_bos_metadata(model: &LlamaModel) -> Result<AddBos, InitWorkerError> 
     }
 }
 
-
 #[derive(Debug)]
 pub(crate) struct Worker<'a, S> {
     pub(crate) n_past: i32,

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,6 +1,5 @@
 use crate::errors::{InitWorkerError, LoadModelError, ReadError};
 use crate::memory;
-use crate::sampler_config::SamplerConfig;
 use crate::tokenizer::{ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks};
 use lazy_static::lazy_static;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
@@ -184,22 +183,6 @@ fn read_add_bos_metadata(model: &LlamaModel) -> Result<AddBos, InitWorkerError> 
     }
 }
 
-pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerConfig> {
-    match model.meta_val_str("sampler.chain.recommended") {
-        Ok(val) => match serde_json::from_str::<SamplerConfig>(val.as_str()) {
-            Ok(sampler) => Some(sampler),
-            Err(_) => {
-                warn!(
-                    "Error parsing sampler: {}. Example of sampler serialization: {}",
-                    val.as_str(),
-                    serde_json::to_string(&SamplerConfig::default()).unwrap()
-                );
-                None
-            }
-        },
-        Err(_) => None,
-    }
-}
 
 #[derive(Debug)]
 pub(crate) struct Worker<'a, S> {

--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -373,7 +373,13 @@ pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerCo
         seq.split(';').map(str::trim).collect()
     } else {
         vec![
-            "penalties", "top_k", "top_p", "min_p", "xtc", "temp", "dist",
+            "penalties",
+            "top_k",
+            "top_p",
+            "min_p",
+            "xtc",
+            "temp",
+            "dist",
         ]
     };
 
@@ -457,7 +463,10 @@ pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerCo
                     }
                 }
             }
-            unknown => warn!("Unknown sampler step '{}' in GGUF metadata, skipping", unknown),
+            unknown => warn!(
+                "Unknown sampler step '{}' in GGUF metadata, skipping",
+                unknown
+            ),
         }
     }
 

--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -331,6 +331,142 @@ pub enum SampleStep {
     MirostatV2 { tau: f32, eta: f32 },
 }
 
+fn read_meta_f32(model: &LlamaModel, key: &str) -> Option<f32> {
+    model.meta_val_str(key).ok()?.trim().parse::<f32>().ok()
+}
+
+fn read_meta_i32(model: &LlamaModel, key: &str) -> Option<i32> {
+    model.meta_val_str(key).ok()?.trim().parse::<i32>().ok()
+}
+
+pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerConfig> {
+    let temp = read_meta_f32(model, "general.sampling.temp");
+    let top_k = read_meta_i32(model, "general.sampling.top_k");
+    let top_p = read_meta_f32(model, "general.sampling.top_p");
+    let min_p = read_meta_f32(model, "general.sampling.min_p");
+    let xtc_probability = read_meta_f32(model, "general.sampling.xtc_probability");
+    let xtc_threshold = read_meta_f32(model, "general.sampling.xtc_threshold");
+    let penalty_last_n = read_meta_i32(model, "general.sampling.penalty_last_n");
+    let penalty_repeat = read_meta_f32(model, "general.sampling.penalty_repeat");
+    let penalty_freq = read_meta_f32(model, "general.sampling.penalty_freq");
+    let penalty_present = read_meta_f32(model, "general.sampling.penalty_present");
+    let mirostat = read_meta_i32(model, "general.sampling.mirostat");
+    let mirostat_tau = read_meta_f32(model, "general.sampling.mirostat_tau");
+    let mirostat_eta = read_meta_f32(model, "general.sampling.mirostat_eta");
+
+    // Return None early if no sampling keys are present in this GGUF
+    if temp.is_none()
+        && top_k.is_none()
+        && top_p.is_none()
+        && min_p.is_none()
+        && xtc_probability.is_none()
+        && penalty_last_n.is_none()
+        && mirostat.is_none()
+    {
+        return None;
+    }
+
+    // Use sequence key if present to determine step order, otherwise fall back to llama.cpp default
+    let sequence_str = model.meta_val_str("general.sampling.sequence").ok();
+    let sampler_names: Vec<&str> = if let Some(ref seq) = sequence_str {
+        seq.split(';').map(str::trim).collect()
+    } else {
+        vec![
+            "penalties", "top_k", "top_p", "min_p", "xtc", "temp", "dist",
+        ]
+    };
+
+    let mut config = SamplerConfig::new();
+    let mut has_sample_step = false;
+
+    for name in &sampler_names {
+        match *name {
+            "temp" | "temperature" => {
+                if let Some(t) = temp {
+                    config = config.shift(ShiftStep::Temperature { temperature: t });
+                }
+            }
+            "top_k" => {
+                if let Some(k) = top_k {
+                    config = config.shift(ShiftStep::TopK { top_k: k });
+                }
+            }
+            "top_p" => {
+                if let Some(p) = top_p {
+                    config = config.shift(ShiftStep::TopP {
+                        top_p: p,
+                        min_keep: 1,
+                    });
+                }
+            }
+            "min_p" => {
+                if let Some(p) = min_p {
+                    config = config.shift(ShiftStep::MinP {
+                        min_p: p,
+                        min_keep: 1,
+                    });
+                }
+            }
+            "xtc" => {
+                if let (Some(prob), Some(thresh)) = (xtc_probability, xtc_threshold) {
+                    config = config.shift(ShiftStep::XTC {
+                        xtc_probability: prob,
+                        xtc_threshold: thresh,
+                        min_keep: 1,
+                    });
+                }
+            }
+            "penalties" | "repeat_penalty" => {
+                if penalty_last_n.is_some() || penalty_repeat.is_some() {
+                    config = config.shift(ShiftStep::Penalties {
+                        penalty_last_n: penalty_last_n.unwrap_or(64),
+                        penalty_repeat: penalty_repeat.unwrap_or(1.0),
+                        penalty_freq: penalty_freq.unwrap_or(0.0),
+                        penalty_present: penalty_present.unwrap_or(0.0),
+                    });
+                }
+            }
+            "dist" => {
+                config = config.sample(SampleStep::Dist);
+                has_sample_step = true;
+            }
+            "greedy" => {
+                config = config.sample(SampleStep::Greedy);
+                has_sample_step = true;
+            }
+            "mirostat" => {
+                if let Some(mode) = mirostat {
+                    match mode {
+                        1 => {
+                            config = config.sample(SampleStep::MirostatV1 {
+                                tau: mirostat_tau.unwrap_or(5.0),
+                                eta: mirostat_eta.unwrap_or(0.1),
+                                m: 100,
+                            });
+                            has_sample_step = true;
+                        }
+                        2 => {
+                            config = config.sample(SampleStep::MirostatV2 {
+                                tau: mirostat_tau.unwrap_or(5.0),
+                                eta: mirostat_eta.unwrap_or(0.1),
+                            });
+                            has_sample_step = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {} // Skip unknown sampler names
+        }
+    }
+
+    if !has_sample_step {
+        config = config.sample(SampleStep::Dist);
+    }
+
+    Some(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -1,6 +1,7 @@
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::sampling::LlamaSampler;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::errors::SamplerError;
 
@@ -456,7 +457,7 @@ pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerCo
                     }
                 }
             }
-            _ => {} // Skip unknown sampler names
+            unknown => warn!("Unknown sampler step '{}' in GGUF metadata, skipping", unknown),
         }
     }
 

--- a/nobodywho/flutter/nobodywho/pubspec.lock
+++ b/nobodywho/flutter/nobodywho/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -330,6 +330,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -382,18 +390,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -611,26 +619,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Adjust our code to use the GGUF sampler spec from the newly implemented [keys in llama.cpp](https://github.com/ggml-org/llama.cpp/pull/17120).