### PR TITLE
Chore/add pre commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v pre-commit &>/dev/null; then
+    echo ""
+    echo "WARNING: pre-commit is not installed. Lint and format checks will not run locally."
+    echo "Install it with:  pip install pre-commit  (or  nix-shell -p pre-commit)"
+    echo "Then run:         pre-commit install"
+    echo ""
+    exit 0
+fi
+
+exec pre-commit run --hook-stage pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,4 @@ repos:
         pass_filenames: false
         types: [python]
 
-      # Ty fucks up on a lotta pytests in general, false positives and whatnot, exclude it for now
-      # - id: ty
-      #   name: ty (type check)
-      #   language: system
-      #   entry: bash -c 'cd nobodywho/python && uvx ty check'
-      #   pass_filenames: false
-      #   types: [python]
+      # Ty fucks up on a lotta pytests in general, false positives and whatnot, thats why it is excluded

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        language: system
+        entry: bash -c 'cd nobodywho && cargo fmt --all --check'
+        pass_filenames: false
+        types: [rust]
+
+      - id: clippy
+        name: clippy
+        language: system
+        entry: bash -c 'cd nobodywho/core && cargo clippy --no-deps -- -D warnings'
+        pass_filenames: false
+        types: [rust]
+
+      - id: ruff
+        name: ruff
+        language: system
+        entry: bash -c 'cd nobodywho/python && uvx ruff check'
+        pass_filenames: false
+        types: [python]
+
+      # Ty fucks up on a lotta pytests in general, false positives and whatnot, exclude it for now
+      # - id: ty
+      #   name: ty (type check)
+      #   language: system
+      #   entry: bash -c 'cd nobodywho/python && uvx ty check'
+      #   pass_filenames: false
+      #   types: [python]


### PR DESCRIPTION
Adds pre-commit which runs rustfmt, clippy and ruff checks, which are run automatically as part of the ci anyways.

Should save at least a few commits.