### PR TITLE
on_download_progress callback

### DIFF
--- a/docs/markdown/flutter/index.md
+++ b/docs/markdown/flutter/index.md
@@ -45,6 +45,19 @@ print(msg); // Yes, indeed, water is wet!
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
+## Tracking download progress
+
+When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```dart
+final chat = await nobodywho.Chat.fromPath(
+  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+  onDownloadProgress: (downloaded, total) {
+    print('$downloaded / $total bytes');
+  },
+);
+```
+
 To get a full overview of the functionality provided by NobodyWho, simply keep reading. You can also have a look at our [flutter starter app repository](https://github.com/nobodywho-ooo/flutter-starter-example).
 
 ## Minimum recommended specs

--- a/docs/markdown/godot/getting-started.md
+++ b/docs/markdown/godot/getting-started.md
@@ -56,6 +56,18 @@ The `model_path` field (and `projection_model_path` for vision models) accepts s
 
 Remote models are downloaded to the platform cache directory on the first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
 
+### Showing download progress
+
+`NobodyWhoModel` emits a `download_progress(downloaded, total)` signal while a remote model is downloading, throttled to roughly 10 Hz with a guaranteed final emit on completion. Connect it if you'd like to drive a progress bar:
+
+```gdscript
+model.download_progress.connect(func(downloaded: int, total: int):
+    print("%d / %d bytes" % [downloaded, total])
+)
+```
+
+The signal is not emitted for local files or already-cached downloads.
+
 ### Knowing when the worker is ready
 
 `start_worker()` returns immediately. The worker finishes loading in the background (including any download). Connect to the new signals if your game logic needs to wait:

--- a/docs/markdown/python/index.md
+++ b/docs/markdown/python/index.md
@@ -35,4 +35,17 @@ print(full_response)
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
+## Tracking download progress
+
+When loading a remote model, pass an `on_download_progress` callback to observe the download. It receives `(downloaded_bytes, total_bytes)` and is not called for cached or local files. If you don't pass anything, NobodyWho prints a default terminal progress bar.
+
+```python
+from nobodywho import Model
+
+model = Model(
+    'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+    on_download_progress=lambda d, t: print(f"{d}/{t} bytes"),
+)
+```
+
 To get a full overview of the functionality provided by NobodyWho, simply keep reading.

--- a/docs/markdown/python/index.md
+++ b/docs/markdown/python/index.md
@@ -44,7 +44,7 @@ from nobodywho import Model
 
 model = Model(
     'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-    on_download_progress=lambda d, t: print(f"{d}/{t} bytes"),
+    on_download_progress=lambda downloaded, total: print(f"{downloaded}/{total} bytes"),
 )
 ```
 

--- a/docs/markdown/react-native/index.md
+++ b/docs/markdown/react-native/index.md
@@ -28,6 +28,19 @@ console.log(response); // Yes, indeed, water is wet!
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
+## Tracking download progress
+
+When loading a remote model (e.g. via a `huggingface:` or `https://` path), pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```typescript
+const chat = await Chat.fromPath({
+  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
+  onDownloadProgress: (downloaded, total) => {
+    console.log(`${downloaded} / ${total} bytes`);
+  },
+});
+```
+
 To get a full overview of the functionality provided by NobodyWho, simply keep reading.
 
 ## Android requirements

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@
           pname = "react-native-jest";
           version = "0.0.0"; # nix derivation metadata only, does not need to match the npm package version
           src = ./nobodywho/react-native;
-          npmDepsHash = "sha256-aSDOiQJ4VIk01riMXmQefbTnIc6Z95BWL0STnfg3vkk=";
+          npmDepsHash = "sha256-g33a0LC+46R+cE2f7Sqy/qzfz9h8xm/GaUp+b7Jb4Ek=";
           dontNpmBuild = true;
           checkPhase = "npx jest";
           doCheck = true;

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "gbnf",
  "gbnf-macro",
  "indexmap",
+ "indicatif",
  "lazy_static",
  "libc",
  "llama-cpp-2",
@@ -2538,7 +2539,6 @@ name = "nobodywho-python"
 version = "1.1.0"
 dependencies = [
  "futures",
- "indicatif",
  "log",
  "nobodywho",
  "nom 8.0.0",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2538,6 +2538,7 @@ name = "nobodywho-python"
 version = "1.1.0"
 dependencies = [
  "futures",
+ "indicatif",
  "log",
  "nobodywho",
  "nom 8.0.0",

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -103,6 +103,16 @@ rec {
       # File a bug if you depend on any for non-debug work!
       debug = internal.debugCrate { inherit packageId; };
     };
+    "nobodywho-uniffi" = rec {
+      packageId = "nobodywho-uniffi";
+      build = internal.buildRustCrateWithFeatures {
+        packageId = "nobodywho-uniffi";
+      };
+
+      # Debug support which might change between releases.
+      # File a bug if you depend on any for non-debug work!
+      debug = internal.debugCrate { inherit packageId; };
+    };
   };
 
 
@@ -318,7 +328,36 @@ rec {
         ];
 
       };
-      "android_logger" = rec {
+      "android_logger 0.14.1" = rec {
+        crateName = "android_logger";
+        version = "0.14.1";
+        edition = "2021";
+        sha256 = "09lqyhpzmqfhg0m4x92gdblx57q3wrk4f0dnwkra286pff77xc05";
+        authors = [
+          "The android_logger Developers"
+        ];
+        dependencies = [
+          {
+            name = "android_log-sys";
+            packageId = "android_log-sys";
+          }
+          {
+            name = "env_filter";
+            packageId = "env_filter";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "log";
+            packageId = "log";
+          }
+        ];
+        features = {
+          "default" = [ "regex" ];
+          "regex" = [ "env_filter/regex" ];
+        };
+        resolvedDefaultFeatures = [ "default" "regex" ];
+      };
+      "android_logger 0.15.1" = rec {
         crateName = "android_logger";
         version = "0.15.1";
         edition = "2021";
@@ -510,6 +549,154 @@ rec {
         features = {
           "serde" = [ "dep:serde" ];
         };
+      };
+      "askama" = rec {
+        crateName = "askama";
+        version = "0.13.1";
+        edition = "2021";
+        sha256 = "19z1zjabw7xbzf4491bwn8mdx6k8b5a8y7a43f1la9pg5vnl8isx";
+        dependencies = [
+          {
+            name = "askama_derive";
+            packageId = "askama_derive";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "itoa";
+            packageId = "itoa";
+          }
+          {
+            name = "percent-encoding";
+            packageId = "percent-encoding";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "alloc" = [ "askama_derive?/alloc" "serde?/alloc" "serde_json?/alloc" "percent-encoding?/alloc" ];
+          "askama_derive" = [ "dep:askama_derive" ];
+          "blocks" = [ "askama_derive?/blocks" ];
+          "code-in-doc" = [ "askama_derive?/code-in-doc" ];
+          "config" = [ "askama_derive?/config" ];
+          "default" = [ "config" "derive" "std" "urlencode" "askama_derive?/default" ];
+          "derive" = [ "askama_derive" ];
+          "full" = [ "default" "blocks" "code-in-doc" "serde_json" "askama_derive?/full" ];
+          "serde_json" = [ "std" "askama_derive?/serde_json" "dep:serde" "dep:serde_json" ];
+          "std" = [ "alloc" "askama_derive?/std" "serde?/std" "serde_json?/std" "percent-encoding?/std" ];
+          "urlencode" = [ "askama_derive?/urlencode" "dep:percent-encoding" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "askama_derive" "config" "derive" ];
+      };
+      "askama_derive" = rec {
+        crateName = "askama_derive";
+        version = "0.13.1";
+        edition = "2021";
+        sha256 = "1b26ijv1b3gxyalwqsgj32v0qzp6268d0y4gqha5qsp3ggsy0qfn";
+        procMacro = true;
+        dependencies = [
+          {
+            name = "askama_parser";
+            packageId = "askama_parser";
+            rename = "parser";
+          }
+          {
+            name = "basic-toml";
+            packageId = "basic-toml";
+            optional = true;
+          }
+          {
+            name = "memchr";
+            packageId = "memchr";
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "rustc-hash";
+            packageId = "rustc-hash";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            optional = true;
+          }
+          {
+            name = "serde_derive";
+            packageId = "serde_derive";
+            optional = true;
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            usesDefaultFeatures = false;
+            features = [ "clone-impls" "derive" "parsing" "printing" ];
+          }
+        ];
+        devDependencies = [
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            features = [ "full" ];
+          }
+        ];
+        features = {
+          "blocks" = [ "syn/full" ];
+          "code-in-doc" = [ "dep:pulldown-cmark" ];
+          "config" = [ "dep:basic-toml" "dep:serde" "dep:serde_derive" "parser/config" ];
+          "default" = [ "config" "derive" "std" "urlencode" ];
+          "full" = [ "default" "blocks" "code-in-doc" "serde_json" ];
+          "std" = [ "alloc" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "config" ];
+      };
+      "askama_parser" = rec {
+        crateName = "askama_parser";
+        version = "0.13.0";
+        edition = "2021";
+        sha256 = "0kqd9pg96dd6w9pm4q7zdhmchhkdrwsljygz56qpp1acabk5qcfg";
+        dependencies = [
+          {
+            name = "memchr";
+            packageId = "memchr";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            optional = true;
+          }
+          {
+            name = "serde_derive";
+            packageId = "serde_derive";
+            optional = true;
+          }
+          {
+            name = "winnow";
+            packageId = "winnow 0.7.15";
+          }
+        ];
+        features = {
+          "config" = [ "dep:serde" "dep:serde_derive" ];
+        };
+        resolvedDefaultFeatures = [ "config" ];
       };
       "async-trait" = rec {
         crateName = "async-trait";
@@ -869,6 +1056,31 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
+      "basic-toml" = rec {
+        crateName = "basic-toml";
+        version = "0.1.10";
+        edition = "2021";
+        sha256 = "12hp59jl28kk229q4sqx6v4fc9p66v8i2byi0vlc9922h9g6fqms";
+        libName = "basic_toml";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+          "David Tolnay <dtolnay@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "serde";
+            packageId = "serde";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+        ];
+
+      };
       "bindgen" = rec {
         crateName = "bindgen";
         version = "0.72.1";
@@ -884,7 +1096,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "cexpr";
@@ -1010,11 +1222,11 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
-      "bitflags 2.11.0" = rec {
+      "bitflags 2.11.1" = rec {
         crateName = "bitflags";
-        version = "2.11.0";
+        version = "2.11.1";
         edition = "2021";
-        sha256 = "1bwjibwry5nfwsfm9kjg2dqx5n5nja9xymwbfl6svnn8jsz6ff44";
+        sha256 = "1cvqijg3rvwgis20a66vfdxannjsxfy5fgjqkaq3l13gyfcj4lf4";
         authors = [
           "The Rust Project Developers"
         ];
@@ -1219,7 +1431,7 @@ rec {
         ];
 
       };
-      "cargo_metadata" = rec {
+      "cargo_metadata 0.14.2" = rec {
         crateName = "cargo_metadata";
         version = "0.14.2";
         edition = "2018";
@@ -1251,6 +1463,50 @@ rec {
             name = "serde_json";
             packageId = "serde_json";
             features = [ "unbounded_depth" ];
+          }
+        ];
+        features = {
+          "builder" = [ "derive_builder" ];
+          "derive_builder" = [ "dep:derive_builder" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "cargo_metadata 0.19.2" = rec {
+        crateName = "cargo_metadata";
+        version = "0.19.2";
+        edition = "2021";
+        sha256 = "1fkr8jp6vhva4kc3rhx13yrnl8g3zch463j20vbwa9scxlabcpnx";
+        authors = [
+          "Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"
+        ];
+        dependencies = [
+          {
+            name = "camino";
+            packageId = "camino";
+            features = [ "serde1" ];
+          }
+          {
+            name = "cargo-platform";
+            packageId = "cargo-platform";
+          }
+          {
+            name = "semver";
+            packageId = "semver";
+            features = [ "serde" ];
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+            features = [ "unbounded_depth" ];
+          }
+          {
+            name = "thiserror";
+            packageId = "thiserror 2.0.18";
           }
         ];
         features = {
@@ -1570,10 +1826,10 @@ rec {
       };
       "clap" = rec {
         crateName = "clap";
-        version = "4.6.0";
+        version = "4.6.1";
         edition = "2024";
         crateBin = [];
-        sha256 = "0l8k0ja5rf4hpn2g98bqv5m6lkh2q6b6likjpmm6fjw3cxdsz4xi";
+        sha256 = "0lcf88l7vlg796rrqr7wipbbmfa5sgsgx4211b7xmxxv8dz13nqx";
         dependencies = [
           {
             name = "clap_builder";
@@ -1608,7 +1864,7 @@ rec {
           "usage" = [ "clap_builder/usage" ];
           "wrap_help" = [ "clap_builder/wrap_help" ];
         };
-        resolvedDefaultFeatures = [ "color" "default" "derive" "error-context" "help" "std" "suggestions" "usage" ];
+        resolvedDefaultFeatures = [ "cargo" "color" "default" "derive" "error-context" "help" "std" "suggestions" "usage" ];
       };
       "clap_builder" = rec {
         crateName = "clap_builder";
@@ -1647,13 +1903,13 @@ rec {
           "unstable-v5" = [ "deprecated" ];
           "wrap_help" = [ "help" "dep:terminal_size" ];
         };
-        resolvedDefaultFeatures = [ "color" "error-context" "help" "std" "suggestions" "usage" ];
+        resolvedDefaultFeatures = [ "cargo" "color" "error-context" "help" "std" "suggestions" "usage" ];
       };
       "clap_derive" = rec {
         crateName = "clap_derive";
-        version = "4.6.0";
+        version = "4.6.1";
         edition = "2024";
-        sha256 = "0snapc468s7n3avr33dky4y7rmb7ha3qsp9l0k5vh6jacf5bs40i";
+        sha256 = "1acpz49hi00iv9jkapixjzcv7s51x8qkfaqscjm36rqgf428dkpj";
         procMacro = true;
         dependencies = [
           {
@@ -2930,7 +3186,7 @@ rec {
           }
           {
             name = "android_logger";
-            packageId = "android_logger";
+            packageId = "android_logger 0.15.1";
             optional = true;
             target = { target, features }: ("android" == target."os" or null);
           }
@@ -3081,7 +3337,7 @@ rec {
           }
           {
             name = "cargo_metadata";
-            packageId = "cargo_metadata";
+            packageId = "cargo_metadata 0.14.2";
           }
           {
             name = "cargo_toml";
@@ -3362,6 +3618,25 @@ rec {
           "with-serde-support" = [ "serde" "serde_derive" "num/serde" ];
         };
         resolvedDefaultFeatures = [ "lazy_static" "with-bigint" ];
+      };
+      "fs-err" = rec {
+        crateName = "fs-err";
+        version = "2.11.0";
+        edition = "2018";
+        sha256 = "0hdajzh5sjvvdjg0n15j91mv8ydvb7ff6m909frvdmg1bw81z948";
+        libName = "fs_err";
+        authors = [
+          "Andrew Hickman <andrew.hickman1@sky.com>"
+        ];
+        buildDependencies = [
+          {
+            name = "autocfg";
+            packageId = "autocfg";
+          }
+        ];
+        features = {
+          "tokio" = [ "dep:tokio" ];
+        };
       };
       "fsevent-sys" = rec {
         crateName = "fsevent-sys";
@@ -4170,7 +4445,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "log" ];
       };
-      "goblin" = rec {
+      "goblin 0.10.5" = rec {
         crateName = "goblin";
         version = "0.10.5";
         edition = "2024";
@@ -4196,7 +4471,7 @@ rec {
           }
           {
             name = "scroll";
-            packageId = "scroll";
+            packageId = "scroll 0.13.0";
             usesDefaultFeatures = false;
           }
         ];
@@ -4214,6 +4489,49 @@ rec {
           "te" = [ "alloc" "endian_fd" ];
         };
         resolvedDefaultFeatures = [ "alloc" "archive" "default" "elf32" "elf64" "endian_fd" "log" "mach32" "mach64" "pe32" "pe64" "std" "te" ];
+      };
+      "goblin 0.8.2" = rec {
+        crateName = "goblin";
+        version = "0.8.2";
+        edition = "2021";
+        sha256 = "0isg7yzqv7y9s4xs594niy4vqzpc7d6h58z65x06dxk5q4q3ldhv";
+        authors = [
+          "m4b <m4b.github.io@gmail.com>"
+          "seu <seu@panopticon.re>"
+          "Will Glynn <will@willglynn.com>"
+          "Philip Craig <philipjcraig@gmail.com>"
+          "Lzu Tao <taolzu@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "log";
+            packageId = "log";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "plain";
+            packageId = "plain";
+          }
+          {
+            name = "scroll";
+            packageId = "scroll 0.12.0";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "alloc" = [ "scroll/derive" "log" ];
+          "archive" = [ "alloc" ];
+          "default" = [ "std" "elf32" "elf64" "mach32" "mach64" "pe32" "pe64" "archive" "endian_fd" ];
+          "endian_fd" = [ "alloc" ];
+          "log" = [ "dep:log" ];
+          "mach32" = [ "alloc" "endian_fd" "archive" ];
+          "mach64" = [ "alloc" "endian_fd" "archive" ];
+          "pe32" = [ "alloc" "endian_fd" ];
+          "pe64" = [ "alloc" "endian_fd" ];
+          "std" = [ "alloc" "scroll/std" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "archive" "default" "elf32" "elf64" "endian_fd" "log" "mach32" "mach64" "pe32" "pe64" "std" ];
       };
       "godot" = rec {
         crateName = "godot";
@@ -5035,9 +5353,9 @@ rec {
       };
       "hyper-rustls" = rec {
         crateName = "hyper-rustls";
-        version = "0.27.8";
+        version = "0.27.9";
         edition = "2021";
-        sha256 = "0nw990f5w2jpr8nqhsyk0xz22cxkn5hdj9k89rmhvg6ls632zdf2";
+        sha256 = "03vfnsm873wsp1dk0q85nxvk7w6syp8c2m5bcdjcyfgg4786ijik";
         libName = "hyper_rustls";
         dependencies = [
           {
@@ -6731,7 +7049,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
             optional = true;
           }
           {
@@ -7074,6 +7392,26 @@ rec {
           "serde" = [ "dep:serde" ];
         };
         resolvedDefaultFeatures = [ "default" ];
+      };
+      "matchers" = rec {
+        crateName = "matchers";
+        version = "0.2.0";
+        edition = "2018";
+        sha256 = "1sasssspdj2vwcwmbq3ra18d3qniapkimfcbr47zmx6750m5llni";
+        authors = [
+          "Eliza Weisman <eliza@buoyant.io>"
+        ];
+        dependencies = [
+          {
+            name = "regex-automata";
+            packageId = "regex-automata";
+            usesDefaultFeatures = false;
+            features = [ "syntax" "dfa-build" "dfa-search" ];
+          }
+        ];
+        features = {
+          "unicode" = [ "regex-automata/unicode" ];
+        };
       };
       "md-5" = rec {
         crateName = "md-5";
@@ -7530,6 +7868,10 @@ rec {
             packageId = "indexmap";
           }
           {
+            name = "indicatif";
+            packageId = "indicatif";
+          }
+          {
             name = "lazy_static";
             packageId = "lazy_static";
           }
@@ -7571,7 +7913,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.9.3";
+            packageId = "rand 0.9.4";
           }
           {
             name = "regex";
@@ -7758,7 +8100,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.9.3";
+            packageId = "rand 0.9.4";
           }
           {
             name = "serde_json";
@@ -7778,6 +8120,66 @@ rec {
           {
             name = "tracing-subscriber";
             packageId = "tracing-subscriber";
+          }
+        ];
+
+      };
+      "nobodywho-uniffi" = rec {
+        crateName = "nobodywho-uniffi";
+        version = "0.1.0";
+        edition = "2021";
+        crateBin = [
+          {
+            name = "uniffi-bindgen";
+            path = "uniffi-bindgen.rs";
+            requiredFeatures = [ ];
+          }
+        ];
+        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./uniffi; };
+        libName = "nobodywho_uniffi";type = [ "cdylib" "staticlib" "lib" ];
+        dependencies = [
+          {
+            name = "android_logger";
+            packageId = "android_logger 0.14.1";
+          }
+          {
+            name = "log";
+            packageId = "log";
+          }
+          {
+            name = "nobodywho";
+            packageId = "nobodywho";
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+          }
+          {
+            name = "thiserror";
+            packageId = "thiserror 2.0.18";
+          }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "sync" ];
+          }
+          {
+            name = "tracing";
+            packageId = "tracing";
+          }
+          {
+            name = "tracing-log";
+            packageId = "tracing-log";
+          }
+          {
+            name = "tracing-subscriber";
+            packageId = "tracing-subscriber";
+            features = [ "fmt" "env-filter" ];
+          }
+          {
+            name = "uniffi";
+            packageId = "uniffi";
+            features = [ "cli" ];
           }
         ];
 
@@ -7806,7 +8208,7 @@ rec {
           "default" = [ "std" ];
           "std" = [ "alloc" "memchr/std" "minimal-lexical/std" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "std" ];
+        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
       };
       "nom 8.0.0" = rec {
         crateName = "nom";
@@ -7842,7 +8244,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
             target = { target, features }: ("macos" == target."os" or null);
           }
           {
@@ -8576,7 +8978,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.8.6";
             usesDefaultFeatures = false;
             features = [ "small_rng" ];
           }
@@ -8596,7 +8998,7 @@ rec {
         dependencies = [
           {
             name = "siphasher";
-            packageId = "siphasher";
+            packageId = "siphasher 1.0.2";
           }
         ];
         features = {
@@ -9126,7 +9528,7 @@ rec {
           }
           {
             name = "goblin";
-            packageId = "goblin";
+            packageId = "goblin 0.10.5";
           }
           {
             name = "serde";
@@ -9392,11 +9794,11 @@ rec {
           "rustc-dep-of-std" = [ "core" ];
         };
       };
-      "rand 0.8.5" = rec {
+      "rand 0.8.6" = rec {
         crateName = "rand";
-        version = "0.8.5";
+        version = "0.8.6";
         edition = "2018";
-        sha256 = "013l6931nn7gkc23jz5mm3qdhf93jjf0fg64nz2lp4i51qd8vbrl";
+        sha256 = "12kd4rljn86m00rcaz4c1rcya4mb4gk5ig6i8xq00a8wjgxfr82w";
         authors = [
           "The Rand Project Developers"
           "The Rust Project Developers"
@@ -9425,22 +9827,19 @@ rec {
           "default" = [ "std" "std_rng" ];
           "getrandom" = [ "rand_core/getrandom" ];
           "libc" = [ "dep:libc" ];
-          "log" = [ "dep:log" ];
-          "packed_simd" = [ "dep:packed_simd" ];
           "rand_chacha" = [ "dep:rand_chacha" ];
           "serde" = [ "dep:serde" ];
           "serde1" = [ "serde" "rand_core/serde1" ];
-          "simd_support" = [ "packed_simd" ];
           "std" = [ "rand_core/std" "rand_chacha/std" "alloc" "getrandom" "libc" ];
           "std_rng" = [ "rand_chacha" ];
         };
         resolvedDefaultFeatures = [ "alloc" "default" "getrandom" "libc" "rand_chacha" "small_rng" "std" "std_rng" ];
       };
-      "rand 0.9.3" = rec {
+      "rand 0.9.4" = rec {
         crateName = "rand";
-        version = "0.9.3";
+        version = "0.9.4";
         edition = "2021";
-        sha256 = "0rkim3hc792p968nqm9rr7yvzp8bjcx3kqz94hhiq5r599jrbh3y";
+        sha256 = "1sknbxgs6nfg0nxdd7689lwbyr2i4vaswchrv4b34z8vpc3azia4";
         authors = [
           "The Rand Project Developers"
           "The Rust Project Developers"
@@ -9594,7 +9993,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
         ];
         features = {
@@ -9616,7 +10015,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
         ];
         features = {
@@ -10246,7 +10645,7 @@ rec {
           }
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "compact_str";
@@ -10313,7 +10712,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "bstr";
@@ -10519,7 +10918,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
             usesDefaultFeatures = false;
           }
           {
@@ -10871,9 +11270,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.11";
+        version = "0.103.12";
         edition = "2021";
-        sha256 = "1m3wpj1sfnpgwd6692lf42bcjsk6mbl6dwgarkn20jzadx8sz9i0";
+        sha256 = "01nxzkfd1l96jzp04svc7iznlkarzx3wb9p63a0i17rc4y2vnyc2";
         libName = "webpki";
         dependencies = [
           {
@@ -11084,7 +11483,29 @@ rec {
           "default" = [ "use_std" ];
         };
       };
-      "scroll" = rec {
+      "scroll 0.12.0" = rec {
+        crateName = "scroll";
+        version = "0.12.0";
+        edition = "2021";
+        sha256 = "19mix9vm4k23jkknpgbi0ylmhpf2hnlpzzrfj9wqcj88lj55kf3a";
+        authors = [
+          "m4b <m4b.github.io@gmail.com>"
+          "Ted Mielczarek <ted@mielczarek.org>"
+        ];
+        dependencies = [
+          {
+            name = "scroll_derive";
+            packageId = "scroll_derive 0.12.1";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+          "derive" = [ "dep:scroll_derive" ];
+        };
+        resolvedDefaultFeatures = [ "derive" "std" ];
+      };
+      "scroll 0.13.0" = rec {
         crateName = "scroll";
         version = "0.13.0";
         edition = "2024";
@@ -11096,7 +11517,7 @@ rec {
         dependencies = [
           {
             name = "scroll_derive";
-            packageId = "scroll_derive";
+            packageId = "scroll_derive 0.13.1";
             optional = true;
           }
         ];
@@ -11106,7 +11527,34 @@ rec {
         };
         resolvedDefaultFeatures = [ "derive" "std" ];
       };
-      "scroll_derive" = rec {
+      "scroll_derive 0.12.1" = rec {
+        crateName = "scroll_derive";
+        version = "0.12.1";
+        edition = "2018";
+        sha256 = "0gb89b1yr8a6jwp4rcm00xqry6ajvmfywsm7bf5f42a686yfm0qp";
+        procMacro = true;
+        authors = [
+          "m4b <m4b.github.io@gmail.com>"
+          "Ted Mielczarek <ted@mielczarek.org>"
+          "Systemcluster <me@systemcluster.me>"
+        ];
+        dependencies = [
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+          }
+        ];
+
+      };
+      "scroll_derive 0.13.1" = rec {
         crateName = "scroll_derive";
         version = "0.13.1";
         edition = "2024";
@@ -11146,7 +11594,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "core-foundation";
@@ -11410,7 +11858,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "default" "indexmap" "preserve_order" "std" "unbounded_depth" ];
       };
-      "serde_spanned" = rec {
+      "serde_spanned 0.6.9" = rec {
         crateName = "serde_spanned";
         version = "0.6.9";
         edition = "2021";
@@ -11432,6 +11880,27 @@ rec {
           "serde" = [ "dep:serde" ];
         };
         resolvedDefaultFeatures = [ "serde" ];
+      };
+      "serde_spanned 1.1.1" = rec {
+        crateName = "serde_spanned";
+        version = "1.1.1";
+        edition = "2024";
+        sha256 = "09jzk7i6wihn3d8i3wi4j4n98ghi93c3b8m8k64nxq0ijn3vaqk6";
+        dependencies = [
+          {
+            name = "serde_core";
+            packageId = "serde_core";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "alloc" = [ "serde_core?/alloc" ];
+          "default" = [ "std" "serde" ];
+          "serde" = [ "dep:serde_core" ];
+          "std" = [ "alloc" "serde_core?/std" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "serde" "std" ];
       };
       "serde_yaml" = rec {
         crateName = "serde_yaml";
@@ -11718,7 +12187,24 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "inline" "text" ];
       };
-      "siphasher" = rec {
+      "siphasher 0.3.11" = rec {
+        crateName = "siphasher";
+        version = "0.3.11";
+        edition = "2018";
+        sha256 = "03axamhmwsrmh0psdw3gf7c0zc4fyl5yjxfifz9qfka6yhkqid9q";
+        authors = [
+          "Frank Denis <github@pureftpd.org>"
+        ];
+        features = {
+          "default" = [ "std" ];
+          "serde" = [ "dep:serde" ];
+          "serde_json" = [ "dep:serde_json" ];
+          "serde_no_std" = [ "serde/alloc" ];
+          "serde_std" = [ "std" "serde/std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "siphasher 1.0.2" = rec {
         crateName = "siphasher";
         version = "1.0.2";
         edition = "2018";
@@ -11776,6 +12262,18 @@ rec {
           "unty" = [ "dep:unty" ];
         };
         resolvedDefaultFeatures = [ "const_generics" "const_new" "serde" ];
+      };
+      "smawk" = rec {
+        crateName = "smawk";
+        version = "0.3.2";
+        edition = "2021";
+        sha256 = "0344z1la39incggwn6nl45k8cbw2x10mr5j0qz85cdz9np0qihxp";
+        authors = [
+          "Martin Geisler <martin@geisler.net>"
+        ];
+        features = {
+          "ndarray" = [ "dep:ndarray" ];
+        };
       };
       "socket2" = rec {
         crateName = "socket2";
@@ -12171,6 +12669,31 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "getrandom" ];
       };
+      "textwrap" = rec {
+        crateName = "textwrap";
+        version = "0.16.2";
+        edition = "2021";
+        sha256 = "0mrhd8q0dnh5hwbwhiv89c6i41yzmhw4clwa592rrp24b9hlfdf1";
+        authors = [
+          "Martin Geisler <martin@geisler.net>"
+        ];
+        dependencies = [
+          {
+            name = "smawk";
+            packageId = "smawk";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "unicode-linebreak" "unicode-width" "smawk" ];
+          "hyphenation" = [ "dep:hyphenation" ];
+          "smawk" = [ "dep:smawk" ];
+          "terminal_size" = [ "dep:terminal_size" ];
+          "unicode-linebreak" = [ "dep:unicode-linebreak" ];
+          "unicode-width" = [ "dep:unicode-width" ];
+        };
+        resolvedDefaultFeatures = [ "smawk" ];
+      };
       "thiserror 1.0.69" = rec {
         crateName = "thiserror";
         version = "1.0.69";
@@ -12365,9 +12888,9 @@ rec {
       };
       "tokio" = rec {
         crateName = "tokio";
-        version = "1.51.1";
+        version = "1.52.1";
         edition = "2021";
-        sha256 = "131vl4p3hdn8kpvgv6qv06lspfxj7yvk9avq7r6p4jysbicgjszn";
+        sha256 = "1imw1dkkv38p66i33m5hsyk3d6prsbyrayjvqhndjvz89ybywzdn";
         authors = [
           "Tokio Contributors <team@tokio.rs>"
         ];
@@ -12681,12 +13204,12 @@ rec {
           }
           {
             name = "serde_spanned";
-            packageId = "serde_spanned";
+            packageId = "serde_spanned 0.6.9";
             features = [ "serde" ];
           }
           {
             name = "toml_datetime";
-            packageId = "toml_datetime";
+            packageId = "toml_datetime 0.6.11";
             features = [ "serde" ];
           }
           {
@@ -12714,7 +13237,71 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "display" "parse" ];
       };
-      "toml_datetime" = rec {
+      "toml 0.9.12+spec-1.1.0" = rec {
+        crateName = "toml";
+        version = "0.9.12+spec-1.1.0";
+        edition = "2021";
+        sha256 = "0qwqbrymqn88mg2yqyq3rj52z6p20448z0jxdbpjsbpwg5g894ng";
+        dependencies = [
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
+            name = "serde_core";
+            packageId = "serde_core";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "serde_spanned";
+            packageId = "serde_spanned 1.1.1";
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "toml_datetime";
+            packageId = "toml_datetime 0.7.5+spec-1.1.0";
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "toml_parser";
+            packageId = "toml_parser";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "toml_writer";
+            packageId = "toml_writer";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
+            name = "winnow";
+            packageId = "winnow 0.7.15";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "debug" = [ "std" "toml_parser?/debug" "dep:anstream" "dep:anstyle" ];
+          "default" = [ "std" "serde" "parse" "display" ];
+          "display" = [ "dep:toml_writer" ];
+          "fast_hash" = [ "preserve_order" "dep:foldhash" ];
+          "parse" = [ "dep:toml_parser" "dep:winnow" ];
+          "preserve_order" = [ "dep:indexmap" "std" ];
+          "serde" = [ "dep:serde_core" "toml_datetime/serde" "serde_spanned/serde" ];
+          "std" = [ "indexmap?/std" "serde_core?/std" "toml_parser?/std" "toml_writer?/std" "toml_datetime/std" "serde_spanned/std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "display" "parse" "serde" "std" ];
+      };
+      "toml_datetime 0.6.11" = rec {
         crateName = "toml_datetime";
         version = "0.6.11";
         edition = "2021";
@@ -12730,6 +13317,27 @@ rec {
           "serde" = [ "dep:serde" ];
         };
         resolvedDefaultFeatures = [ "serde" ];
+      };
+      "toml_datetime 0.7.5+spec-1.1.0" = rec {
+        crateName = "toml_datetime";
+        version = "0.7.5+spec-1.1.0";
+        edition = "2021";
+        sha256 = "0iqkgvgsxmszpai53dbip7sf2igic39s4dby29dbqf1h9bnwzqcj";
+        dependencies = [
+          {
+            name = "serde_core";
+            packageId = "serde_core";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "alloc" = [ "serde_core?/alloc" ];
+          "default" = [ "std" ];
+          "serde" = [ "dep:serde_core" ];
+          "std" = [ "alloc" "serde_core?/std" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "serde" "std" ];
       };
       "toml_edit" = rec {
         crateName = "toml_edit";
@@ -12749,13 +13357,13 @@ rec {
           }
           {
             name = "serde_spanned";
-            packageId = "serde_spanned";
+            packageId = "serde_spanned 0.6.9";
             optional = true;
             features = [ "serde" ];
           }
           {
             name = "toml_datetime";
-            packageId = "toml_datetime";
+            packageId = "toml_datetime 0.6.11";
           }
           {
             name = "toml_write";
@@ -12764,7 +13372,7 @@ rec {
           }
           {
             name = "winnow";
-            packageId = "winnow";
+            packageId = "winnow 0.7.15";
             optional = true;
           }
         ];
@@ -12785,6 +13393,26 @@ rec {
         };
         resolvedDefaultFeatures = [ "display" "parse" "serde" ];
       };
+      "toml_parser" = rec {
+        crateName = "toml_parser";
+        version = "1.1.2+spec-1.1.0";
+        edition = "2024";
+        sha256 = "09kmzc55a0j21whm290wlf5a8b18a0qc87a1s8sncrckc6wfkax2";
+        dependencies = [
+          {
+            name = "winnow";
+            packageId = "winnow 1.0.1";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "debug" = [ "std" "dep:anstream" "dep:anstyle" ];
+          "default" = [ "std" ];
+          "simd" = [ "winnow/simd" ];
+          "std" = [ "alloc" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "std" ];
+      };
       "toml_write" = rec {
         crateName = "toml_write";
         version = "0.1.2";
@@ -12795,6 +13423,17 @@ rec {
           "std" = [ "alloc" ];
         };
         resolvedDefaultFeatures = [ "alloc" "default" "std" ];
+      };
+      "toml_writer" = rec {
+        crateName = "toml_writer";
+        version = "1.1.1+spec-1.1.0";
+        edition = "2024";
+        sha256 = "1nwjhvvrxz8f4ck1qi4xcz2x9qhpci37nrknhxxf9sqk22dsyvbm";
+        features = {
+          "default" = [ "std" ];
+          "std" = [ "alloc" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "std" ];
       };
       "topological-sort" = rec {
         crateName = "topological-sort";
@@ -12908,7 +13547,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "bytes";
@@ -13172,7 +13811,7 @@ rec {
           "lru" = [ "dep:lru" ];
           "std" = [ "log/std" ];
         };
-        resolvedDefaultFeatures = [ "log-tracer" "std" ];
+        resolvedDefaultFeatures = [ "default" "log-tracer" "std" ];
       };
       "tracing-subscriber" = rec {
         crateName = "tracing-subscriber";
@@ -13187,9 +13826,26 @@ rec {
         ];
         dependencies = [
           {
+            name = "matchers";
+            packageId = "matchers";
+            optional = true;
+          }
+          {
             name = "nu-ansi-term";
             packageId = "nu-ansi-term";
             optional = true;
+          }
+          {
+            name = "once_cell";
+            packageId = "once_cell";
+            optional = true;
+          }
+          {
+            name = "regex-automata";
+            packageId = "regex-automata";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "std" ];
           }
           {
             name = "sharded-slab";
@@ -13207,6 +13863,12 @@ rec {
             optional = true;
           }
           {
+            name = "tracing";
+            packageId = "tracing";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+          {
             name = "tracing-core";
             packageId = "tracing-core";
             usesDefaultFeatures = false;
@@ -13220,6 +13882,10 @@ rec {
           }
         ];
         devDependencies = [
+          {
+            name = "tracing";
+            packageId = "tracing";
+          }
           {
             name = "tracing-log";
             packageId = "tracing-log";
@@ -13252,7 +13918,7 @@ rec {
           "valuable-serde" = [ "dep:valuable-serde" ];
           "valuable_crate" = [ "dep:valuable_crate" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "ansi" "default" "fmt" "nu-ansi-term" "registry" "sharded-slab" "smallvec" "std" "thread_local" "tracing-log" ];
+        resolvedDefaultFeatures = [ "alloc" "ansi" "default" "env-filter" "fmt" "matchers" "nu-ansi-term" "once_cell" "registry" "sharded-slab" "smallvec" "std" "thread_local" "tracing" "tracing-log" ];
       };
       "try-lock" = rec {
         crateName = "try-lock";
@@ -13438,7 +14104,7 @@ rec {
           }
           {
             name = "rand";
-            packageId = "rand 0.8.5";
+            packageId = "rand 0.8.6";
           }
         ];
         features = {
@@ -13446,6 +14112,353 @@ rec {
           "timing" = [ "time" ];
         };
         resolvedDefaultFeatures = [ "default" ];
+      };
+      "uniffi" = rec {
+        crateName = "uniffi";
+        version = "0.30.0";
+        edition = "2021";
+        crateBin = [];
+        sha256 = "0kiglfqqbfr6klm3wcfx76jslb294pbv52xnd3q3sk7hqckzcrn8";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "camino";
+            packageId = "camino";
+            optional = true;
+          }
+          {
+            name = "cargo_metadata";
+            packageId = "cargo_metadata 0.19.2";
+            optional = true;
+          }
+          {
+            name = "clap";
+            packageId = "clap";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "cargo" "derive" "error-context" "help" "suggestions" "std" "usage" ];
+          }
+          {
+            name = "uniffi_bindgen";
+            packageId = "uniffi_bindgen";
+            optional = true;
+          }
+          {
+            name = "uniffi_core";
+            packageId = "uniffi_core";
+          }
+          {
+            name = "uniffi_macros";
+            packageId = "uniffi_macros";
+          }
+          {
+            name = "uniffi_pipeline";
+            packageId = "uniffi_pipeline";
+          }
+        ];
+        features = {
+          "bindgen" = [ "dep:uniffi_bindgen" ];
+          "bindgen-tests" = [ "dep:uniffi_bindgen" "uniffi_bindgen?/bindgen-tests" ];
+          "build" = [ "dep:uniffi_build" ];
+          "cargo-metadata" = [ "dep:cargo_metadata" "uniffi_bindgen?/cargo-metadata" ];
+          "cli" = [ "bindgen" "dep:clap" "dep:camino" ];
+          "default" = [ "cargo-metadata" ];
+          "ffi-trace" = [ "uniffi_core/ffi-trace" "uniffi_bindgen?/ffi-trace" ];
+          "scaffolding-ffi-buffer-fns" = [ "uniffi_core/scaffolding-ffi-buffer-fns" "uniffi_macros/scaffolding-ffi-buffer-fns" ];
+          "tokio" = [ "uniffi_core/tokio" ];
+          "wasm-unstable-single-threaded" = [ "uniffi_core/wasm-unstable-single-threaded" "uniffi_macros/wasm-unstable-single-threaded" ];
+        };
+        resolvedDefaultFeatures = [ "bindgen" "cargo-metadata" "cli" "default" ];
+      };
+      "uniffi_bindgen" = rec {
+        crateName = "uniffi_bindgen";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "19a1hlzd46si5wxwqa65jwrxlba982pm94msr3kynhbn2q0ad33w";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "askama";
+            packageId = "askama";
+            usesDefaultFeatures = false;
+            features = [ "config" "derive" "alloc" ];
+          }
+          {
+            name = "camino";
+            packageId = "camino";
+          }
+          {
+            name = "cargo_metadata";
+            packageId = "cargo_metadata 0.19.2";
+            optional = true;
+          }
+          {
+            name = "fs-err";
+            packageId = "fs-err";
+          }
+          {
+            name = "glob";
+            packageId = "glob";
+          }
+          {
+            name = "goblin";
+            packageId = "goblin 0.8.2";
+          }
+          {
+            name = "heck";
+            packageId = "heck 0.5.0";
+          }
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+            features = [ "serde" ];
+          }
+          {
+            name = "once_cell";
+            packageId = "once_cell";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "tempfile";
+            packageId = "tempfile";
+          }
+          {
+            name = "textwrap";
+            packageId = "textwrap";
+            usesDefaultFeatures = false;
+            features = [ "smawk" ];
+          }
+          {
+            name = "toml";
+            packageId = "toml 0.9.12+spec-1.1.0";
+          }
+          {
+            name = "uniffi_internal_macros";
+            packageId = "uniffi_internal_macros";
+          }
+          {
+            name = "uniffi_meta";
+            packageId = "uniffi_meta";
+          }
+          {
+            name = "uniffi_pipeline";
+            packageId = "uniffi_pipeline";
+          }
+          {
+            name = "uniffi_udl";
+            packageId = "uniffi_udl";
+          }
+        ];
+        features = {
+          "bindgen-tests" = [ "cargo-metadata" "dep:uniffi_testing" ];
+          "cargo-metadata" = [ "dep:cargo_metadata" ];
+          "default" = [ "cargo-metadata" ];
+          "ffi-trace" = [ "uniffi_testing?/ffi-trace" ];
+        };
+        resolvedDefaultFeatures = [ "cargo-metadata" "default" ];
+      };
+      "uniffi_core" = rec {
+        crateName = "uniffi_core";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "1yc9h29rj6qvw04p12w2isqnh91wxxab25hlz568zzmziq1mlyky";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "bytes";
+            packageId = "bytes";
+          }
+          {
+            name = "once_cell";
+            packageId = "once_cell";
+          }
+          {
+            name = "static_assertions";
+            packageId = "static_assertions";
+          }
+        ];
+        features = {
+          "tokio" = [ "dep:async-compat" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "uniffi_internal_macros" = rec {
+        crateName = "uniffi_internal_macros";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "1prf3nhd0k91nmx6m3fgy6jwa2na4p76ws8m41p74wvv7vwsdhp3";
+        procMacro = true;
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            features = [ "full" "visit-mut" "extra-traits" ];
+          }
+        ];
+        features = {
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "uniffi_macros" = rec {
+        crateName = "uniffi_macros";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "0hb1jgw1f04qcb1lnaizxz5vqmn6b6qcbh1vq2pr4ybcqfgk1ik4";
+        procMacro = true;
+        dependencies = [
+          {
+            name = "camino";
+            packageId = "camino";
+          }
+          {
+            name = "fs-err";
+            packageId = "fs-err";
+          }
+          {
+            name = "once_cell";
+            packageId = "once_cell";
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            features = [ "full" "visit-mut" ];
+          }
+          {
+            name = "toml";
+            packageId = "toml 0.9.12+spec-1.1.0";
+          }
+          {
+            name = "uniffi_meta";
+            packageId = "uniffi_meta";
+          }
+        ];
+        features = {
+          "trybuild" = [ "dep:uniffi_build" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "uniffi_meta" = rec {
+        crateName = "uniffi_meta";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "08nwkkgfcz0mxhmjx1g5glayxl4pkxl74j29maq1kfid74iqh4qa";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "siphasher";
+            packageId = "siphasher 0.3.11";
+          }
+          {
+            name = "uniffi_internal_macros";
+            packageId = "uniffi_internal_macros";
+          }
+          {
+            name = "uniffi_pipeline";
+            packageId = "uniffi_pipeline";
+          }
+        ];
+
+      };
+      "uniffi_pipeline" = rec {
+        crateName = "uniffi_pipeline";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "0a9c89rqk5d7qi8jxbqfli233757766273liri9qwpyj2nsw89wc";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "heck";
+            packageId = "heck 0.5.0";
+          }
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+          }
+          {
+            name = "tempfile";
+            packageId = "tempfile";
+          }
+          {
+            name = "uniffi_internal_macros";
+            packageId = "uniffi_internal_macros";
+          }
+        ];
+
+      };
+      "uniffi_udl" = rec {
+        crateName = "uniffi_udl";
+        version = "0.30.0";
+        edition = "2021";
+        sha256 = "1jmgvv7vx0il8qlmwh2x68qjbs6m47vd5xss9ypxgvlahkfsrbfh";
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "textwrap";
+            packageId = "textwrap";
+            usesDefaultFeatures = false;
+            features = [ "smawk" ];
+          }
+          {
+            name = "uniffi_meta";
+            packageId = "uniffi_meta";
+          }
+          {
+            name = "weedle2";
+            packageId = "weedle2";
+          }
+        ];
+
       };
       "unit-prefix" = rec {
         crateName = "unit-prefix";
@@ -14122,7 +15135,7 @@ rec {
         dependencies = [
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "hashbrown";
@@ -14674,9 +15687,9 @@ rec {
       };
       "webpki-root-certs" = rec {
         crateName = "webpki-root-certs";
-        version = "1.0.6";
+        version = "1.0.7";
         edition = "2021";
-        sha256 = "1jm844z3caldlsb4ycb2h7q6vw4awfdgmddmx2sgyxi6mjj1hkw0";
+        sha256 = "0b59x5mzsilk42w59nif3lfhc24pgzb0v35pi6p01qy37z7424gk";
         libName = "webpki_root_certs";
         dependencies = [
           {
@@ -14690,9 +15703,9 @@ rec {
       };
       "webpki-roots" = rec {
         crateName = "webpki-roots";
-        version = "1.0.6";
+        version = "1.0.7";
         edition = "2021";
-        sha256 = "1v8brkarm4spqkjs6y5b67xixnz4zlg33d1wwxigz4rr0qyazkr2";
+        sha256 = "17gblaqmp51znxd2c18c04k8yfnf7s77c04n6hdmzxbcr52fxxaj";
         libName = "webpki_roots";
         dependencies = [
           {
@@ -14700,6 +15713,24 @@ rec {
             packageId = "rustls-pki-types";
             rename = "pki-types";
             usesDefaultFeatures = false;
+          }
+        ];
+
+      };
+      "weedle2" = rec {
+        crateName = "weedle2";
+        version = "5.0.0";
+        edition = "2021";
+        sha256 = "03mf9r8py0za38jh35ww3lgvd0lxky2hhy26z7d8g6h9xhj2r3cr";
+        libName = "weedle";
+        authors = [
+          "Sharad Chand <sharad.d.chand@gmail.com>"
+          "Jan-Erik Rediger <jrediger@mozilla.com>"
+        ];
+        dependencies = [
+          {
+            name = "nom";
+            packageId = "nom 7.1.3";
           }
         ];
 
@@ -16392,7 +17423,7 @@ rec {
         ];
 
       };
-      "winnow" = rec {
+      "winnow 0.7.15" = rec {
         crateName = "winnow";
         version = "0.7.15";
         edition = "2021";
@@ -16413,6 +17444,22 @@ rec {
           "unstable-doc" = [ "alloc" "std" "simd" "unstable-recover" ];
         };
         resolvedDefaultFeatures = [ "alloc" "default" "std" ];
+      };
+      "winnow 1.0.1" = rec {
+        crateName = "winnow";
+        version = "1.0.1";
+        edition = "2021";
+        sha256 = "1dbji1bwviy08pl74f2qw2m4w9hc4p3vyl3lfj05jdydy59w1nh9";
+        features = {
+          "ascii" = [ "parser" ];
+          "binary" = [ "parser" ];
+          "debug" = [ "std" "dep:anstream" "dep:anstyle" "dep:is_terminal_polyfill" "dep:terminal_size" ];
+          "default" = [ "std" "ascii" "binary" ];
+          "simd" = [ "dep:memchr" ];
+          "std" = [ "alloc" "memchr?/std" ];
+          "unstable-doc" = [ "alloc" "std" "ascii" "binary" "simd" "unstable-recover" ];
+          "unstable-recover" = [ "parser" ];
+        };
       };
       "wit-bindgen" = rec {
         crateName = "wit-bindgen";
@@ -16580,7 +17627,7 @@ rec {
           }
           {
             name = "bitflags";
-            packageId = "bitflags 2.11.0";
+            packageId = "bitflags 2.11.1";
           }
           {
             name = "indexmap";

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3.31"
 ahash = "0.8.12"
 indexmap = "2.13.0"
 ureq = { version = "3", features = ["rustls"] }
+indicatif = "0.18"
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -11,7 +11,7 @@
 //! use std::sync::Arc;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let model = Arc::new(llm::get_model("model.gguf", true, None)?);
+//! let model = Arc::new(llm::get_model("model.gguf", true, None, None)?);
 //!
 //! let chat = ChatBuilder::new(model)
 //!     .with_system_prompt(Some("You are a helpful assistant"))
@@ -191,7 +191,7 @@ impl Default for ChatConfig {
 /// use std::sync::Arc;
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let model = Arc::new(llm::get_model("model.gguf", true, None)?);
+/// let model = Arc::new(llm::get_model("model.gguf", true, None, None)?);
 ///
 /// let my_tool = Tool::new(
 ///     "example".to_string(),
@@ -528,7 +528,7 @@ impl ChatHandle {
     /// # use nobodywho::chat::ChatBuilder;
     /// # use nobodywho::llm::get_model;
     /// # use std::sync::Arc;
-    /// # let model = Arc::new(get_model("model.gguf", true, None).unwrap());
+    /// # let model = Arc::new(get_model("model.gguf", true, None, None).unwrap());
     /// # let chat = ChatBuilder::new(model).build();
     /// chat.set_system_prompt(Some("You are a helpful coding assistant.".to_string()))?;
     /// # Ok::<(), nobodywho::errors::SetterError>(())
@@ -810,7 +810,7 @@ impl ChatHandleAsync {
     /// # use nobodywho::chat::ChatBuilder;
     /// # use nobodywho::llm::get_model;
     /// # use std::sync::Arc;
-    /// # let model = Arc::new(get_model("model.gguf", true, None).unwrap());
+    /// # let model = Arc::new(get_model("model.gguf", true, None, None).unwrap());
     /// # let chat = ChatBuilder::new(model).build_async();
     /// # chat.set_system_prompt(Some("You are a helpful coding assistant.".to_string())).await?;
     /// # Ok::<(), nobodywho::errors::SetterError>(())

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod test_utils {
     pub fn load_test_model() -> Arc<Model> {
         let path = test_model_path();
         Arc::new(
-            get_model(&path, true, None)
+            get_model(&path, true, None, None)
                 .unwrap_or_else(|e| panic!("Failed to load test model from {}: {:?}", path, e)),
         )
     }
@@ -76,7 +76,7 @@ pub mod test_utils {
         //      this segfault doesn't happen on nobodywho commit 94d51c5.
         //      it's most likely related to an upstream change in llama.cpp
         Arc::new(
-            get_model(&path, false, None).unwrap_or_else(|e| {
+            get_model(&path, false, None, None).unwrap_or_else(|e| {
                 panic!("Failed to load embeddings model from {}: {:?}", path, e)
             }),
         )
@@ -87,7 +87,7 @@ pub mod test_utils {
         let path = test_crossencoder_model_path();
         // Same GPU offloading note as embeddings model
         Arc::new(
-            get_model(&path, false, None).unwrap_or_else(|e| {
+            get_model(&path, false, None, None).unwrap_or_else(|e| {
                 panic!("Failed to load crossencoder model from {}: {:?}", path, e)
             }),
         )

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -76,6 +76,43 @@ pub fn default_progress_callback() -> DownloadProgressCallback {
     })
 }
 
+/// Wrap a progress callback so it fires at most ~10 Hz, with a guaranteed
+/// final emit on completion.
+///
+/// Use this when each invocation of the user-provided callback is expensive —
+/// typically because it crosses a language boundary (Dart isolate hop, JSI
+/// hop, etc.). Without throttling, a fast download (thousands of chunks/sec)
+/// would saturate the cross-language bridge. The Python binding does NOT need
+/// this since a PyO3 callable invocation is cheap; it forwards every chunk.
+///
+/// Implementation: single mutex protecting the last-emit `Instant`. Emits if
+/// `now - last >= 100ms` or if `total > 0 && downloaded >= total` (completion,
+/// so the UI never sticks at 99%).
+pub fn throttled_progress_callback<F>(callback: F) -> DownloadProgressCallback
+where
+    F: Fn(u64, u64) + Send + Sync + 'static,
+{
+    let last_emit = Arc::new(Mutex::new(None::<std::time::Instant>));
+    Arc::new(move |downloaded: u64, total: u64| {
+        let is_done = total > 0 && downloaded >= total;
+        let emit = {
+            let mut last = last_emit.lock().expect("progress mutex poisoned");
+            let due = last.map_or(true, |t: std::time::Instant| {
+                t.elapsed() >= Duration::from_millis(100)
+            });
+            if is_done || due {
+                *last = Some(std::time::Instant::now());
+                true
+            } else {
+                false
+            }
+        };
+        if emit {
+            callback(downloaded, total);
+        }
+    })
+}
+
 #[derive(Debug)]
 pub struct Model {
     pub(crate) language_model: LlamaModel,
@@ -834,4 +871,37 @@ impl<T> Drop for WorkerGuard<T> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn throttled_callback_drops_intermediate_calls_within_window() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = Arc::clone(&count);
+        let cb = throttled_progress_callback(move |_d, _t| {
+            count_inner.fetch_add(1, Ordering::Relaxed);
+        });
+
+        // First call always emits; subsequent calls within 100ms are dropped.
+        for i in 0..1000 {
+            cb(i, 10_000);
+        }
+        let n = count.load(Ordering::Relaxed);
+        assert!(n >= 1 && n <= 5, "expected 1–5 emits, got {}", n);
+    }
+
+    #[test]
+    fn throttled_callback_always_emits_on_completion() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = Arc::clone(&count);
+        let cb = throttled_progress_callback(move |_d, _t| {
+            count_inner.fetch_add(1, Ordering::Relaxed);
+        });
+
+        // First call: emits. Second call inside the window but is_done=true: emits.
+        cb(50, 100);
+        cb(100, 100);
+        assert_eq!(count.load(Ordering::Relaxed), 2);
+    }
+}

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -85,12 +85,9 @@ pub fn default_progress_callback() -> DownloadProgressCallback {
 /// would saturate the cross-language bridge. The Python binding does NOT need
 /// this since a PyO3 callable invocation is cheap; it forwards every chunk.
 ///
-/// Implementation: lock-free `AtomicU64` holding nanoseconds since a process-wide
-/// epoch. The load/check/store has a benign race (two concurrent emitters could
-/// both decide to emit within the same window) but `download_file` is
-/// single-threaded per download, and an extra emit is harmless. Emits if
-/// `now - last >= 100ms` or if `total > 0 && downloaded >= total` (completion,
-/// so the UI never sticks at 99%). 0 is the "never emitted" sentinel.
+/// Lock-free: nanoseconds since a process-wide epoch in an `AtomicU64`, with `0`
+/// as the never-emitted sentinel. The load/check/store can race, but an extra
+/// emit per ~100ms window is harmless and downloads are single-threaded anyway.
 pub fn throttled_progress_callback<F>(callback: F) -> DownloadProgressCallback
 where
     F: Fn(u64, u64) + Send + Sync + 'static,
@@ -98,7 +95,7 @@ where
     static EPOCH: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
     const THROTTLE_NS: u64 = 100_000_000;
 
-    let last_emit_ns = Arc::new(AtomicU64::new(0));
+    let last_emit_ns = AtomicU64::new(0);
     Arc::new(move |downloaded: u64, total: u64| {
         let is_done = total > 0 && downloaded >= total;
         let now_ns = EPOCH.elapsed().as_nanos() as u64;

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -97,7 +97,7 @@ where
         let is_done = total > 0 && downloaded >= total;
         let emit = {
             let mut last = last_emit.lock().expect("progress mutex poisoned");
-            let due = last.map_or(true, |t: std::time::Instant| {
+            let due = last.is_none_or(|t: std::time::Instant| {
                 t.elapsed() >= Duration::from_millis(100)
             });
             if is_done || due {

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,6 +1,7 @@
 use crate::errors::{InitWorkerError, LoadModelError, ReadError};
 use crate::memory;
 use crate::tokenizer::{ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks};
+use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaPoolingType};
@@ -12,7 +13,6 @@ use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::token::LlamaToken;
-use indicatif::{ProgressBar, ProgressStyle};
 use std::io::{Read, Write};
 use std::pin::pin;
 use std::rc::Rc;

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -16,7 +16,7 @@ use llama_cpp_2::token::LlamaToken;
 use std::io::{Read, Write};
 use std::pin::pin;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 use tracing::{debug, debug_span, error, info, info_span, warn};
@@ -85,29 +85,27 @@ pub fn default_progress_callback() -> DownloadProgressCallback {
 /// would saturate the cross-language bridge. The Python binding does NOT need
 /// this since a PyO3 callable invocation is cheap; it forwards every chunk.
 ///
-/// Implementation: single mutex protecting the last-emit `Instant`. Emits if
+/// Implementation: lock-free `AtomicU64` holding nanoseconds since a process-wide
+/// epoch. The load/check/store has a benign race (two concurrent emitters could
+/// both decide to emit within the same window) but `download_file` is
+/// single-threaded per download, and an extra emit is harmless. Emits if
 /// `now - last >= 100ms` or if `total > 0 && downloaded >= total` (completion,
-/// so the UI never sticks at 99%).
+/// so the UI never sticks at 99%). 0 is the "never emitted" sentinel.
 pub fn throttled_progress_callback<F>(callback: F) -> DownloadProgressCallback
 where
     F: Fn(u64, u64) + Send + Sync + 'static,
 {
-    let last_emit = Arc::new(Mutex::new(None::<std::time::Instant>));
+    static EPOCH: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
+    const THROTTLE_NS: u64 = 100_000_000;
+
+    let last_emit_ns = Arc::new(AtomicU64::new(0));
     Arc::new(move |downloaded: u64, total: u64| {
         let is_done = total > 0 && downloaded >= total;
-        let emit = {
-            let mut last = last_emit.lock().expect("progress mutex poisoned");
-            let due = last.is_none_or(|t: std::time::Instant| {
-                t.elapsed() >= Duration::from_millis(100)
-            });
-            if is_done || due {
-                *last = Some(std::time::Instant::now());
-                true
-            } else {
-                false
-            }
-        };
-        if emit {
+        let now_ns = EPOCH.elapsed().as_nanos() as u64;
+        let prev = last_emit_ns.load(Ordering::Relaxed);
+        let due = prev == 0 || now_ns.saturating_sub(prev) >= THROTTLE_NS;
+        if is_done || due {
+            last_emit_ns.store(now_ns, Ordering::Relaxed);
             callback(downloaded, total);
         }
     })

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -29,6 +29,13 @@ lazy_static! {
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
 
+/// Callback invoked during model downloads with `(downloaded_bytes, total_bytes)`.
+///
+/// Invoked on each read chunk from the single download thread. If the same callback
+/// is shared across concurrent downloads, the closure is responsible for its own
+/// synchronization (hence the `Sync` bound).
+pub type DownloadProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
+
 #[derive(Debug)]
 pub struct Model {
     pub(crate) language_model: LlamaModel,
@@ -130,13 +137,14 @@ fn parse_model_path(
 /// on the filesystem
 fn resolve_fancy_path_to_fs(
     parsed_path: ParsedModelPath,
+    progress: Option<&DownloadProgressCallback>,
 ) -> Result<std::path::PathBuf, LoadModelError> {
     let fs_model_path = match parsed_path {
         ParsedModelPath::HuggingFaceUrl(owner, repo, filename) => {
-            download_model_from_hf(&owner, &repo, &filename)?
+            download_model_from_hf(&owner, &repo, &filename, progress)?
         }
         ParsedModelPath::FilesystemPath(path) => path,
-        ParsedModelPath::HttpUrl(url) => download_model_from_url(&url)?,
+        ParsedModelPath::HttpUrl(url) => download_model_from_url(&url, progress)?,
     };
 
     if !fs_model_path.exists() {
@@ -148,17 +156,19 @@ fn resolve_fancy_path_to_fs(
     Ok(fs_model_path)
 }
 
-#[tracing::instrument(level = "info")]
+#[tracing::instrument(level = "info", skip(progress))]
 pub fn get_model(
     model_path: &str,
     use_gpu_if_available: bool,
     mmproj_path: Option<&str>,
+    progress: Option<DownloadProgressCallback>,
 ) -> Result<Model, LoadModelError> {
-    let real_model_path = resolve_fancy_path_to_fs(parse_model_path(model_path)?)?;
+    let real_model_path =
+        resolve_fancy_path_to_fs(parse_model_path(model_path)?, progress.as_ref())?;
     let real_mmproj_path = mmproj_path
         .map(parse_model_path) // parse inside option
         .transpose()? // return early if parse fails
-        .map(resolve_fancy_path_to_fs) // download the file if needed
+        .map(|p| resolve_fancy_path_to_fs(p, progress.as_ref())) // download the file if needed
         .transpose()?; // return early if download fails
 
     // TODO: `LlamaModelParams` uses all devices by default. Set it to an empty list once an upstream device API is available.
@@ -224,11 +234,12 @@ pub fn get_model(
 /// * The model file is not found (`LoadModelError::ModelNotFound`)
 /// * The model file is invalid or unsupported (`LoadModelError::InvalidModel`)
 /// * The communication channel closes unexpectedly (`LoadModelError::ModelChannelError`)
-#[tracing::instrument(level = "info")]
+#[tracing::instrument(level = "info", skip(progress))]
 pub async fn get_model_async(
     model_path: String,
     use_gpu_if_available: bool,
     mmproj_path: Option<String>,
+    progress: Option<DownloadProgressCallback>,
 ) -> Result<Model, LoadModelError> {
     let (output_tx, mut output_rx) = tokio::sync::mpsc::channel(4096);
     std::thread::spawn(move || {
@@ -236,6 +247,7 @@ pub async fn get_model_async(
             &model_path,
             use_gpu_if_available,
             mmproj_path.as_deref(),
+            progress,
         ))
     });
 
@@ -307,6 +319,7 @@ fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadMod
 fn download_file(
     url: &str,
     target_path: &std::path::Path,
+    progress: Option<&DownloadProgressCallback>,
 ) -> Result<(), crate::errors::LoadModelError> {
     for component in target_path.components() {
         if component == std::path::Component::ParentDir {
@@ -393,6 +406,10 @@ fn download_file(
             })?;
             downloaded += n as u64;
 
+            if let Some(cb) = progress {
+                cb(downloaded, content_length.get());
+            }
+
             let pct = (downloaded * 100) / content_length;
             if pct >= last_logged_pct + 5 {
                 info!(
@@ -437,25 +454,29 @@ fn download_model_from_hf(
     owner: &str,
     repo: &str,
     filename: &str,
+    progress: Option<&DownloadProgressCallback>,
 ) -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     let cache_dir = get_cache_dir()?;
     let target_path = cache_dir.join(owner).join(repo).join(filename);
     let url = format!("https://huggingface.co/{owner}/{repo}/resolve/main/{filename}");
-    download_file(&url, &target_path)?;
+    download_file(&url, &target_path, progress)?;
     Ok(target_path)
 }
 
 /// Download a model from a generic HTTP(S) URL and return the local path to it.
 ///
 /// The file is cached by its URL path components under the cache directory.
-fn download_model_from_url(url: &str) -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
+fn download_model_from_url(
+    url: &str,
+    progress: Option<&DownloadProgressCallback>,
+) -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     let cache_dir = get_cache_dir()?;
     // Derive a cache path from the URL: strip scheme, use the rest as path components
     let path_part = url
         .trim_start_matches("https://")
         .trim_start_matches("http://");
     let target_path = cache_dir.join("http").join(path_part);
-    download_file(url, &target_path)?;
+    download_file(url, &target_path, progress)?;
     Ok(target_path)
 }
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -12,11 +12,13 @@ use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::token::LlamaToken;
+use indicatif::{ProgressBar, ProgressStyle};
 use std::io::{Read, Write};
 use std::pin::pin;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+use std::time::Duration;
 use tracing::{debug, debug_span, error, info, info_span, warn};
 
 #[derive(Debug)]
@@ -35,6 +37,44 @@ static LLAMA_BACKEND: LazyLock<LlamaBackend> =
 /// is shared across concurrent downloads, the closure is responsible for its own
 /// synchronization (hence the `Sync` bound).
 pub type DownloadProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
+
+/// Default terminal progress bar shown when the user doesn't pass their own callback.
+///
+/// Renders an `indicatif` bar with spinner, elapsed time, wide bar, binary byte counts,
+/// throughput, and ETA. indicatif auto-disables on non-TTY stderr, so this is safe to use
+/// unconditionally — GUI bindings (Godot, Flutter mobile) won't see output in production.
+/// Detects a new download (model → mmproj transition) by watching for `total` to change,
+/// finishes the previous bar, and starts a fresh one.
+pub fn default_progress_callback() -> DownloadProgressCallback {
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} [{elapsed_precise}] {wide_bar:.cyan/blue} \
+         {binary_bytes}/{binary_total_bytes} ({binary_bytes_per_sec}, {eta})",
+    )
+    .expect("static progress bar template is valid")
+    .progress_chars("█▉▊▋▌▍▎▏ ");
+
+    let state: Arc<Mutex<(Option<ProgressBar>, u64)>> = Arc::new(Mutex::new((None, 0)));
+
+    Arc::new(move |downloaded: u64, total: u64| {
+        let mut s = state.lock().expect("progress bar mutex poisoned");
+        if s.0.is_none() || s.1 != total {
+            if let Some(old) = s.0.take() {
+                old.finish_and_clear();
+            }
+            let bar = ProgressBar::new(total);
+            bar.set_style(style.clone());
+            bar.enable_steady_tick(Duration::from_millis(100));
+            s.0 = Some(bar);
+            s.1 = total;
+        }
+        let bar = s.0.as_ref().unwrap();
+        bar.set_position(downloaded);
+        if downloaded >= total {
+            bar.finish();
+            s.0 = None;
+        }
+    })
+}
 
 #[derive(Debug)]
 pub struct Model {
@@ -137,7 +177,7 @@ fn parse_model_path(
 /// on the filesystem
 fn resolve_fancy_path_to_fs(
     parsed_path: ParsedModelPath,
-    progress: Option<&DownloadProgressCallback>,
+    progress: &DownloadProgressCallback,
 ) -> Result<std::path::PathBuf, LoadModelError> {
     let fs_model_path = match parsed_path {
         ParsedModelPath::HuggingFaceUrl(owner, repo, filename) => {
@@ -163,12 +203,12 @@ pub fn get_model(
     mmproj_path: Option<&str>,
     progress: Option<DownloadProgressCallback>,
 ) -> Result<Model, LoadModelError> {
-    let real_model_path =
-        resolve_fancy_path_to_fs(parse_model_path(model_path)?, progress.as_ref())?;
+    let progress = progress.unwrap_or_else(default_progress_callback);
+    let real_model_path = resolve_fancy_path_to_fs(parse_model_path(model_path)?, &progress)?;
     let real_mmproj_path = mmproj_path
         .map(parse_model_path) // parse inside option
         .transpose()? // return early if parse fails
-        .map(|p| resolve_fancy_path_to_fs(p, progress.as_ref())) // download the file if needed
+        .map(|p| resolve_fancy_path_to_fs(p, &progress)) // download the file if needed
         .transpose()?; // return early if download fails
 
     // TODO: `LlamaModelParams` uses all devices by default. Set it to an empty list once an upstream device API is available.
@@ -319,7 +359,7 @@ fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadMod
 fn download_file(
     url: &str,
     target_path: &std::path::Path,
-    progress: Option<&DownloadProgressCallback>,
+    progress: &DownloadProgressCallback,
 ) -> Result<(), crate::errors::LoadModelError> {
     for component in target_path.components() {
         if component == std::path::Component::ParentDir {
@@ -406,9 +446,7 @@ fn download_file(
             })?;
             downloaded += n as u64;
 
-            if let Some(cb) = progress {
-                cb(downloaded, content_length.get());
-            }
+            progress(downloaded, content_length.get());
 
             let pct = (downloaded * 100) / content_length;
             if pct >= last_logged_pct + 5 {
@@ -454,7 +492,7 @@ fn download_model_from_hf(
     owner: &str,
     repo: &str,
     filename: &str,
-    progress: Option<&DownloadProgressCallback>,
+    progress: &DownloadProgressCallback,
 ) -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     let cache_dir = get_cache_dir()?;
     let target_path = cache_dir.join(owner).join(repo).join(filename);
@@ -468,7 +506,7 @@ fn download_model_from_hf(
 /// The file is cached by its URL path components under the cache directory.
 fn download_model_from_url(
     url: &str,
-    progress: Option<&DownloadProgressCallback>,
+    progress: &DownloadProgressCallback,
 ) -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     let cache_dir = get_cache_dir()?;
     // Derive a cache path from the URL: strip scheme, use the rest as path components

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -461,7 +461,7 @@ mod tests {
     #[ignore = "requires QWEN36_MODEL env var pointing at a Qwen3.6 GGUF"]
     fn diagnose_qwen36_detection() {
         let path = std::env::var("QWEN36_MODEL").expect("set QWEN36_MODEL");
-        let model = crate::llm::get_model(&path, false, None).expect("load model");
+        let model = crate::llm::get_model(&path, false, None, None).expect("load model");
 
         let name = model
             .language_model

--- a/nobodywho/flutter/nobodywho/lib/nobodywho.dart
+++ b/nobodywho/flutter/nobodywho/lib/nobodywho.dart
@@ -11,7 +11,7 @@ export 'src/rust/lib.dart'
         newToolImpl, // Internal helper
         toolCallArgumentsJson, // Internal helper
         PromptPart, // Users should use the hand-written PromptPart sealed class
-        noopProgressCallback; // Internal default for progressCallback parameters
+        noopOnDownloadProgress; // Internal default for onDownloadProgress parameters
 export 'src/rust/frb_generated.dart' show NobodyWho;
 
 import 'src/rust/lib.dart' as nobodywho;
@@ -586,7 +586,7 @@ class Chat {
   /// [projectionModelPath] is an optional path to a `.mmproj` projection model file,
   /// required for vision/multimodal models (e.g. LLaVA, Qwen-VL).
   ///
-  /// [progressCallback] is invoked while a remote model is being downloaded
+  /// [onDownloadProgress] is invoked while a remote model is being downloaded
   /// (HuggingFace or HTTPS URLs). It receives `(downloadedBytes, totalBytes)`
   /// and is throttled in Rust to roughly 10 Hz, with mandatory emits on the
   /// first chunk, on a new file (e.g. mmproj following the model), and on
@@ -603,12 +603,12 @@ class Chat {
     List<Tool> tools = const [],
     nobodywho.SamplerConfig? sampler,
     bool useGpu = true,
-    FutureOr<void> Function(int downloaded, int total) progressCallback =
-        nobodywho.noopProgressCallback,
+    FutureOr<void> Function(int downloaded, int total) onDownloadProgress =
+        nobodywho.noopOnDownloadProgress,
   }) async {
     final chat = await nobodywho.RustChat.fromPath(
       modelPath: modelPath,
-      progressCallback: progressCallback,
+      onDownloadProgress: onDownloadProgress,
       projectionModelPath: projectionModelPath,
       systemPrompt: systemPrompt,
       contextSize: contextSize,

--- a/nobodywho/flutter/nobodywho/lib/nobodywho.dart
+++ b/nobodywho/flutter/nobodywho/lib/nobodywho.dart
@@ -10,7 +10,8 @@ export 'src/rust/lib.dart'
         RustTool, // Users should use Tool
         newToolImpl, // Internal helper
         toolCallArgumentsJson, // Internal helper
-        PromptPart; // Users should use the hand-written PromptPart sealed class
+        PromptPart, // Users should use the hand-written PromptPart sealed class
+        noopProgressCallback; // Internal default for progressCallback parameters
 export 'src/rust/frb_generated.dart' show NobodyWho;
 
 import 'src/rust/lib.dart' as nobodywho;
@@ -584,6 +585,14 @@ class Chat {
   ///
   /// [projectionModelPath] is an optional path to a `.mmproj` projection model file,
   /// required for vision/multimodal models (e.g. LLaVA, Qwen-VL).
+  ///
+  /// [progressCallback] is invoked while a remote model is being downloaded
+  /// (HuggingFace or HTTPS URLs). It receives `(downloadedBytes, totalBytes)`
+  /// and is throttled in Rust to roughly 10 Hz, with mandatory emits on the
+  /// first chunk, on a new file (e.g. mmproj following the model), and on
+  /// completion. It is not invoked for cached/local files. The callback may
+  /// be sync or async; awaiting slow work inside it will stall the download
+  /// thread.
   static Future<Chat> fromPath({
     required String modelPath,
     String? projectionModelPath,
@@ -594,9 +603,12 @@ class Chat {
     List<Tool> tools = const [],
     nobodywho.SamplerConfig? sampler,
     bool useGpu = true,
+    FutureOr<void> Function(int downloaded, int total) progressCallback =
+        nobodywho.noopProgressCallback,
   }) async {
     final chat = await nobodywho.RustChat.fromPath(
       modelPath: modelPath,
+      progressCallback: progressCallback,
       projectionModelPath: projectionModelPath,
       systemPrompt: systemPrompt,
       contextSize: contextSize,

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class NobodyWho
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1629052597;
+  int get rustContentHash => 1341680574;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -81,6 +81,8 @@ class NobodyWho
 abstract class NobodyWhoApi extends BaseApi {
   Future<CrossEncoder> crateCrossEncoderFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   });
@@ -106,6 +108,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<Encoder> crateEncoderFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   });
@@ -114,6 +118,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<Model> crateModelLoad({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     bool useGpu = true,
     String? projectionModelPath = null,
   });
@@ -130,6 +136,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<RustChat> crateRustChatFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -351,6 +359,11 @@ abstract class NobodyWhoApi extends BaseApi {
     required Map<String, String> parameterDescriptions,
   });
 
+  void crateNoopProgressCallback({
+    required PlatformInt64 downloaded,
+    required PlatformInt64 total,
+  });
+
   String crateToolCallArgumentsJson({required ToolCall toolCall});
 
   RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Asset;
@@ -510,6 +523,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<CrossEncoder> crateCrossEncoderFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   }) {
@@ -518,6 +533,10 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
+          sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+            progressCallback,
+            serializer,
+          );
           sse_encode_u_32(nCtx, serializer);
           sse_encode_bool(useGpu, serializer);
           pdeCallFfi(
@@ -533,7 +552,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateCrossEncoderFromPathConstMeta,
-        argValues: [modelPath, nCtx, useGpu],
+        argValues: [modelPath, progressCallback, nCtx, useGpu],
         apiImpl: this,
       ),
     );
@@ -541,7 +560,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
 
   TaskConstMeta get kCrateCrossEncoderFromPathConstMeta => const TaskConstMeta(
     debugName: "CrossEncoder_from_path",
-    argNames: ["modelPath", "nCtx", "useGpu"],
+    argNames: ["modelPath", "progressCallback", "nCtx", "useGpu"],
   );
 
   @override
@@ -696,6 +715,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<Encoder> crateEncoderFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   }) {
@@ -704,6 +725,10 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
+          sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+            progressCallback,
+            serializer,
+          );
           sse_encode_u_32(nCtx, serializer);
           sse_encode_bool(useGpu, serializer);
           pdeCallFfi(
@@ -719,7 +744,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateEncoderFromPathConstMeta,
-        argValues: [modelPath, nCtx, useGpu],
+        argValues: [modelPath, progressCallback, nCtx, useGpu],
         apiImpl: this,
       ),
     );
@@ -727,7 +752,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
 
   TaskConstMeta get kCrateEncoderFromPathConstMeta => const TaskConstMeta(
     debugName: "Encoder_from_path",
-    argNames: ["modelPath", "nCtx", "useGpu"],
+    argNames: ["modelPath", "progressCallback", "nCtx", "useGpu"],
   );
 
   @override
@@ -763,6 +788,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<Model> crateModelLoad({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     bool useGpu = true,
     String? projectionModelPath = null,
   }) {
@@ -771,6 +798,10 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
+          sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+            progressCallback,
+            serializer,
+          );
           sse_encode_bool(useGpu, serializer);
           sse_encode_opt_String(projectionModelPath, serializer);
           pdeCallFfi(
@@ -786,7 +817,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateModelLoadConstMeta,
-        argValues: [modelPath, useGpu, projectionModelPath],
+        argValues: [modelPath, progressCallback, useGpu, projectionModelPath],
         apiImpl: this,
       ),
     );
@@ -794,7 +825,12 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
 
   TaskConstMeta get kCrateModelLoadConstMeta => const TaskConstMeta(
     debugName: "Model_load",
-    argNames: ["modelPath", "useGpu", "projectionModelPath"],
+    argNames: [
+      "modelPath",
+      "progressCallback",
+      "useGpu",
+      "projectionModelPath",
+    ],
   );
 
   @override
@@ -866,6 +902,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<RustChat> crateRustChatFromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -880,6 +918,10 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
+          sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+            progressCallback,
+            serializer,
+          );
           sse_encode_opt_String(projectionModelPath, serializer);
           sse_encode_opt_String(systemPrompt, serializer);
           sse_encode_u_32(contextSize, serializer);
@@ -909,6 +951,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         constMeta: kCrateRustChatFromPathConstMeta,
         argValues: [
           modelPath,
+          progressCallback,
           projectionModelPath,
           systemPrompt,
           contextSize,
@@ -927,6 +970,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     debugName: "RustChat_from_path",
     argNames: [
       "modelPath",
+      "progressCallback",
       "projectionModelPath",
       "systemPrompt",
       "contextSize",
@@ -2727,6 +2771,35 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   );
 
   @override
+  void crateNoopProgressCallback({
+    required PlatformInt64 downloaded,
+    required PlatformInt64 total,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_i_64(downloaded, serializer);
+          sse_encode_i_64(total, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateNoopProgressCallbackConstMeta,
+        argValues: [downloaded, total],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateNoopProgressCallbackConstMeta => const TaskConstMeta(
+    debugName: "noop_progress_callback",
+    argNames: ["downloaded", "total"],
+  );
+
+  @override
   String crateToolCallArgumentsJson({required ToolCall toolCall}) {
     return handler.executeSync(
       SyncTask(
@@ -2736,7 +2809,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             toolCall,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2774,6 +2847,42 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       if (rawOutput != null) {
         serializer.buffer.putUint8(0);
         sse_encode_String(rawOutput.value, serializer);
+      } else {
+        serializer.buffer.putUint8(1);
+        sse_encode_AnyhowException(rawError!.value, serializer);
+      }
+      final output = serializer.intoRaw();
+
+      generalizedFrbRustBinding.dartFnDeliverOutput(
+        callId: callId,
+        ptr: output.ptr,
+        rustVecLen: output.rustVecLen,
+        dataLen: output.dataLen,
+      );
+    };
+  }
+
+  Future<void> Function(int, dynamic, dynamic)
+  encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) raw,
+  ) {
+    return (callId, rawArg0, rawArg1) async {
+      final arg0 = dco_decode_i_64(rawArg0);
+      final arg1 = dco_decode_i_64(rawArg1);
+
+      Box<void>? rawOutput;
+      Box<AnyhowException>? rawError;
+      try {
+        rawOutput = Box(await raw(arg0, arg1));
+      } catch (e, s) {
+        rawError = Box(AnyhowException("$e\n\n$s"));
+      }
+
+      final serializer = SseSerializer(generalizedFrbRustBinding);
+      assert((rawOutput != null) ^ (rawError != null));
+      if (rawOutput != null) {
+        serializer.buffer.putUint8(0);
+        sse_encode_unit(rawOutput.value, serializer);
       } else {
         serializer.buffer.putUint8(1);
         sse_encode_AnyhowException(rawError!.value, serializer);
@@ -3201,6 +3310,13 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  FutureOr<void> Function(PlatformInt64, PlatformInt64)
+  dco_decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError('');
+  }
+
+  @protected
   Object dco_decode_DartOpaque(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return decodeDartOpaque(raw, generalizedFrbRustBinding);
@@ -3445,6 +3561,12 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
+  }
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeI64(raw);
   }
 
   @protected
@@ -4344,6 +4466,12 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getPlatformInt64();
@@ -5077,6 +5205,18 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  void sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_DartOpaque(
+      encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(self),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_DartOpaque(Object self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_isize(
@@ -5419,6 +5559,12 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   void sse_encode_i_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putInt32(self);
+  }
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putPlatformInt64(self);
   }
 
   @protected

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class NobodyWho
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1341680574;
+  int get rustContentHash => -453489807;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -81,8 +81,8 @@ class NobodyWho
 abstract class NobodyWhoApi extends BaseApi {
   Future<CrossEncoder> crateCrossEncoderFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   });
@@ -108,8 +108,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<Encoder> crateEncoderFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   });
@@ -118,8 +118,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<Model> crateModelLoad({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     bool useGpu = true,
     String? projectionModelPath = null,
   });
@@ -136,8 +136,8 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<RustChat> crateRustChatFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -359,7 +359,7 @@ abstract class NobodyWhoApi extends BaseApi {
     required Map<String, String> parameterDescriptions,
   });
 
-  void crateNoopProgressCallback({
+  void crateNoopOnDownloadProgress({
     required PlatformInt64 downloaded,
     required PlatformInt64 total,
   });
@@ -523,8 +523,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<CrossEncoder> crateCrossEncoderFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   }) {
@@ -534,7 +534,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
           sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-            progressCallback,
+            onDownloadProgress,
             serializer,
           );
           sse_encode_u_32(nCtx, serializer);
@@ -552,7 +552,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateCrossEncoderFromPathConstMeta,
-        argValues: [modelPath, progressCallback, nCtx, useGpu],
+        argValues: [modelPath, onDownloadProgress, nCtx, useGpu],
         apiImpl: this,
       ),
     );
@@ -560,7 +560,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
 
   TaskConstMeta get kCrateCrossEncoderFromPathConstMeta => const TaskConstMeta(
     debugName: "CrossEncoder_from_path",
-    argNames: ["modelPath", "progressCallback", "nCtx", "useGpu"],
+    argNames: ["modelPath", "onDownloadProgress", "nCtx", "useGpu"],
   );
 
   @override
@@ -715,8 +715,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<Encoder> crateEncoderFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   }) {
@@ -726,7 +726,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
           sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-            progressCallback,
+            onDownloadProgress,
             serializer,
           );
           sse_encode_u_32(nCtx, serializer);
@@ -744,7 +744,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateEncoderFromPathConstMeta,
-        argValues: [modelPath, progressCallback, nCtx, useGpu],
+        argValues: [modelPath, onDownloadProgress, nCtx, useGpu],
         apiImpl: this,
       ),
     );
@@ -752,7 +752,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
 
   TaskConstMeta get kCrateEncoderFromPathConstMeta => const TaskConstMeta(
     debugName: "Encoder_from_path",
-    argNames: ["modelPath", "progressCallback", "nCtx", "useGpu"],
+    argNames: ["modelPath", "onDownloadProgress", "nCtx", "useGpu"],
   );
 
   @override
@@ -788,8 +788,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<Model> crateModelLoad({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     bool useGpu = true,
     String? projectionModelPath = null,
   }) {
@@ -799,7 +799,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
           sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-            progressCallback,
+            onDownloadProgress,
             serializer,
           );
           sse_encode_bool(useGpu, serializer);
@@ -817,7 +817,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateModelLoadConstMeta,
-        argValues: [modelPath, progressCallback, useGpu, projectionModelPath],
+        argValues: [modelPath, onDownloadProgress, useGpu, projectionModelPath],
         apiImpl: this,
       ),
     );
@@ -827,7 +827,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     debugName: "Model_load",
     argNames: [
       "modelPath",
-      "progressCallback",
+      "onDownloadProgress",
       "useGpu",
       "projectionModelPath",
     ],
@@ -902,8 +902,8 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   @override
   Future<RustChat> crateRustChatFromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -919,7 +919,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(modelPath, serializer);
           sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-            progressCallback,
+            onDownloadProgress,
             serializer,
           );
           sse_encode_opt_String(projectionModelPath, serializer);
@@ -951,7 +951,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         constMeta: kCrateRustChatFromPathConstMeta,
         argValues: [
           modelPath,
-          progressCallback,
+          onDownloadProgress,
           projectionModelPath,
           systemPrompt,
           contextSize,
@@ -970,7 +970,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     debugName: "RustChat_from_path",
     argNames: [
       "modelPath",
-      "progressCallback",
+      "onDownloadProgress",
       "projectionModelPath",
       "systemPrompt",
       "contextSize",
@@ -2771,7 +2771,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   );
 
   @override
-  void crateNoopProgressCallback({
+  void crateNoopOnDownloadProgress({
     required PlatformInt64 downloaded,
     required PlatformInt64 total,
   }) {
@@ -2787,17 +2787,18 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: null,
         ),
-        constMeta: kCrateNoopProgressCallbackConstMeta,
+        constMeta: kCrateNoopOnDownloadProgressConstMeta,
         argValues: [downloaded, total],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateNoopProgressCallbackConstMeta => const TaskConstMeta(
-    debugName: "noop_progress_callback",
-    argNames: ["downloaded", "total"],
-  );
+  TaskConstMeta get kCrateNoopOnDownloadProgressConstMeta =>
+      const TaskConstMeta(
+        debugName: "noop_on_download_progress",
+        argNames: ["downloaded", "total"],
+      );
 
   @override
   String crateToolCallArgumentsJson({required ToolCall toolCall}) {

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
@@ -263,6 +263,10 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   dco_decode_DartFn_Inputs_String_Output_String_AnyhowException(dynamic raw);
 
   @protected
+  FutureOr<void> Function(PlatformInt64, PlatformInt64)
+  dco_decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(dynamic raw);
+
+  @protected
   Object dco_decode_DartOpaque(dynamic raw);
 
   @protected
@@ -408,6 +412,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   int dco_decode_i_32(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
 
   @protected
   PlatformInt64 dco_decode_isize(dynamic raw);
@@ -833,6 +840,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
@@ -1148,6 +1158,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  void sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_DartOpaque(Object self, SseSerializer serializer);
 
   @protected
@@ -1321,6 +1337,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
@@ -265,6 +265,10 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   dco_decode_DartFn_Inputs_String_Output_String_AnyhowException(dynamic raw);
 
   @protected
+  FutureOr<void> Function(PlatformInt64, PlatformInt64)
+  dco_decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(dynamic raw);
+
+  @protected
   Object dco_decode_DartOpaque(dynamic raw);
 
   @protected
@@ -410,6 +414,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   int dco_decode_i_32(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
 
   @protected
   PlatformInt64 dco_decode_isize(dynamic raw);
@@ -835,6 +842,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
@@ -1150,6 +1160,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  void sse_encode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_DartOpaque(Object self, SseSerializer serializer);
 
   @protected
@@ -1323,6 +1339,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -10,12 +10,12 @@ part 'lib.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `dart_function_type_to_json_schema`, `sample_step`, `shift_step`, `wrap_progress`
 
-/// No-op default for download progress callbacks. Not meant to be called by
+/// No-op default for `onDownloadProgress` callbacks. Not meant to be called by
 /// users — it exists so we can reference it as a const tear-off in the Dart
-/// `#[frb(default = "noopProgressCallback")]` attribute (closure literals
+/// `#[frb(default = "noopOnDownloadProgress")]` attribute (closure literals
 /// aren't const in Dart, but top-level function tear-offs are).
-void noopProgressCallback(PlatformInt64 downloaded, PlatformInt64 total) =>
-    NobodyWho.instance.api.crateNoopProgressCallback(
+void noopOnDownloadProgress(PlatformInt64 downloaded, PlatformInt64 total) =>
+    NobodyWho.instance.api.crateNoopOnDownloadProgress(
       downloaded: downloaded,
       total: total,
     );
@@ -67,20 +67,20 @@ abstract class CrossEncoder implements RustOpaqueInterface {
   ///
   /// Args:
   ///     model_path: Path or URL to a GGUF cross-encoder model file.
-  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
   ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
   ///         final emit on completion. Not invoked for cached/local files.
   ///     n_ctx: Context size for the cross-encoder. Defaults to 4096.
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<CrossEncoder> fromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateCrossEncoderFromPath(
     modelPath: modelPath,
-    progressCallback: progressCallback,
+    onDownloadProgress: onDownloadProgress,
     nCtx: nCtx,
     useGpu: useGpu,
   );
@@ -110,20 +110,20 @@ abstract class Encoder implements RustOpaqueInterface {
   ///
   /// Args:
   ///     model_path: Path or URL to a GGUF embedding model file.
-  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
   ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
   ///         final emit on completion. Not invoked for cached/local files.
   ///     n_ctx: Context size for the encoder. Defaults to 4096.
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<Encoder> fromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     int nCtx = 4096,
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateEncoderFromPath(
     modelPath: modelPath,
-    progressCallback: progressCallback,
+    onDownloadProgress: onDownloadProgress,
     nCtx: nCtx,
     useGpu: useGpu,
   );
@@ -145,20 +145,20 @@ abstract class Model implements RustOpaqueInterface {
   ///
   /// Args:
   ///     model_path: Path or URL to a GGUF model file.
-  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
   ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
   ///         final emit on completion. Not invoked for cached/local files.
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   ///     projection_model_path: Optional path to a `.mmproj` file for vision/multimodal models.
   static Future<Model> load({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     bool useGpu = true,
     String? projectionModelPath = null,
   }) => NobodyWho.instance.api.crateModelLoad(
     modelPath: modelPath,
-    progressCallback: progressCallback,
+    onDownloadProgress: onDownloadProgress,
     useGpu: useGpu,
     projectionModelPath: projectionModelPath,
   );
@@ -181,7 +181,7 @@ abstract class RustChat implements RustOpaqueInterface {
   ///
   /// Args:
   ///     model_path: Path to GGUF model file
-  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
   ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
   ///         final emit on completion. Not invoked for cached/local files.
   ///     projection_model_path: Path to a .mmproj file for vision/multimodal models
@@ -192,8 +192,8 @@ abstract class RustChat implements RustOpaqueInterface {
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<RustChat> fromPath({
     required String modelPath,
-    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
-        noopProgressCallback,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
+        noopOnDownloadProgress,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -204,7 +204,7 @@ abstract class RustChat implements RustOpaqueInterface {
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateRustChatFromPath(
     modelPath: modelPath,
-    progressCallback: progressCallback,
+    onDownloadProgress: onDownloadProgress,
     projectionModelPath: projectionModelPath,
     systemPrompt: systemPrompt,
     contextSize: contextSize,

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -63,6 +63,15 @@ abstract class CompletionError implements RustOpaqueInterface {}
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CrossEncoder>>
 abstract class CrossEncoder implements RustOpaqueInterface {
+  /// Load a cross-encoder model from a local path, HuggingFace path, or HTTPS URL.
+  ///
+  /// Args:
+  ///     model_path: Path or URL to a GGUF cross-encoder model file.
+  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+  ///         final emit on completion. Not invoked for cached/local files.
+  ///     n_ctx: Context size for the cross-encoder. Defaults to 4096.
+  ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<CrossEncoder> fromPath({
     required String modelPath,
     FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
@@ -97,6 +106,15 @@ abstract class CrossEncoderWorkerError implements RustOpaqueInterface {}
 abstract class Encoder implements RustOpaqueInterface {
   Future<Float32List> encode({required String text});
 
+  /// Load an embedding model from a local path, HuggingFace path, or HTTPS URL.
+  ///
+  /// Args:
+  ///     model_path: Path or URL to a GGUF embedding model file.
+  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+  ///         final emit on completion. Not invoked for cached/local files.
+  ///     n_ctx: Context size for the encoder. Defaults to 4096.
+  ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<Encoder> fromPath({
     required String modelPath,
     FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
@@ -122,6 +140,16 @@ abstract class GetterError implements RustOpaqueInterface {}
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Model>>
 abstract class Model implements RustOpaqueInterface {
+  /// Load a model from a local path, HuggingFace path (`huggingface:owner/repo/file.gguf`),
+  /// or HTTPS URL. Remote models are downloaded and cached automatically.
+  ///
+  /// Args:
+  ///     model_path: Path or URL to a GGUF model file.
+  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+  ///         final emit on completion. Not invoked for cached/local files.
+  ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
+  ///     projection_model_path: Optional path to a `.mmproj` file for vision/multimodal models.
   static Future<Model> load({
     required String modelPath,
     FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
@@ -153,6 +181,9 @@ abstract class RustChat implements RustOpaqueInterface {
   ///
   /// Args:
   ///     model_path: Path to GGUF model file
+  ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+  ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+  ///         final emit on completion. Not invoked for cached/local files.
   ///     projection_model_path: Path to a .mmproj file for vision/multimodal models
   ///     system_prompt: System message to guide the model's behavior
   ///     context_size: Context size (maximum conversation length in tokens)

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -8,7 +8,17 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'lib.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `dart_function_type_to_json_schema`, `sample_step`, `shift_step`
+// These functions are ignored because they are not marked as `pub`: `dart_function_type_to_json_schema`, `sample_step`, `shift_step`, `wrap_progress`
+
+/// No-op default for download progress callbacks. Not meant to be called by
+/// users — it exists so we can reference it as a const tear-off in the Dart
+/// `#[frb(default = "noopProgressCallback")]` attribute (closure literals
+/// aren't const in Dart, but top-level function tear-offs are).
+void noopProgressCallback(PlatformInt64 downloaded, PlatformInt64 total) =>
+    NobodyWho.instance.api.crateNoopProgressCallback(
+      downloaded: downloaded,
+      total: total,
+    );
 
 /// Helper function to convert ToolCall arguments to a JSON string.
 /// This is needed because serde_json::Value becomes an opaque type in Dart.
@@ -55,10 +65,13 @@ abstract class CompletionError implements RustOpaqueInterface {}
 abstract class CrossEncoder implements RustOpaqueInterface {
   static Future<CrossEncoder> fromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateCrossEncoderFromPath(
     modelPath: modelPath,
+    progressCallback: progressCallback,
     nCtx: nCtx,
     useGpu: useGpu,
   );
@@ -86,10 +99,13 @@ abstract class Encoder implements RustOpaqueInterface {
 
   static Future<Encoder> fromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     int nCtx = 4096,
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateEncoderFromPath(
     modelPath: modelPath,
+    progressCallback: progressCallback,
     nCtx: nCtx,
     useGpu: useGpu,
   );
@@ -108,10 +124,13 @@ abstract class GetterError implements RustOpaqueInterface {}
 abstract class Model implements RustOpaqueInterface {
   static Future<Model> load({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     bool useGpu = true,
     String? projectionModelPath = null,
   }) => NobodyWho.instance.api.crateModelLoad(
     modelPath: modelPath,
+    progressCallback: progressCallback,
     useGpu: useGpu,
     projectionModelPath: projectionModelPath,
   );
@@ -142,6 +161,8 @@ abstract class RustChat implements RustOpaqueInterface {
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
   static Future<RustChat> fromPath({
     required String modelPath,
+    FutureOr<void> Function(PlatformInt64, PlatformInt64) progressCallback =
+        noopProgressCallback,
     String? projectionModelPath = null,
     String? systemPrompt = null,
     int contextSize = 4096,
@@ -152,6 +173,7 @@ abstract class RustChat implements RustOpaqueInterface {
     bool useGpu = true,
   }) => NobodyWho.instance.api.crateRustChatFromPath(
     modelPath: modelPath,
+    progressCallback: progressCallback,
     projectionModelPath: projectionModelPath,
     systemPrompt: systemPrompt,
     contextSize: contextSize,

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -267,6 +267,15 @@ void main() {
       print(msg); // Yes, indeed, water is wet!
     });
 
+    test('index.md:52', () async {
+      final chat = await nobodywho.Chat.fromPath(
+        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+        onDownloadProgress: (downloaded, total) {
+          print('$downloaded / $total bytes');
+        },
+      );
+    });
+
     test('sampling.md:15', () async {
       final chat = await nobodywho.Chat.fromPath(
         modelPath: "./model.gguf",

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1341680574;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -453489807;
 
 // Section: executor
 
@@ -75,9 +75,10 @@ fn wire__crate__CrossEncoder_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
-            );
+            let api_on_download_progress =
+                decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                    <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+                );
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -85,7 +86,7 @@ fn wire__crate__CrossEncoder_from_path_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::CrossEncoder::from_path(
                         &api_model_path,
-                        api_progress_callback,
+                        api_on_download_progress,
                         api_n_ctx,
                         api_use_gpu,
                     )?;
@@ -343,9 +344,10 @@ fn wire__crate__Encoder_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
-            );
+            let api_on_download_progress =
+                decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                    <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+                );
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -353,7 +355,7 @@ fn wire__crate__Encoder_from_path_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::Encoder::from_path(
                         &api_model_path,
-                        api_progress_callback,
+                        api_on_download_progress,
                         api_n_ctx,
                         api_use_gpu,
                     )?;
@@ -434,9 +436,10 @@ fn wire__crate__Model_load_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
-            );
+            let api_on_download_progress =
+                decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                    <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+                );
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             let api_projection_model_path = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -444,7 +447,7 @@ fn wire__crate__Model_load_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::Model::load(
                         &api_model_path,
-                        api_progress_callback,
+                        api_on_download_progress,
                         api_use_gpu,
                         api_projection_model_path,
                     )?;
@@ -575,9 +578,10 @@ fn wire__crate__RustChat_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
-                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
-            );
+            let api_on_download_progress =
+                decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                    <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+                );
             let api_projection_model_path = <Option<String>>::sse_decode(&mut deserializer);
             let api_system_prompt = <Option<String>>::sse_decode(&mut deserializer);
             let api_context_size = <u32>::sse_decode(&mut deserializer);
@@ -592,7 +596,7 @@ fn wire__crate__RustChat_from_path_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::RustChat::from_path(
                         &api_model_path,
-                        api_progress_callback,
+                        api_on_download_progress,
                         api_projection_model_path,
                         api_system_prompt,
                         api_context_size,
@@ -3078,14 +3082,14 @@ fn wire__crate__new_tool_impl_impl(
         },
     )
 }
-fn wire__crate__noop_progress_callback_impl(
+fn wire__crate__noop_on_download_progress_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "noop_progress_callback",
+            debug_name: "noop_on_download_progress",
             port: None,
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
@@ -3104,7 +3108,7 @@ fn wire__crate__noop_progress_callback_impl(
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok({
-                    crate::noop_progress_callback(api__downloaded, api__total);
+                    crate::noop_on_download_progress(api__downloaded, api__total);
                 })?;
                 Ok(output_ok)
             })())
@@ -4170,7 +4174,7 @@ fn pde_ffi_dispatcher_sync_impl(
         61 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
         62 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
         63 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__noop_progress_callback_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__noop_on_download_progress_impl(ptr, rust_vec_len, data_len),
         65 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1629052597;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1341680574;
 
 // Section: executor
 
@@ -75,13 +75,20 @@ fn wire__crate__CrossEncoder_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
+            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+            );
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::CrossEncoder::from_path(&api_model_path, api_n_ctx, api_use_gpu)?;
+                    let output_ok = crate::CrossEncoder::from_path(
+                        &api_model_path,
+                        api_progress_callback,
+                        api_n_ctx,
+                        api_use_gpu,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -336,13 +343,20 @@ fn wire__crate__Encoder_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
+            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+            );
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::Encoder::from_path(&api_model_path, api_n_ctx, api_use_gpu)?;
+                    let output_ok = crate::Encoder::from_path(
+                        &api_model_path,
+                        api_progress_callback,
+                        api_n_ctx,
+                        api_use_gpu,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -420,6 +434,9 @@ fn wire__crate__Model_load_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
+            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+            );
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             let api_projection_model_path = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -427,6 +444,7 @@ fn wire__crate__Model_load_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::Model::load(
                         &api_model_path,
+                        api_progress_callback,
                         api_use_gpu,
                         api_projection_model_path,
                     )?;
@@ -557,6 +575,9 @@ fn wire__crate__RustChat_from_path_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_model_path = <String>::sse_decode(&mut deserializer);
+            let api_progress_callback = decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+                <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
+            );
             let api_projection_model_path = <Option<String>>::sse_decode(&mut deserializer);
             let api_system_prompt = <Option<String>>::sse_decode(&mut deserializer);
             let api_context_size = <u32>::sse_decode(&mut deserializer);
@@ -571,6 +592,7 @@ fn wire__crate__RustChat_from_path_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::RustChat::from_path(
                         &api_model_path,
+                        api_progress_callback,
                         api_projection_model_path,
                         api_system_prompt,
                         api_context_size,
@@ -3056,6 +3078,39 @@ fn wire__crate__new_tool_impl_impl(
         },
     )
 }
+fn wire__crate__noop_progress_callback_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "noop_progress_callback",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api__downloaded = <i64>::sse_decode(&mut deserializer);
+            let api__total = <i64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::noop_progress_callback(api__downloaded, api__total);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__tool_call_arguments_json_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -3169,6 +3224,42 @@ fn decode_DartFn_Inputs_String_Output_String_AnyhowException(
         flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
             dart_opaque.clone(),
             arg0,
+        ))
+    }
+}
+fn decode_DartFn_Inputs_i_64_i_64_Output_unit_AnyhowException(
+    dart_opaque: flutter_rust_bridge::DartOpaque,
+) -> impl Fn(i64, i64) -> flutter_rust_bridge::DartFnFuture<()> {
+    use flutter_rust_bridge::IntoDart;
+
+    async fn body(dart_opaque: flutter_rust_bridge::DartOpaque, arg0: i64, arg1: i64) -> () {
+        let args = vec![
+            arg0.into_into_dart().into_dart(),
+            arg1.into_into_dart().into_dart(),
+        ];
+        let message = FLUTTER_RUST_BRIDGE_HANDLER
+            .dart_fn_invoke(dart_opaque, args)
+            .await;
+
+        let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+        let action = deserializer.cursor.read_u8().unwrap();
+        let ans = match action {
+            0 => std::result::Result::Ok(<()>::sse_decode(&mut deserializer)),
+            1 => std::result::Result::Err(
+                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
+            ),
+            _ => unreachable!(),
+        };
+        deserializer.end();
+        let ans = ans.expect("Dart throws exception but Rust side assume it is not failable");
+        ans
+    }
+
+    move |arg0: i64, arg1: i64| {
+        flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
+            dart_opaque.clone(),
+            arg0,
+            arg1,
         ))
     }
 }
@@ -3652,6 +3743,13 @@ impl SseDecode for i32 {
     }
 }
 
+impl SseDecode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_i64::<NativeEndian>().unwrap()
+    }
+}
+
 impl SseDecode for isize {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4072,7 +4170,8 @@ fn pde_ffi_dispatcher_sync_impl(
         61 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
         62 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
         63 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__noop_progress_callback_impl(ptr, rust_vec_len, data_len),
+        65 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -4845,6 +4944,13 @@ impl SseEncode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_i32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_i64::<NativeEndian>(self).unwrap();
     }
 }
 

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -19,12 +19,12 @@ pub enum PromptPart {
     Audio { path: String },
 }
 
-/// No-op default for download progress callbacks. Not meant to be called by
+/// No-op default for `onDownloadProgress` callbacks. Not meant to be called by
 /// users — it exists so we can reference it as a const tear-off in the Dart
-/// `#[frb(default = "noopProgressCallback")]` attribute (closure literals
+/// `#[frb(default = "noopOnDownloadProgress")]` attribute (closure literals
 /// aren't const in Dart, but top-level function tear-offs are).
 #[flutter_rust_bridge::frb(sync, positional)]
-pub fn noop_progress_callback(_downloaded: i64, _total: i64) {}
+pub fn noop_on_download_progress(_downloaded: i64, _total: i64) {}
 
 /// Bridge a Dart async progress callback into the synchronous closure core
 /// expects, with ~10 Hz throttling provided by `throttled_progress_callback`.
@@ -92,7 +92,7 @@ impl Model {
     ///
     /// Args:
     ///     model_path: Path or URL to a GGUF model file.
-    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
     ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
     ///         final emit on completion. Not invoked for cached/local files.
     ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
@@ -100,7 +100,7 @@ impl Model {
     #[flutter_rust_bridge::frb]
     pub fn load(
         model_path: &str,
-        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+        #[frb(default = "noopOnDownloadProgress")] on_download_progress: impl Fn(i64, i64) -> DartFnFuture<()>
             + Send
             + Sync
             + 'static,
@@ -111,7 +111,7 @@ impl Model {
             model_path,
             use_gpu,
             projection_model_path.as_deref(),
-            Some(wrap_progress(progress_callback)),
+            Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| e.to_string())?;
         Ok(Self {
@@ -177,7 +177,7 @@ impl RustChat {
     ///
     /// Args:
     ///     model_path: Path to GGUF model file
-    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
     ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
     ///         final emit on completion. Not invoked for cached/local files.
     ///     projection_model_path: Path to a .mmproj file for vision/multimodal models
@@ -190,7 +190,7 @@ impl RustChat {
     #[allow(clippy::too_many_arguments)]
     pub fn from_path(
         model_path: &str,
-        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+        #[frb(default = "noopOnDownloadProgress")] on_download_progress: impl Fn(i64, i64) -> DartFnFuture<()>
             + Send
             + Sync
             + 'static,
@@ -207,7 +207,7 @@ impl RustChat {
             model_path,
             use_gpu,
             projection_model_path.as_deref(),
-            Some(wrap_progress(progress_callback)),
+            Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| e.to_string())?;
         let sampler_config = sampler.map(|s| s.sampler_config).unwrap_or_default();
@@ -402,7 +402,7 @@ impl Encoder {
     ///
     /// Args:
     ///     model_path: Path or URL to a GGUF embedding model file.
-    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
     ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
     ///         final emit on completion. Not invoked for cached/local files.
     ///     n_ctx: Context size for the encoder. Defaults to 4096.
@@ -410,7 +410,7 @@ impl Encoder {
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,
-        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+        #[frb(default = "noopOnDownloadProgress")] on_download_progress: impl Fn(i64, i64) -> DartFnFuture<()>
             + Send
             + Sync
             + 'static,
@@ -421,7 +421,7 @@ impl Encoder {
             model_path,
             use_gpu,
             None,
-            Some(wrap_progress(progress_callback)),
+            Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| e.to_string())?;
         let handle = nobodywho::encoder::EncoderAsync::new(Arc::new(model), n_ctx);
@@ -454,7 +454,7 @@ impl CrossEncoder {
     ///
     /// Args:
     ///     model_path: Path or URL to a GGUF cross-encoder model file.
-    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///     on_download_progress: Invoked with `(downloadedBytes, totalBytes)` while a
     ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
     ///         final emit on completion. Not invoked for cached/local files.
     ///     n_ctx: Context size for the cross-encoder. Defaults to 4096.
@@ -462,7 +462,7 @@ impl CrossEncoder {
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,
-        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+        #[frb(default = "noopOnDownloadProgress")] on_download_progress: impl Fn(i64, i64) -> DartFnFuture<()>
             + Send
             + Sync
             + 'static,
@@ -473,7 +473,7 @@ impl CrossEncoder {
             model_path,
             use_gpu,
             None,
-            Some(wrap_progress(progress_callback)),
+            Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| e.to_string())?;
         let handle = nobodywho::crossencoder::CrossEncoderAsync::new(Arc::new(model), n_ctx);

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -108,6 +108,16 @@ pub struct Model {
 }
 
 impl Model {
+    /// Load a model from a local path, HuggingFace path (`huggingface:owner/repo/file.gguf`),
+    /// or HTTPS URL. Remote models are downloaded and cached automatically.
+    ///
+    /// Args:
+    ///     model_path: Path or URL to a GGUF model file.
+    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+    ///         final emit on completion. Not invoked for cached/local files.
+    ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
+    ///     projection_model_path: Optional path to a `.mmproj` file for vision/multimodal models.
     #[flutter_rust_bridge::frb]
     pub fn load(
         model_path: &str,
@@ -188,6 +198,9 @@ impl RustChat {
     ///
     /// Args:
     ///     model_path: Path to GGUF model file
+    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+    ///         final emit on completion. Not invoked for cached/local files.
     ///     projection_model_path: Path to a .mmproj file for vision/multimodal models
     ///     system_prompt: System message to guide the model's behavior
     ///     context_size: Context size (maximum conversation length in tokens)
@@ -406,6 +419,15 @@ impl Encoder {
         Self { handle }
     }
 
+    /// Load an embedding model from a local path, HuggingFace path, or HTTPS URL.
+    ///
+    /// Args:
+    ///     model_path: Path or URL to a GGUF embedding model file.
+    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+    ///         final emit on completion. Not invoked for cached/local files.
+    ///     n_ctx: Context size for the encoder. Defaults to 4096.
+    ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,
@@ -449,6 +471,15 @@ impl CrossEncoder {
         Self { handle }
     }
 
+    /// Load a cross-encoder model from a local path, HuggingFace path, or HTTPS URL.
+    ///
+    /// Args:
+    ///     model_path: Path or URL to a GGUF cross-encoder model file.
+    ///     progress_callback: Invoked with `(downloadedBytes, totalBytes)` while a
+    ///         remote model is being downloaded. Throttled to ~10 Hz with a guaranteed
+    ///         final emit on completion. Not invoked for cached/local files.
+    ///     n_ctx: Context size for the cross-encoder. Defaults to 4096.
+    ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -72,7 +72,7 @@ impl Model {
         #[frb(default = "null")] projection_model_path: Option<String>,
     ) -> Result<Self, String> {
         let model =
-            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref())
+            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref(), None)
                 .map_err(|e| e.to_string())?;
         Ok(Self {
             model: Arc::new(model),
@@ -157,7 +157,7 @@ impl RustChat {
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
         let model =
-            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref())
+            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref(), None)
                 .map_err(|e| e.to_string())?;
         let sampler_config = sampler.map(|s| s.sampler_config).unwrap_or_default();
 
@@ -354,7 +354,7 @@ impl Encoder {
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
         let model =
-            nobodywho::llm::get_model(model_path, use_gpu, None).map_err(|e| e.to_string())?;
+            nobodywho::llm::get_model(model_path, use_gpu, None, None).map_err(|e| e.to_string())?;
         let handle = nobodywho::encoder::EncoderAsync::new(Arc::new(model), n_ctx);
 
         Ok(Self { handle })
@@ -388,7 +388,7 @@ impl CrossEncoder {
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
         let model =
-            nobodywho::llm::get_model(model_path, use_gpu, None).map_err(|e| e.to_string())?;
+            nobodywho::llm::get_model(model_path, use_gpu, None, None).map_err(|e| e.to_string())?;
         let handle = nobodywho::crossencoder::CrossEncoderAsync::new(Arc::new(model), n_ctx);
         Ok(Self { handle })
     }

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -19,6 +19,49 @@ pub enum PromptPart {
     Audio { path: String },
 }
 
+/// No-op default for download progress callbacks. Not meant to be called by
+/// users — it exists so we can reference it as a const tear-off in the Dart
+/// `#[frb(default = "noopProgressCallback")]` attribute (closure literals
+/// aren't const in Dart, but top-level function tear-offs are).
+#[flutter_rust_bridge::frb(sync, positional)]
+pub fn noop_progress_callback(_downloaded: i64, _total: i64) {}
+
+/// Wrap a Dart async progress callback into the synchronous closure that core's
+/// `download_file` expects.
+///
+/// Core fires the inner callback per chunk (potentially thousands of times per
+/// second on fast networks). Each Dart round-trip via `block_on` costs a Dart
+/// isolate event-loop hop, so we sample the stream at ~10 Hz, plus an extra
+/// emit on completion so the UI never sticks at 99%.
+///
+/// The Dart callback takes `(i64, i64)` rather than `(u64, u64)` so that frb
+/// generates a plain `int` Dart parameter; i64::MAX is ~9.2 EB which is far
+/// beyond any practical model file size.
+fn wrap_progress<F>(callback: F) -> nobodywho::llm::DownloadProgressCallback
+where
+    F: Fn(i64, i64) -> flutter_rust_bridge::DartFnFuture<()> + Send + Sync + 'static,
+{
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+    let last_emit = Arc::new(Mutex::new(None::<Instant>));
+    Arc::new(move |downloaded: u64, total: u64| {
+        let is_done = total > 0 && downloaded >= total;
+        let emit = {
+            let mut last = last_emit.lock().expect("progress state mutex poisoned");
+            let due = last.map_or(true, |t| t.elapsed() >= Duration::from_millis(100));
+            if is_done || due {
+                *last = Some(Instant::now());
+                true
+            } else {
+                false
+            }
+        };
+        if emit {
+            futures::executor::block_on(callback(downloaded as i64, total as i64));
+        }
+    })
+}
+
 #[flutter_rust_bridge::frb(mirror(ToolCall))]
 pub struct _ToolCall {
     pub name: String,
@@ -68,12 +111,20 @@ impl Model {
     #[flutter_rust_bridge::frb]
     pub fn load(
         model_path: &str,
+        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+            + Send
+            + Sync
+            + 'static,
         #[frb(default = true)] use_gpu: bool,
         #[frb(default = "null")] projection_model_path: Option<String>,
     ) -> Result<Self, String> {
-        let model =
-            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref(), None)
-                .map_err(|e| e.to_string())?;
+        let model = nobodywho::llm::get_model(
+            model_path,
+            use_gpu,
+            projection_model_path.as_deref(),
+            Some(wrap_progress(progress_callback)),
+        )
+        .map_err(|e| e.to_string())?;
         Ok(Self {
             model: Arc::new(model),
         })
@@ -147,6 +198,10 @@ impl RustChat {
     #[allow(clippy::too_many_arguments)]
     pub fn from_path(
         model_path: &str,
+        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+            + Send
+            + Sync
+            + 'static,
         #[frb(default = "null")] projection_model_path: Option<String>,
         #[frb(default = "null")] system_prompt: Option<String>,
         #[frb(default = 4096)] context_size: u32,
@@ -156,9 +211,13 @@ impl RustChat {
         #[frb(default = "null")] sampler: Option<SamplerConfig>,
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
-        let model =
-            nobodywho::llm::get_model(model_path, use_gpu, projection_model_path.as_deref(), None)
-                .map_err(|e| e.to_string())?;
+        let model = nobodywho::llm::get_model(
+            model_path,
+            use_gpu,
+            projection_model_path.as_deref(),
+            Some(wrap_progress(progress_callback)),
+        )
+        .map_err(|e| e.to_string())?;
         let sampler_config = sampler.map(|s| s.sampler_config).unwrap_or_default();
 
         // Handle deprecated allow_thinking parameter
@@ -350,11 +409,20 @@ impl Encoder {
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,
+        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+            + Send
+            + Sync
+            + 'static,
         #[frb(default = 4096)] n_ctx: u32,
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
-        let model =
-            nobodywho::llm::get_model(model_path, use_gpu, None, None).map_err(|e| e.to_string())?;
+        let model = nobodywho::llm::get_model(
+            model_path,
+            use_gpu,
+            None,
+            Some(wrap_progress(progress_callback)),
+        )
+        .map_err(|e| e.to_string())?;
         let handle = nobodywho::encoder::EncoderAsync::new(Arc::new(model), n_ctx);
 
         Ok(Self { handle })
@@ -384,11 +452,20 @@ impl CrossEncoder {
     #[flutter_rust_bridge::frb]
     pub fn from_path(
         model_path: &str,
+        #[frb(default = "noopProgressCallback")] progress_callback: impl Fn(i64, i64) -> DartFnFuture<()>
+            + Send
+            + Sync
+            + 'static,
         #[frb(default = 4096)] n_ctx: u32,
         #[frb(default = true)] use_gpu: bool,
     ) -> Result<Self, String> {
-        let model =
-            nobodywho::llm::get_model(model_path, use_gpu, None, None).map_err(|e| e.to_string())?;
+        let model = nobodywho::llm::get_model(
+            model_path,
+            use_gpu,
+            None,
+            Some(wrap_progress(progress_callback)),
+        )
+        .map_err(|e| e.to_string())?;
         let handle = nobodywho::crossencoder::CrossEncoderAsync::new(Arc::new(model), n_ctx);
         Ok(Self { handle })
     }

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -26,13 +26,8 @@ pub enum PromptPart {
 #[flutter_rust_bridge::frb(sync, positional)]
 pub fn noop_progress_callback(_downloaded: i64, _total: i64) {}
 
-/// Wrap a Dart async progress callback into the synchronous closure that core's
-/// `download_file` expects.
-///
-/// Core fires the inner callback per chunk (potentially thousands of times per
-/// second on fast networks). Each Dart round-trip via `block_on` costs a Dart
-/// isolate event-loop hop, so we sample the stream at ~10 Hz, plus an extra
-/// emit on completion so the UI never sticks at 99%.
+/// Bridge a Dart async progress callback into the synchronous closure core
+/// expects, with ~10 Hz throttling provided by `throttled_progress_callback`.
 ///
 /// The Dart callback takes `(i64, i64)` rather than `(u64, u64)` so that frb
 /// generates a plain `int` Dart parameter; i64::MAX is ~9.2 EB which is far
@@ -41,24 +36,8 @@ fn wrap_progress<F>(callback: F) -> nobodywho::llm::DownloadProgressCallback
 where
     F: Fn(i64, i64) -> flutter_rust_bridge::DartFnFuture<()> + Send + Sync + 'static,
 {
-    use std::sync::Mutex;
-    use std::time::{Duration, Instant};
-    let last_emit = Arc::new(Mutex::new(None::<Instant>));
-    Arc::new(move |downloaded: u64, total: u64| {
-        let is_done = total > 0 && downloaded >= total;
-        let emit = {
-            let mut last = last_emit.lock().expect("progress state mutex poisoned");
-            let due = last.map_or(true, |t| t.elapsed() >= Duration::from_millis(100));
-            if is_done || due {
-                *last = Some(Instant::now());
-                true
-            } else {
-                false
-            }
-        };
-        if emit {
-            futures::executor::block_on(callback(downloaded as i64, total as i64));
-        }
+    nobodywho::llm::throttled_progress_callback(move |downloaded, total| {
+        futures::executor::block_on(callback(downloaded as i64, total as i64));
     })
 }
 

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -72,11 +72,12 @@ struct NobodyWhoModel {
     use_gpu_if_available: bool,
 
     model: Option<Arc<llm::Model>>,
+    base: Base<Node>,
 }
 
 #[godot_api]
 impl INode for NobodyWhoModel {
-    fn init(_base: Base<Node>) -> Self {
+    fn init(base: Base<Node>) -> Self {
         // default values to show in godot editor
         let model_path: GString = GString::from("model.gguf");
 
@@ -85,12 +86,20 @@ impl INode for NobodyWhoModel {
             projection_model_path: GString::from(""),
             use_gpu_if_available: true,
             model: None,
+            base,
         }
     }
 }
 
 #[godot_api]
 impl NobodyWhoModel {
+    #[signal]
+    /// Emitted while a remote model is being downloaded, with `(downloaded, total)`
+    /// byte counts. Throttled to ~10 Hz with a guaranteed final emit on
+    /// completion. Not emitted when the model resolves to a local file or a
+    /// cached download (no actual transfer).
+    fn download_progress(downloaded: i64, total: i64);
+
     /// Load the model without holding a `GdMut` across `.await`. Takes the node by value
     /// so each bind is scoped to a short block — other code can still access the node
     /// during the (potentially slow) load/download.
@@ -116,7 +125,57 @@ impl NobodyWhoModel {
             )
         };
 
-        let model = Arc::new(llm::get_model_async(path, use_gpu, mmproj, None).await?);
+        // Bridge the download-thread progress callback to a main-thread signal
+        // emit via an mpsc channel.
+        //
+        // Why the channel is mandatory, not stylistic: core invokes the progress
+        // callback from a std::thread::spawn'd download worker. gdext signals
+        // must be emitted on the main thread, and Gd<T> is !Send so we can't
+        // capture this node in a Send + Sync closure (which is what
+        // DownloadProgressCallback requires). The download thread does only
+        // tx.send; the rx.recv side runs inside this godot::task::spawn'd async
+        // (main thread) and is the one that touches Gd<Self>.
+        let emit_node = gd.clone();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(u64, u64)>();
+        let progress = llm::throttled_progress_callback(move |d, t| {
+            // Send only fails if rx was dropped, which only happens after this
+            // function returns — at which point we don't care about events.
+            let _ = tx.send((d, t));
+        });
+
+        let load_fut = llm::get_model_async(path, use_gpu, mmproj, Some(progress));
+        tokio::pin!(load_fut);
+
+        // select! lets one task drive the load AND drain progress on the same
+        // main-thread executor. A two-task version would also work, but keeping
+        // it in one task means the drain ends deterministically when load_fut
+        // resolves — no separate teardown needed.
+        let model = loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    if let Some((d, t)) = event {
+                        emit_node
+                            .signals()
+                            .download_progress()
+                            .emit(d as i64, t as i64);
+                    }
+                    // None means tx was dropped (callback gone, load finished);
+                    // the next iteration's load arm will resolve.
+                }
+                result = &mut load_fut => {
+                    break result?;
+                }
+            }
+        };
+
+        // Drain any events buffered between the last select! check and the load
+        // arm completing — guarantees the throttle's mandatory completion emit
+        // reaches GDScript.
+        while let Ok((d, t)) = rx.try_recv() {
+            emit_node.signals().download_progress().emit(d as i64, t as i64);
+        }
+
+        let model = Arc::new(model);
 
         // Rebind briefly to memoize.
         gd.bind_mut().model = Some(Arc::clone(&model));

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -116,7 +116,7 @@ impl NobodyWhoModel {
             )
         };
 
-        let model = Arc::new(llm::get_model_async(path, use_gpu, mmproj).await?);
+        let model = Arc::new(llm::get_model_async(path, use_gpu, mmproj, None).await?);
 
         // Rebind briefly to memoize.
         gd.bind_mut().model = Some(Arc::clone(&model));

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -172,7 +172,10 @@ impl NobodyWhoModel {
         // arm completing — guarantees the throttle's mandatory completion emit
         // reaches GDScript.
         while let Ok((d, t)) = rx.try_recv() {
-            emit_node.signals().download_progress().emit(d as i64, t as i64);
+            emit_node
+                .signals()
+                .download_progress()
+                .emit(d as i64, t as i64);
         }
 
         let model = Arc::new(model);

--- a/nobodywho/python/Cargo.toml
+++ b/nobodywho/python/Cargo.toml
@@ -22,7 +22,6 @@ pyo3-introspection = "0.28.3"
 pyo3-log = "0.13.2"
 pythonize = "0.28.0"
 nom = "8.0.0"
-indicatif = "0.18"
 
 
 [dependencies.pyo3]

--- a/nobodywho/python/Cargo.toml
+++ b/nobodywho/python/Cargo.toml
@@ -22,6 +22,7 @@ pyo3-introspection = "0.28.3"
 pyo3-log = "0.13.2"
 pythonize = "0.28.0"
 nom = "8.0.0"
+indicatif = "0.18"
 
 
 [dependencies.pyo3]

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -570,7 +570,7 @@ class Model:
     Sharing is efficient because the underlying model data is reference-counted.
     There is no `ModelAsync` variant. A regular `Model` can be used with both `Chat` and `ChatAsync`.
     """
-    def __new__(cls, /, model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model":
+    def __new__(cls, /, model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, on_download_progress: "typing.Callable[[int, int], None] | None" = None) -> "Model":
         """
         Create a new Model from a GGUF file.
         
@@ -578,7 +578,7 @@ class Model:
             model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
             use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
             projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
-            progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
+            on_download_progress: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
         
         Returns:
             A Model instance
@@ -587,7 +587,7 @@ class Model:
             RuntimeError: If the model file cannot be loaded
         """
     @staticmethod
-    async def load_model_async(model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model":
+    async def load_model_async(model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, on_download_progress: "typing.Callable[[int, int], None] | None" = None) -> "Model":
         """
         Asynchronously load a model from a GGUF file.
         
@@ -599,7 +599,7 @@ class Model:
             model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
             use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
             projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
-            progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
+            on_download_progress: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
         
         Returns:
             A Model instance wrapped in an awaitable (async function returns a coroutine)

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -570,7 +570,7 @@ class Model:
     Sharing is efficient because the underlying model data is reference-counted.
     There is no `ModelAsync` variant. A regular `Model` can be used with both `Chat` and `ChatAsync`.
     """
-    def __new__(cls, /, model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None) -> "Model":
+    def __new__(cls, /, model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model":
         """
         Create a new Model from a GGUF file.
         
@@ -578,6 +578,7 @@ class Model:
             model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
             use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
             projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
+            progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
         
         Returns:
             A Model instance
@@ -586,7 +587,7 @@ class Model:
             RuntimeError: If the model file cannot be loaded
         """
     @staticmethod
-    async def load_model_async(model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None) -> "Model":
+    async def load_model_async(model_path: "os.PathLike | str", use_gpu_if_available: bool = True, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model":
         """
         Asynchronously load a model from a GGUF file.
         
@@ -598,6 +599,7 @@ class Model:
             model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
             use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
             projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
+            progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
         
         Returns:
             A Model instance wrapped in an awaitable (async function returns a coroutine)

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Model {
     model: Arc<nobodywho::llm::Model>,
 }
 
-/// Wrap a Python `progress_callback` argument into a core `DownloadProgressCallback`.
+/// Wrap a Python `on_download_progress` argument into a core `DownloadProgressCallback`.
 ///
 /// - `Some(py_callable)` → wraps it so the Python function is invoked on each chunk
 ///   with `(downloaded_bytes, total_bytes)`. Exceptions are printed and swallowed.
@@ -28,7 +28,7 @@ pub struct Model {
 ///
 /// Returns `TypeError` if `py_callback` is not callable, so a non-callable argument
 /// fails fast at construction rather than per-chunk during download.
-fn resolve_progress_callback(
+fn resolve_on_download_progress(
     py_callback: Option<Py<PyAny>>,
 ) -> PyResult<Option<nobodywho::llm::DownloadProgressCallback>> {
     let Some(cb) = py_callback else {
@@ -37,7 +37,7 @@ fn resolve_progress_callback(
     Python::attach(|py| {
         if !cb.bind(py).is_callable() {
             return Err(pyo3::exceptions::PyTypeError::new_err(
-                "progress_callback must be callable, taking (downloaded_bytes, total_bytes)",
+                "on_download_progress must be callable, taking (downloaded_bytes, total_bytes)",
             ));
         }
         Ok(())
@@ -59,7 +59,7 @@ impl Model {
     ///     model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
     ///     use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
     ///     projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
-    ///     progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
+    ///     on_download_progress: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
     ///
     /// Returns:
     ///     A Model instance
@@ -67,12 +67,12 @@ impl Model {
     /// Raises:
     ///     RuntimeError: If the model file cannot be loaded
     #[new]
-    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
+    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, on_download_progress: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
     pub fn new(
         model_path: std::path::PathBuf,
         use_gpu_if_available: bool,
         projection_model_path: Option<std::path::PathBuf>,
-        progress_callback: Option<Py<PyAny>>,
+        on_download_progress: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         let path_str = model_path.to_str().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
@@ -91,7 +91,7 @@ impl Model {
                 })
             })
             .transpose()?;
-        let progress = resolve_progress_callback(progress_callback)?;
+        let progress = resolve_on_download_progress(on_download_progress)?;
         let model_result =
             nobodywho::llm::get_model(path_str, use_gpu_if_available, mmproj_str, progress);
         match model_result {
@@ -112,7 +112,7 @@ impl Model {
     ///     model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
     ///     use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
     ///     projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
-    ///     progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
+    ///     on_download_progress: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
     ///
     /// Returns:
     ///     A Model instance wrapped in an awaitable (async function returns a coroutine)
@@ -120,12 +120,12 @@ impl Model {
     /// Raises:
     ///     RuntimeError: If the model file cannot be loaded
     #[staticmethod]
-    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
+    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, on_download_progress: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
     pub async fn load_model_async(
         model_path: std::path::PathBuf,
         use_gpu_if_available: bool,
         projection_model_path: Option<std::path::PathBuf>,
-        progress_callback: Option<Py<PyAny>>,
+        on_download_progress: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         let path_str = model_path.to_str().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
@@ -144,7 +144,7 @@ impl Model {
                 })
             })
             .transpose()?;
-        let progress = resolve_progress_callback(progress_callback)?;
+        let progress = resolve_on_download_progress(on_download_progress)?;
         let model_result = nobodywho::llm::get_model_async(
             path_str.to_owned(),
             use_gpu_if_available,

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
+use indicatif::{ProgressBar, ProgressStyle};
 use pyo3::prelude::*;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 mod parse;
 
@@ -21,6 +22,66 @@ pub struct Model {
     model: Arc<nobodywho::llm::Model>,
 }
 
+/// Resolve a Python-side `progress_callback` argument into a core `DownloadProgressCallback`.
+///
+/// - `Some(py_callable)` → wraps it so the Python function is invoked on each chunk
+///   with `(downloaded_bytes, total_bytes)`. Exceptions are printed and swallowed.
+/// - `None` → installs the default terminal progress bar (see `default_progress_callback`).
+///
+/// The callback fires from the download thread. If a projection model is also downloaded,
+/// it fires for each download sequentially, so `total_bytes` resets when the second begins.
+fn resolve_progress_callback(
+    py_callback: Option<Py<PyAny>>,
+) -> Option<nobodywho::llm::DownloadProgressCallback> {
+    match py_callback {
+        Some(cb) => Some(Arc::new(move |downloaded: u64, total: u64| {
+            Python::attach(|py| {
+                if let Err(e) = cb.call1(py, (downloaded, total)) {
+                    e.print(py);
+                }
+            });
+        }) as nobodywho::llm::DownloadProgressCallback),
+        None => Some(default_progress_callback()),
+    }
+}
+
+/// Default terminal progress bar shown when the user doesn't pass their own callback.
+///
+/// Renders an `indicatif` bar with spinner, elapsed time, wide bar, binary byte counts,
+/// throughput, and ETA. indicatif auto-disables on non-TTY stderr, so this is safe to use
+/// unconditionally. Detects a new download (model → mmproj transition) by watching for
+/// `total` to change, finishes the previous bar, and starts a fresh one.
+fn default_progress_callback() -> nobodywho::llm::DownloadProgressCallback {
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} [{elapsed_precise}] {wide_bar:.cyan/blue} \
+         {binary_bytes}/{binary_total_bytes} ({binary_bytes_per_sec}, {eta})",
+    )
+    .expect("static progress bar template is valid")
+    .progress_chars("█▉▊▋▌▍▎▏ ");
+
+    let state: Arc<Mutex<(Option<ProgressBar>, u64)>> = Arc::new(Mutex::new((None, 0)));
+
+    Arc::new(move |downloaded: u64, total: u64| {
+        let mut s = state.lock().expect("progress bar mutex poisoned");
+        if s.0.is_none() || s.1 != total {
+            if let Some(old) = s.0.take() {
+                old.finish_and_clear();
+            }
+            let bar = ProgressBar::new(total);
+            bar.set_style(style.clone());
+            bar.enable_steady_tick(Duration::from_millis(100));
+            s.0 = Some(bar);
+            s.1 = total;
+        }
+        let bar = s.0.as_ref().unwrap();
+        bar.set_position(downloaded);
+        if downloaded >= total {
+            bar.finish();
+            s.0 = None;
+        }
+    })
+}
+
 #[pymethods]
 impl Model {
     /// Create a new Model from a GGUF file.
@@ -29,6 +90,7 @@ impl Model {
     ///     model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
     ///     use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
     ///     projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
+    ///     progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
     ///
     /// Returns:
     ///     A Model instance
@@ -36,11 +98,12 @@ impl Model {
     /// Raises:
     ///     RuntimeError: If the model file cannot be loaded
     #[new]
-    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None) -> "Model")]
+    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
     pub fn new(
         model_path: std::path::PathBuf,
         use_gpu_if_available: bool,
         projection_model_path: Option<std::path::PathBuf>,
+        progress_callback: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         let path_str = model_path.to_str().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
@@ -59,7 +122,9 @@ impl Model {
                 })
             })
             .transpose()?;
-        let model_result = nobodywho::llm::get_model(path_str, use_gpu_if_available, mmproj_str);
+        let progress = resolve_progress_callback(progress_callback);
+        let model_result =
+            nobodywho::llm::get_model(path_str, use_gpu_if_available, mmproj_str, progress);
         match model_result {
             Ok(model) => Ok(Self {
                 model: Arc::new(model),
@@ -78,6 +143,7 @@ impl Model {
     ///     model_path: Path or URL to a GGUF model file. Accepts a local file path (e.g. `./model.gguf`), a `huggingface:` path (e.g. `huggingface:owner/repo/file.gguf`), or an `https://` URL. Remote models are downloaded and cached automatically.
     ///     use_gpu_if_available: If True, attempts to use GPU acceleration. Defaults to True.
     ///     projection_model_path: Path or URL to a multimodal projector file for vision models. Accepts the same formats as model_path. Defaults to None.
+    ///     progress_callback: Optional callable invoked during model downloads with `(downloaded_bytes, total_bytes)`. Not called for locally cached models. If a projection model is also downloaded, the callback fires for each download sequentially, so `total_bytes` resets between them. Defaults to None.
     ///
     /// Returns:
     ///     A Model instance wrapped in an awaitable (async function returns a coroutine)
@@ -85,11 +151,12 @@ impl Model {
     /// Raises:
     ///     RuntimeError: If the model file cannot be loaded
     #[staticmethod]
-    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None) -> "Model")]
+    #[pyo3(signature = (model_path: "os.PathLike | str", use_gpu_if_available = true, projection_model_path: "os.PathLike | str | None" = None, progress_callback: "typing.Callable[[int, int], None] | None" = None) -> "Model")]
     pub async fn load_model_async(
         model_path: std::path::PathBuf,
         use_gpu_if_available: bool,
         projection_model_path: Option<std::path::PathBuf>,
+        progress_callback: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         let path_str = model_path.to_str().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
@@ -108,10 +175,12 @@ impl Model {
                 })
             })
             .transpose()?;
+        let progress = resolve_progress_callback(progress_callback);
         let model_result = nobodywho::llm::get_model_async(
             path_str.to_owned(),
             use_gpu_if_available,
             mmproj_str.map(str::to_owned),
+            progress,
         )
         .await;
         match model_result {
@@ -146,7 +215,7 @@ impl<'py> ModelOrPath<'py> {
                         path.display()
                     ))
                 })?;
-                nobodywho::llm::get_model(path_str, true, None)
+                nobodywho::llm::get_model(path_str, true, None, Some(default_progress_callback()))
                     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
                     .map(Arc::new)
             }

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -1,9 +1,7 @@
-use std::time::Duration;
-
-use indicatif::{ProgressBar, ProgressStyle};
 use pyo3::prelude::*;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::time::Duration;
 
 mod parse;
 
@@ -22,64 +20,35 @@ pub struct Model {
     model: Arc<nobodywho::llm::Model>,
 }
 
-/// Resolve a Python-side `progress_callback` argument into a core `DownloadProgressCallback`.
+/// Wrap a Python `progress_callback` argument into a core `DownloadProgressCallback`.
 ///
 /// - `Some(py_callable)` → wraps it so the Python function is invoked on each chunk
 ///   with `(downloaded_bytes, total_bytes)`. Exceptions are printed and swallowed.
-/// - `None` → installs the default terminal progress bar (see `default_progress_callback`).
+/// - `None` → returns `None`; core installs its own default terminal progress bar.
 ///
-/// The callback fires from the download thread. If a projection model is also downloaded,
-/// it fires for each download sequentially, so `total_bytes` resets when the second begins.
+/// Returns `TypeError` if `py_callback` is not callable, so a non-callable argument
+/// fails fast at construction rather than per-chunk during download.
 fn resolve_progress_callback(
     py_callback: Option<Py<PyAny>>,
-) -> Option<nobodywho::llm::DownloadProgressCallback> {
-    match py_callback {
-        Some(cb) => Some(Arc::new(move |downloaded: u64, total: u64| {
-            Python::attach(|py| {
-                if let Err(e) = cb.call1(py, (downloaded, total)) {
-                    e.print(py);
-                }
-            });
-        }) as nobodywho::llm::DownloadProgressCallback),
-        None => Some(default_progress_callback()),
-    }
-}
-
-/// Default terminal progress bar shown when the user doesn't pass their own callback.
-///
-/// Renders an `indicatif` bar with spinner, elapsed time, wide bar, binary byte counts,
-/// throughput, and ETA. indicatif auto-disables on non-TTY stderr, so this is safe to use
-/// unconditionally. Detects a new download (model → mmproj transition) by watching for
-/// `total` to change, finishes the previous bar, and starts a fresh one.
-fn default_progress_callback() -> nobodywho::llm::DownloadProgressCallback {
-    let style = ProgressStyle::with_template(
-        "{spinner:.green} [{elapsed_precise}] {wide_bar:.cyan/blue} \
-         {binary_bytes}/{binary_total_bytes} ({binary_bytes_per_sec}, {eta})",
-    )
-    .expect("static progress bar template is valid")
-    .progress_chars("█▉▊▋▌▍▎▏ ");
-
-    let state: Arc<Mutex<(Option<ProgressBar>, u64)>> = Arc::new(Mutex::new((None, 0)));
-
-    Arc::new(move |downloaded: u64, total: u64| {
-        let mut s = state.lock().expect("progress bar mutex poisoned");
-        if s.0.is_none() || s.1 != total {
-            if let Some(old) = s.0.take() {
-                old.finish_and_clear();
+) -> PyResult<Option<nobodywho::llm::DownloadProgressCallback>> {
+    let Some(cb) = py_callback else {
+        return Ok(None);
+    };
+    Python::attach(|py| {
+        if !cb.bind(py).is_callable() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "progress_callback must be callable, taking (downloaded_bytes, total_bytes)",
+            ));
+        }
+        Ok(())
+    })?;
+    Ok(Some(Arc::new(move |downloaded: u64, total: u64| {
+        Python::attach(|py| {
+            if let Err(e) = cb.call1(py, (downloaded, total)) {
+                e.print(py);
             }
-            let bar = ProgressBar::new(total);
-            bar.set_style(style.clone());
-            bar.enable_steady_tick(Duration::from_millis(100));
-            s.0 = Some(bar);
-            s.1 = total;
-        }
-        let bar = s.0.as_ref().unwrap();
-        bar.set_position(downloaded);
-        if downloaded >= total {
-            bar.finish();
-            s.0 = None;
-        }
-    })
+        });
+    }) as nobodywho::llm::DownloadProgressCallback))
 }
 
 #[pymethods]
@@ -122,7 +91,7 @@ impl Model {
                 })
             })
             .transpose()?;
-        let progress = resolve_progress_callback(progress_callback);
+        let progress = resolve_progress_callback(progress_callback)?;
         let model_result =
             nobodywho::llm::get_model(path_str, use_gpu_if_available, mmproj_str, progress);
         match model_result {
@@ -175,7 +144,7 @@ impl Model {
                 })
             })
             .transpose()?;
-        let progress = resolve_progress_callback(progress_callback);
+        let progress = resolve_progress_callback(progress_callback)?;
         let model_result = nobodywho::llm::get_model_async(
             path_str.to_owned(),
             use_gpu_if_available,
@@ -215,7 +184,7 @@ impl<'py> ModelOrPath<'py> {
                         path.display()
                     ))
                 })?;
-                nobodywho::llm::get_model(path_str, true, None, Some(default_progress_callback()))
+                nobodywho::llm::get_model(path_str, true, None, None)
                     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
                     .map(Arc::new)
             }

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -104,7 +104,8 @@ typedef void (*UniffiCallbackInterfaceRustToolCallbackMethod0)(
 typedef struct UniffiVTableCallbackInterfaceRustDownloadProgressCallback {
   UniffiCallbackInterfaceFree uniffi_free;
   UniffiCallbackInterfaceClone uniffi_clone;
-  UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0 on_progress;
+  UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0
+      on_download_progress;
 } UniffiVTableCallbackInterfaceRustDownloadProgressCallback;
 typedef struct UniffiVTableCallbackInterfaceRustToolCallback {
   UniffiCallbackInterfaceFree uniffi_free;
@@ -269,7 +270,7 @@ float uniffi_nobodywho_uniffi_fn_func_cosine_similarity(
     RustBuffer a, RustBuffer b, RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(
     RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path,
-    RustBuffer progress_callback);
+    RustBuffer on_download_progress);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_sampler_preset_default(
     RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_sampler_preset_dry(
@@ -464,7 +465,7 @@ uint16_t uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new_async();
 uint16_t uniffi_nobodywho_uniffi_checksum_constructor_samplerbuilder_new();
 uint16_t uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json();
 uint16_t
-uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress();
+uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call();
 uint32_t ffi_nobodywho_uniffi_uniffi_contract_version();
 }
@@ -2072,7 +2073,7 @@ static void cleanup() {
 } // namespace
   // uniffi::nobodywho::cb::callbackinterfaceclone::vtablecallbackinterfacerustdownloadprogresscallback
   // Implementation of CallbackInterfaceRustDownloadProgressCallbackMethod0 for
-  // vtable field on_progress in
+  // vtable field on_download_progress in
   // VTableCallbackInterfaceRustDownloadProgressCallback
 
 // Callback function:
@@ -2245,11 +2246,12 @@ struct Bridging<UniffiVTableCallbackInterfaceRustDownloadProgressCallback> {
         vtablecallbackinterfacerustdownloadprogresscallback::
             makeCallbackFunction(rt, callInvoker,
                                  jsObject.getProperty(rt, "uniffiClone"));
-    rsObject.on_progress = uniffi::nobodywho::cb::
+    rsObject.on_download_progress = uniffi::nobodywho::cb::
         callbackinterfacerustdownloadprogresscallbackmethod0::
             vtablecallbackinterfacerustdownloadprogresscallback::
-                makeCallbackFunction(rt, callInvoker,
-                                     jsObject.getProperty(rt, "onProgress"));
+                makeCallbackFunction(
+                    rt, callInvoker,
+                    jsObject.getProperty(rt, "onDownloadProgress"));
 
     return rsObject;
   }
@@ -4635,17 +4637,17 @@ NativeNobodywho::NativeNobodywho(
                 rt, thisVal, args, count);
       });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_method_"
-        "rustdownloadprogresscallback_on_progress"] =
+        "rustdownloadprogresscallback_on_download_progress"] =
       jsi::Function::createFromHostFunction(
           rt,
           jsi::PropNameID::forAscii(
               rt, "ubrn_uniffi_nobodywho_uniffi_checksum_method_"
-                  "rustdownloadprogresscallback_on_progress"),
+                  "rustdownloadprogresscallback_on_download_progress"),
           0,
           [this](jsi::Runtime &rt, const jsi::Value &thisVal,
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this
-                ->cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
+                ->cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress(
                     rt, thisVal, args, count);
           });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call"] =
@@ -7022,11 +7024,11 @@ jsi::Value NativeNobodywho::
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }
 jsi::Value NativeNobodywho::
-    cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
+    cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress(
         jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
         size_t count) {
   auto value =
-      uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress();
+      uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -95,9 +95,17 @@ typedef struct UniffiForeignFutureResultVoid {
 } UniffiForeignFutureResultVoid;
 typedef void (*UniffiForeignFutureCompleteVoid)(
     uint64_t callback_data, UniffiForeignFutureResultVoid result);
+typedef void (*UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0)(
+    uint64_t uniffi_handle, uint64_t downloaded, uint64_t total,
+    void *uniffi_out_return, RustCallStatus *rust_call_status);
 typedef void (*UniffiCallbackInterfaceRustToolCallbackMethod0)(
     uint64_t uniffi_handle, RustBuffer arguments_json,
     RustBuffer *uniffi_out_return, RustCallStatus *rust_call_status);
+typedef struct UniffiVTableCallbackInterfaceRustDownloadProgressCallback {
+  UniffiCallbackInterfaceFree uniffi_free;
+  UniffiCallbackInterfaceClone uniffi_clone;
+  UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0 on_progress;
+} UniffiVTableCallbackInterfaceRustDownloadProgressCallback;
 typedef struct UniffiVTableCallbackInterfaceRustToolCallback {
   UniffiCallbackInterfaceFree uniffi_free;
   UniffiCallbackInterfaceClone uniffi_clone;
@@ -253,12 +261,15 @@ uniffi_nobodywho_uniffi_fn_constructor_samplerconfig_from_json(
     RustBuffer json_str, RustCallStatus *uniffi_out_err);
 RustBuffer uniffi_nobodywho_uniffi_fn_method_samplerconfig_to_json(
     /*handle*/ uint64_t ptr, RustCallStatus *uniffi_out_err);
+void uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+    UniffiVTableCallbackInterfaceRustDownloadProgressCallback *vtable);
 void uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(
     UniffiVTableCallbackInterfaceRustToolCallback *vtable);
 float uniffi_nobodywho_uniffi_fn_func_cosine_similarity(
     RustBuffer a, RustBuffer b, RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(
-    RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path);
+    RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path,
+    RustBuffer progress_callback);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_sampler_preset_default(
     RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_sampler_preset_dry(
@@ -452,6 +463,8 @@ uint16_t uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new();
 uint16_t uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new_async();
 uint16_t uniffi_nobodywho_uniffi_checksum_constructor_samplerbuilder_new();
 uint16_t uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json();
+uint16_t
+uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call();
 uint32_t ffi_nobodywho_uniffi_uniffi_contract_version();
 }
@@ -889,6 +902,119 @@ static void cleanup() {
 }
 } // namespace uniffi::nobodywho::cb::foreignfuturedroppedcallback
   // Implementation of free callback function CallbackInterfaceFree
+
+// Callback function:
+// uniffi::nobodywho::st::vtablecallbackinterfacerustdownloadprogresscallback::vtablecallbackinterfacerustdownloadprogresscallback::free::UniffiCallbackInterfaceFree
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback`
+// function calls the lambda, which itself calls the `body` which then calls
+// into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the
+// lambda sometime in the future.
+namespace uniffi::nobodywho::st::
+    vtablecallbackinterfacerustdownloadprogresscallback::
+        vtablecallbackinterfacerustdownloadprogresscallback::free {
+using namespace facebook;
+
+// We need to store a lambda in a global so we can call it from
+// a function pointer. The function pointer is passed to Rust.
+static std::function<void(uint64_t)> rsLambda = nullptr;
+
+// This is the main body of the callback. It's called from the lambda,
+// which itself is called from the callback function which is passed to Rust.
+static void body(jsi::Runtime &rt,
+                 std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                 std::shared_ptr<jsi::Value> callbackValue,
+                 uint64_t rs_handle) {
+
+  // Convert the arguments from Rust, into jsi::Values.
+  // We'll use the Bridging class to do this…
+  auto js_handle =
+      uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_handle);
+
+  // Now we are ready to call the callback.
+  // We are already on the JS thread, because this `body` function was
+  // invoked from the CallInvoker.
+  try {
+    // Getting the callback function
+    auto cb = callbackValue->asObject(rt).asFunction(rt);
+    auto uniffiResult = cb.call(rt, js_handle);
+
+  } catch (const jsi::JSError &error) {
+    std::cout << "Error in callback UniffiCallbackInterfaceFree: "
+              << error.what() << std::endl;
+    throw error;
+  }
+}
+
+static void callback(uint64_t rs_handle) {
+  // If the runtime has shutdown, then there is no point in trying to
+  // call into Javascript. BUT how do we tell if the runtime has shutdown?
+  //
+  // Answer: the module destructor calls into callback `cleanup` method,
+  // which nulls out the rsLamda.
+  //
+  // If rsLamda is null, then there is no runtime to call into.
+  if (rsLambda == nullptr) {
+    // This only occurs when destructors are calling into Rust free/drop,
+    // which causes the JS callback to be dropped.
+    return;
+  }
+
+  // The runtime, the actual callback jsi::funtion, and the callInvoker
+  // are all in the lambda.
+  rsLambda(rs_handle);
+}
+
+[[maybe_unused]] static UniffiCallbackInterfaceFree
+makeCallbackFunction( // uniffi::nobodywho::st::vtablecallbackinterfacerustdownloadprogresscallback::vtablecallbackinterfacerustdownloadprogresscallback::free
+    jsi::Runtime &rt,
+    std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+    const jsi::Value &value) {
+  if (rsLambda != nullptr) {
+    // `makeCallbackFunction` is called in two circumstances:
+    //
+    // 1. at startup, when initializing callback interface vtables.
+    // 2. when polling futures. This happens at least once per future that is
+    //    exposed to Javascript. We know that this is always the same function,
+    //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+    //
+    // We can therefore return the callback function without making anything
+    // new if we've been initialized already.
+    return callback;
+  }
+  auto callbackFunction = value.asObject(rt).asFunction(rt);
+  auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+  rsLambda = [&rt, callInvoker, callbackValue](uint64_t rs_handle) {
+    // We immediately make a lambda which will do the work of transforming the
+    // arguments into JSI values and calling the callback.
+    uniffi_runtime::UniffiCallFunc jsLambda =
+        [callInvoker, callbackValue, rs_handle](jsi::Runtime &rt) mutable {
+          body(rt, callInvoker, callbackValue, rs_handle);
+        };
+    // We'll then call that lambda from the callInvoker which will
+    // look after calling it on the correct thread.
+
+    callInvoker->invokeNonBlocking(rt, jsLambda);
+  };
+  return callback;
+}
+
+// This method is called from the destructor of NativeNobodywho, which only
+// happens when the jsi::Runtime is being destroyed.
+static void cleanup() {
+  // The lambda holds a reference to the the Runtime, so when this is nulled
+  // out, then the pointer will no longer be left dangling.
+  rsLambda = nullptr;
+}
+} // namespace
+  // uniffi::nobodywho::st::vtablecallbackinterfacerustdownloadprogresscallback::vtablecallbackinterfacerustdownloadprogresscallback::free
 
 // Callback function:
 // uniffi::nobodywho::st::vtablecallbackinterfacerusttoolcallback::vtablecallbackinterfacerusttoolcallback::free::UniffiCallbackInterfaceFree
@@ -1822,6 +1948,313 @@ template <> struct Bridging<UniffiForeignFutureCompleteVoid> {
     return jsi::Value::undefined();
   }
 };
+} // namespace uniffi::nobodywho
+  // Implementation of CallbackInterfaceClone for vtable field uniffi_clone in
+  // VTableCallbackInterfaceRustDownloadProgressCallback
+
+// Callback function:
+// uniffi::nobodywho::cb::callbackinterfaceclone::vtablecallbackinterfacerustdownloadprogresscallback::UniffiCallbackInterfaceClone
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback`
+// function calls the lambda, which itself calls the `body` which then calls
+// into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the
+// lambda sometime in the future.
+namespace uniffi::nobodywho::cb::callbackinterfaceclone::
+    vtablecallbackinterfacerustdownloadprogresscallback {
+using namespace facebook;
+
+// We need to store a lambda in a global so we can call it from
+// a function pointer. The function pointer is passed to Rust.
+static std::function<void(uint64_t, uint64_t *)> rsLambda = nullptr;
+
+// This is the main body of the callback. It's called from the lambda,
+// which itself is called from the callback function which is passed to Rust.
+static void body(jsi::Runtime &rt,
+                 std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                 std::shared_ptr<jsi::Value> callbackValue, uint64_t rs_handle,
+                 uint64_t *uniffi_direct_return) {
+
+  // Convert the arguments from Rust, into jsi::Values.
+  // We'll use the Bridging class to do this…
+  auto js_handle =
+      uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_handle);
+
+  // Now we are ready to call the callback.
+  // We are already on the JS thread, because this `body` function was
+  // invoked from the CallInvoker.
+  try {
+    // Getting the callback function
+    auto cb = callbackValue->asObject(rt).asFunction(rt);
+    auto uniffiResult = cb.call(rt, js_handle);
+
+    // Write the direct return value back to the caller.
+    if (uniffi_direct_return != nullptr) {
+      *uniffi_direct_return =
+          uniffi_jsi::Bridging<uint64_t>::fromJs(rt, callInvoker, uniffiResult);
+    }
+  } catch (const jsi::JSError &error) {
+    std::cout << "Error in callback UniffiCallbackInterfaceClone: "
+              << error.what() << std::endl;
+    throw error;
+  }
+}
+
+static uint64_t callback(uint64_t rs_handle) {
+  // If the runtime has shutdown, then there is no point in trying to
+  // call into Javascript. BUT how do we tell if the runtime has shutdown?
+  //
+  // Answer: the module destructor calls into callback `cleanup` method,
+  // which nulls out the rsLamda.
+  //
+  // If rsLamda is null, then there is no runtime to call into.
+  if (rsLambda == nullptr) {
+    // This only occurs when destructors are calling into Rust free/drop,
+    // which causes the JS callback to be dropped.
+    return 0;
+  }
+  uint64_t uniffi_result = 0;
+
+  // The runtime, the actual callback jsi::funtion, and the callInvoker
+  // are all in the lambda.
+  rsLambda(rs_handle, &uniffi_result);
+  return uniffi_result;
+}
+
+[[maybe_unused]] static UniffiCallbackInterfaceClone
+makeCallbackFunction( // uniffi::nobodywho::cb::callbackinterfaceclone::vtablecallbackinterfacerustdownloadprogresscallback
+    jsi::Runtime &rt,
+    std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+    const jsi::Value &value) {
+  if (rsLambda != nullptr) {
+    // `makeCallbackFunction` is called in two circumstances:
+    //
+    // 1. at startup, when initializing callback interface vtables.
+    // 2. when polling futures. This happens at least once per future that is
+    //    exposed to Javascript. We know that this is always the same function,
+    //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+    //
+    // We can therefore return the callback function without making anything
+    // new if we've been initialized already.
+    return callback;
+  }
+  auto callbackFunction = value.asObject(rt).asFunction(rt);
+  auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+  rsLambda = [&rt, callInvoker, callbackValue](uint64_t rs_handle,
+                                               uint64_t *uniffi_direct_return) {
+    // We immediately make a lambda which will do the work of transforming the
+    // arguments into JSI values and calling the callback.
+    uniffi_runtime::UniffiCallFunc jsLambda =
+        [callInvoker, callbackValue, rs_handle,
+         uniffi_direct_return](jsi::Runtime &rt) mutable {
+          body(rt, callInvoker, callbackValue, rs_handle, uniffi_direct_return);
+        };
+    // We'll then call that lambda from the callInvoker which will
+    // look after calling it on the correct thread.
+    callInvoker->invokeBlocking(rt, jsLambda);
+  };
+  return callback;
+}
+
+// This method is called from the destructor of NativeNobodywho, which only
+// happens when the jsi::Runtime is being destroyed.
+static void cleanup() {
+  // The lambda holds a reference to the the Runtime, so when this is nulled
+  // out, then the pointer will no longer be left dangling.
+  rsLambda = nullptr;
+}
+} // namespace
+  // uniffi::nobodywho::cb::callbackinterfaceclone::vtablecallbackinterfacerustdownloadprogresscallback
+  // Implementation of CallbackInterfaceRustDownloadProgressCallbackMethod0 for
+  // vtable field on_progress in
+  // VTableCallbackInterfaceRustDownloadProgressCallback
+
+// Callback function:
+// uniffi::nobodywho::cb::callbackinterfacerustdownloadprogresscallbackmethod0::vtablecallbackinterfacerustdownloadprogresscallback::UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback`
+// function calls the lambda, which itself calls the `body` which then calls
+// into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the
+// lambda sometime in the future.
+namespace uniffi::nobodywho::cb::
+    callbackinterfacerustdownloadprogresscallbackmethod0::
+        vtablecallbackinterfacerustdownloadprogresscallback {
+using namespace facebook;
+
+// We need to store a lambda in a global so we can call it from
+// a function pointer. The function pointer is passed to Rust.
+static std::function<void(uint64_t, uint64_t, uint64_t, void *,
+                          RustCallStatus *)>
+    rsLambda = nullptr;
+
+// This is the main body of the callback. It's called from the lambda,
+// which itself is called from the callback function which is passed to Rust.
+static void body(jsi::Runtime &rt,
+                 std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                 std::shared_ptr<jsi::Value> callbackValue,
+                 uint64_t rs_uniffiHandle, uint64_t rs_downloaded,
+                 uint64_t rs_total, void *rs_uniffiOutReturn,
+                 RustCallStatus *uniffi_call_status) {
+
+  // Convert the arguments from Rust, into jsi::Values.
+  // We'll use the Bridging class to do this…
+  auto js_uniffiHandle =
+      uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiHandle);
+  auto js_downloaded =
+      uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_downloaded);
+  auto js_total =
+      uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_total);
+
+  // Now we are ready to call the callback.
+  // We are already on the JS thread, because this `body` function was
+  // invoked from the CallInvoker.
+  try {
+    // Getting the callback function
+    auto cb = callbackValue->asObject(rt).asFunction(rt);
+    auto uniffiResult = cb.call(rt, js_uniffiHandle, js_downloaded, js_total);
+
+    // Now copy the result back from JS into the RustCallStatus object.
+    uniffi::nobodywho::Bridging<RustCallStatus>::copyFromJs(
+        rt, callInvoker, uniffiResult, uniffi_call_status);
+
+    if (uniffi_call_status->code != UNIFFI_CALL_STATUS_OK) {
+      // The JS callback finished abnormally, so we cannot retrieve the return
+      // value.
+      return;
+    }
+
+  } catch (const jsi::JSError &error) {
+    std::cout << "Error in callback "
+                 "UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0: "
+              << error.what() << std::endl;
+    throw error;
+  }
+}
+
+static void callback(uint64_t rs_uniffiHandle, uint64_t rs_downloaded,
+                     uint64_t rs_total, void *rs_uniffiOutReturn,
+                     RustCallStatus *uniffi_call_status) {
+  // If the runtime has shutdown, then there is no point in trying to
+  // call into Javascript. BUT how do we tell if the runtime has shutdown?
+  //
+  // Answer: the module destructor calls into callback `cleanup` method,
+  // which nulls out the rsLamda.
+  //
+  // If rsLamda is null, then there is no runtime to call into.
+  if (rsLambda == nullptr) {
+    // This only occurs when destructors are calling into Rust free/drop,
+    // which causes the JS callback to be dropped.
+    return;
+  }
+
+  // The runtime, the actual callback jsi::funtion, and the callInvoker
+  // are all in the lambda.
+  rsLambda(rs_uniffiHandle, rs_downloaded, rs_total, rs_uniffiOutReturn,
+           uniffi_call_status);
+}
+
+[[maybe_unused]] static UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0
+makeCallbackFunction( // uniffi::nobodywho::cb::callbackinterfacerustdownloadprogresscallbackmethod0::vtablecallbackinterfacerustdownloadprogresscallback
+    jsi::Runtime &rt,
+    std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+    const jsi::Value &value) {
+  if (rsLambda != nullptr) {
+    // `makeCallbackFunction` is called in two circumstances:
+    //
+    // 1. at startup, when initializing callback interface vtables.
+    // 2. when polling futures. This happens at least once per future that is
+    //    exposed to Javascript. We know that this is always the same function,
+    //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+    //
+    // We can therefore return the callback function without making anything
+    // new if we've been initialized already.
+    return callback;
+  }
+  auto callbackFunction = value.asObject(rt).asFunction(rt);
+  auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+  rsLambda = [&rt, callInvoker,
+              callbackValue](uint64_t rs_uniffiHandle, uint64_t rs_downloaded,
+                             uint64_t rs_total, void *rs_uniffiOutReturn,
+                             RustCallStatus *uniffi_call_status) {
+    // We immediately make a lambda which will do the work of transforming the
+    // arguments into JSI values and calling the callback.
+    uniffi_runtime::UniffiCallFunc jsLambda =
+        [callInvoker, callbackValue, rs_uniffiHandle, rs_downloaded, rs_total,
+         rs_uniffiOutReturn, uniffi_call_status](jsi::Runtime &rt) mutable {
+          body(rt, callInvoker, callbackValue, rs_uniffiHandle, rs_downloaded,
+               rs_total, rs_uniffiOutReturn, uniffi_call_status);
+        };
+    // We'll then call that lambda from the callInvoker which will
+    // look after calling it on the correct thread.
+    callInvoker->invokeBlocking(rt, jsLambda);
+  };
+  return callback;
+}
+
+// This method is called from the destructor of NativeNobodywho, which only
+// happens when the jsi::Runtime is being destroyed.
+static void cleanup() {
+  // The lambda holds a reference to the the Runtime, so when this is nulled
+  // out, then the pointer will no longer be left dangling.
+  rsLambda = nullptr;
+}
+} // namespace
+  // uniffi::nobodywho::cb::callbackinterfacerustdownloadprogresscallbackmethod0::vtablecallbackinterfacerustdownloadprogresscallback
+namespace uniffi::nobodywho {
+using namespace facebook;
+using CallInvoker = uniffi_runtime::UniffiCallInvoker;
+
+template <>
+struct Bridging<UniffiVTableCallbackInterfaceRustDownloadProgressCallback> {
+  static UniffiVTableCallbackInterfaceRustDownloadProgressCallback
+  fromJs(jsi::Runtime &rt, std::shared_ptr<CallInvoker> callInvoker,
+         const jsi::Value &jsValue) {
+    // Check if the input is an object
+    if (!jsValue.isObject()) {
+      throw jsi::JSError(
+          rt, "Expected an object for "
+              "UniffiVTableCallbackInterfaceRustDownloadProgressCallback");
+    }
+
+    // Get the object from the jsi::Value
+    auto jsObject = jsValue.getObject(rt);
+
+    // Create the vtable struct
+    UniffiVTableCallbackInterfaceRustDownloadProgressCallback rsObject;
+
+    // Create the vtable from the js callbacks.
+    rsObject.uniffi_free = uniffi::nobodywho::st::
+        vtablecallbackinterfacerustdownloadprogresscallback::
+            vtablecallbackinterfacerustdownloadprogresscallback::free::
+                makeCallbackFunction(rt, callInvoker,
+                                     jsObject.getProperty(rt, "uniffiFree"));
+    rsObject.uniffi_clone = uniffi::nobodywho::cb::callbackinterfaceclone::
+        vtablecallbackinterfacerustdownloadprogresscallback::
+            makeCallbackFunction(rt, callInvoker,
+                                 jsObject.getProperty(rt, "uniffiClone"));
+    rsObject.on_progress = uniffi::nobodywho::cb::
+        callbackinterfacerustdownloadprogresscallbackmethod0::
+            vtablecallbackinterfacerustdownloadprogresscallback::
+                makeCallbackFunction(rt, callInvoker,
+                                     jsObject.getProperty(rt, "onProgress"));
+
+    return rsObject;
+  }
+};
+
 } // namespace uniffi::nobodywho
   // Implementation of CallbackInterfaceClone for vtable field uniffi_clone in
   // VTableCallbackInterfaceRustToolCallback
@@ -2887,6 +3320,19 @@ NativeNobodywho::NativeNobodywho(
                     rt, thisVal, args, count);
           });
   props["ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_"
+        "rustdownloadprogresscallback"] = jsi::Function::createFromHostFunction(
+      rt,
+      jsi::PropNameID::forAscii(rt,
+                                "ubrn_uniffi_nobodywho_uniffi_fn_init_callback_"
+                                "vtable_rustdownloadprogresscallback"),
+      1,
+      [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+             const jsi::Value *args, size_t count) -> jsi::Value {
+        return this
+            ->cpp_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+                rt, thisVal, args, count);
+      });
+  props["ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_"
         "rusttoolcallback"] = jsi::Function::createFromHostFunction(
       rt,
       jsi::PropNameID::forAscii(rt, "ubrn_uniffi_nobodywho_uniffi_fn_init_"
@@ -2914,7 +3360,7 @@ NativeNobodywho::NativeNobodywho(
           rt,
           jsi::PropNameID::forAscii(
               rt, "ubrn_uniffi_nobodywho_uniffi_fn_func_load_model"),
-          3,
+          4,
           [this](jsi::Runtime &rt, const jsi::Value &thisVal,
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
@@ -4188,6 +4634,20 @@ NativeNobodywho::NativeNobodywho(
             ->cpp_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json(
                 rt, thisVal, args, count);
       });
+  props["ubrn_uniffi_nobodywho_uniffi_checksum_method_"
+        "rustdownloadprogresscallback_on_progress"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_nobodywho_uniffi_checksum_method_"
+                  "rustdownloadprogresscallback_on_progress"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this
+                ->cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
+                    rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -4352,8 +4812,14 @@ NativeNobodywho::~NativeNobodywho() {
   // Cleanup for callback function ForeignFutureDroppedCallback
   uniffi::nobodywho::cb::foreignfuturedroppedcallback::cleanup();
   // Cleanup for "free" callback function CallbackInterfaceFree
+  uniffi::nobodywho::st::vtablecallbackinterfacerustdownloadprogresscallback::
+      vtablecallbackinterfacerustdownloadprogresscallback::free::cleanup();
   uniffi::nobodywho::st::vtablecallbackinterfacerusttoolcallback::
       vtablecallbackinterfacerusttoolcallback::free::cleanup();
+  uniffi::nobodywho::cb::callbackinterfaceclone::
+      vtablecallbackinterfacerustdownloadprogresscallback::cleanup();
+  uniffi::nobodywho::cb::callbackinterfacerustdownloadprogresscallbackmethod0::
+      vtablecallbackinterfacerustdownloadprogresscallback::cleanup();
   uniffi::nobodywho::cb::callbackinterfaceclone::
       vtablecallbackinterfacerusttoolcallback::cleanup();
   uniffi::nobodywho::cb::callbackinterfacerusttoolcallbackmethod0::
@@ -5396,6 +5862,21 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_method_samplerconfig_to_json(
   return uniffi::nobodywho::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
 }
 jsi::Value NativeNobodywho::
+    cpp_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+        jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+        size_t count) {
+  auto vtableInstance = uniffi::nobodywho::Bridging<
+      UniffiVTableCallbackInterfaceRustDownloadProgressCallback>::
+      fromJs(rt, callInvoker, args[0]);
+
+  std::lock_guard<std::mutex> lock(uniffi::nobodywho::registry::vtableMutex);
+  uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+      uniffi::nobodywho::registry::putTable(
+          "UniffiVTableCallbackInterfaceRustDownloadProgressCallback",
+          vtableInstance));
+  return jsi::Value::undefined();
+}
+jsi::Value NativeNobodywho::
     cpp_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(
         jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
         size_t count) {
@@ -5430,8 +5911,9 @@ jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
   auto value = uniffi_nobodywho_uniffi_fn_func_load_model(
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[0]),
       uniffi_jsi::Bridging<int8_t>::fromJs(rt, callInvoker, args[1]),
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[2]),
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker,
-                                                      args[2]));
+                                                      args[3]));
 
   return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker,
                                                          value);
@@ -6536,6 +7018,15 @@ jsi::Value NativeNobodywho::
         size_t count) {
   auto value =
       uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeNobodywho::
+    cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
+        jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+        size_t count) {
+  auto value =
+      uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/nobodywho/react-native/generated/cpp/nobodywho.hpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.hpp
@@ -211,6 +211,10 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value
+  cpp_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value
   cpp_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -571,6 +575,10 @@ protected:
       size_t count);
   jsi::Value
   cpp_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value
+  cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call(

--- a/nobodywho/react-native/generated/cpp/nobodywho.hpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.hpp
@@ -578,7 +578,7 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value
-  cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(
+  cpp_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call(

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -77,9 +77,10 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_fn_free_samplerconfig(handle: bigint, uniffi_out_err: UniffiRustCallStatus): void;
     ubrn_uniffi_nobodywho_uniffi_fn_constructor_samplerconfig_from_json(jsonStr: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_method_samplerconfig_to_json(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
+    ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(vtable: UniffiVTableCallbackInterfaceRustDownloadProgressCallback): void;
     ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(vtable: UniffiVTableCallbackInterfaceRustToolCallback): void;
     ubrn_uniffi_nobodywho_uniffi_fn_func_cosine_similarity(a: Uint8Array, b: Uint8Array, uniffi_out_err: UniffiRustCallStatus): number;
-    ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array, progressCallback: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_default(uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_dry(uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_grammar(grammar: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -189,6 +190,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new_async(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerbuilder_new(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json(): number;
+    ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call(): number;
     ubrn_ffi_nobodywho_uniffi_uniffi_contract_version(): number;
     ubrn_uniffi_internal_fn_method_rustchat_ffi__bless_pointer(pointer: bigint, uniffi_out_err: UniffiRustCallStatus): UniffiGcObject;
@@ -278,8 +280,15 @@ export type UniffiForeignFutureResultVoid = {
   callStatus: UniffiRustCallStatus;
 };
 export type UniffiForeignFutureCompleteVoid = (callbackData: bigint, result: UniffiForeignFutureResultVoid) => void;
+type UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0 = (uniffiHandle: bigint, downloaded: bigint, total: bigint) => UniffiResult<void>
+;
 type UniffiCallbackInterfaceRustToolCallbackMethod0 = (uniffiHandle: bigint, argumentsJson: Uint8Array) => Uint8Array
 ;
+export type UniffiVTableCallbackInterfaceRustDownloadProgressCallback = {
+  uniffiFree: UniffiCallbackInterfaceFree;
+  uniffiClone: UniffiCallbackInterfaceClone;
+  onProgress: UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0;
+};
 export type UniffiVTableCallbackInterfaceRustToolCallback = {
   uniffiFree: UniffiCallbackInterfaceFree;
   uniffiClone: UniffiCallbackInterfaceClone;

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -80,7 +80,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(vtable: UniffiVTableCallbackInterfaceRustDownloadProgressCallback): void;
     ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(vtable: UniffiVTableCallbackInterfaceRustToolCallback): void;
     ubrn_uniffi_nobodywho_uniffi_fn_func_cosine_similarity(a: Uint8Array, b: Uint8Array, uniffi_out_err: UniffiRustCallStatus): number;
-    ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array, progressCallback: Uint8Array): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array, onDownloadProgress: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_default(uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_dry(uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_grammar(grammar: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -190,7 +190,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new_async(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerbuilder_new(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json(): number;
-    ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress(): number;
+    ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call(): number;
     ubrn_ffi_nobodywho_uniffi_uniffi_contract_version(): number;
     ubrn_uniffi_internal_fn_method_rustchat_ffi__bless_pointer(pointer: bigint, uniffi_out_err: UniffiRustCallStatus): UniffiGcObject;
@@ -287,7 +287,7 @@ type UniffiCallbackInterfaceRustToolCallbackMethod0 = (uniffiHandle: bigint, arg
 export type UniffiVTableCallbackInterfaceRustDownloadProgressCallback = {
   uniffiFree: UniffiCallbackInterfaceFree;
   uniffiClone: UniffiCallbackInterfaceClone;
-  onProgress: UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0;
+  onDownloadProgress: UniffiCallbackInterfaceRustDownloadProgressCallbackMethod0;
 };
 export type UniffiVTableCallbackInterfaceRustToolCallback = {
   uniffiFree: UniffiCallbackInterfaceFree;

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -105,13 +105,13 @@ export function cosineSimilarity(a: Array</*f32*/number>, b: Array</*f32*/number
  * uniffi-bindgen-react-native generates invalid JS (`async static` instead
  * of `static async`) for async constructors.
  */
-export async function loadModel(modelPath: string, useGpu: boolean, projectionModelPath: string | undefined, progressCallback: RustDownloadProgressCallback | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustModelInterface> /*throws*/ {
+export async function loadModel(modelPath: string, useGpu: boolean, projectionModelPath: string | undefined, onDownloadProgress: RustDownloadProgressCallback | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustModelInterface> /*throws*/ {
     const __stack = uniffiIsDebug ? new Error().stack : undefined;
     try {
         return await uniffiRustCallAsync(
             /*rustCaller:*/ uniffiCaller,
             /*rustFutureFunc:*/ () => {
-                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(FfiConverterString.lower(modelPath),FfiConverterBool.lower(useGpu),FfiConverterOptionalString.lower(projectionModelPath),FfiConverterOptionalTypeRustDownloadProgressCallback.lower(progressCallback)
+                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(FfiConverterString.lower(modelPath),FfiConverterBool.lower(useGpu),FfiConverterOptionalString.lower(projectionModelPath),FfiConverterOptionalTypeRustDownloadProgressCallback.lower(onDownloadProgress)
                 );
             },
             /*pollFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_poll_u64,
@@ -243,7 +243,7 @@ export function samplerPresetTopP(topP: /*f32*/number): SamplerConfigInterface {
  */
 export interface RustDownloadProgressCallback {
     
-    onProgress(downloaded: /*u64*/bigint, total: /*u64*/bigint) : void;
+    onDownloadProgress(downloaded: /*u64*/bigint, total: /*u64*/bigint) : void;
 }
 
 
@@ -252,7 +252,7 @@ const uniffiCallbackInterfaceRustDownloadProgressCallback: { vtable: UniffiVTabl
     // Create the VTable using a series of closures.
     // ts automatically converts these into C callback functions.
     vtable: {
-        onProgress: (
+        onDownloadProgress: (
             uniffiHandle: bigint,
             downloaded: bigint,
             total: bigint,) => {
@@ -260,7 +260,7 @@ const uniffiCallbackInterfaceRustDownloadProgressCallback: { vtable: UniffiVTabl
             ()
             : void => {
                 const jsCallback = FfiConverterTypeRustDownloadProgressCallback.lift(uniffiHandle);
-                return jsCallback.onProgress(
+                return jsCallback.onDownloadProgress(
                     FfiConverterUInt64.lift(downloaded), 
                     FfiConverterUInt64.lift(total)
                 )
@@ -3035,7 +3035,7 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_cosine_similarity() !== 63439) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_cosine_similarity");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 21168) {
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 33587) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_model");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_default() !== 10834) {
@@ -3191,8 +3191,8 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json() !== 6867) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress() !== 20201) {
-        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress");
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress() !== 28617) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_download_progress");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call() !== 43958) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call");

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -32,6 +32,7 @@ import nativeModule, {
   type UniffiForeignFutureCompleteRustBuffer,
   type UniffiForeignFutureResultVoid,
   type UniffiForeignFutureCompleteVoid,
+  type UniffiVTableCallbackInterfaceRustDownloadProgressCallback,
   type UniffiVTableCallbackInterfaceRustToolCallback,
 } from "./nobodywho-ffi";
 import {
@@ -104,13 +105,13 @@ export function cosineSimilarity(a: Array</*f32*/number>, b: Array</*f32*/number
  * uniffi-bindgen-react-native generates invalid JS (`async static` instead
  * of `static async`) for async constructors.
  */
-export async function loadModel(modelPath: string, useGpu: boolean, projectionModelPath: string | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustModelInterface> /*throws*/ {
+export async function loadModel(modelPath: string, useGpu: boolean, projectionModelPath: string | undefined, progressCallback: RustDownloadProgressCallback | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustModelInterface> /*throws*/ {
     const __stack = uniffiIsDebug ? new Error().stack : undefined;
     try {
         return await uniffiRustCallAsync(
             /*rustCaller:*/ uniffiCaller,
             /*rustFutureFunc:*/ () => {
-                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(FfiConverterString.lower(modelPath),FfiConverterBool.lower(useGpu),FfiConverterOptionalString.lower(projectionModelPath)
+                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(FfiConverterString.lower(modelPath),FfiConverterBool.lower(useGpu),FfiConverterOptionalString.lower(projectionModelPath),FfiConverterOptionalTypeRustDownloadProgressCallback.lower(progressCallback)
                 );
             },
             /*pollFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_poll_u64,
@@ -231,6 +232,69 @@ export function samplerPresetTopP(topP: /*f32*/number): SamplerConfigInterface {
     }
 
 
+
+
+
+/**
+ * Callback interface for download progress reporting. Implement this in your
+ * language to receive `(downloadedBytes, totalBytes)` events while a remote
+ * model is being downloaded. Throttled to ~10 Hz with a guaranteed final emit
+ * on completion. Not invoked for cached/local files.
+ */
+export interface RustDownloadProgressCallback {
+    
+    onProgress(downloaded: /*u64*/bigint, total: /*u64*/bigint) : void;
+}
+
+
+// Put the implementation in a struct so we don't pollute the top-level namespace
+const uniffiCallbackInterfaceRustDownloadProgressCallback: { vtable: UniffiVTableCallbackInterfaceRustDownloadProgressCallback; register: () => void; } = {
+    // Create the VTable using a series of closures.
+    // ts automatically converts these into C callback functions.
+    vtable: {
+        onProgress: (
+            uniffiHandle: bigint,
+            downloaded: bigint,
+            total: bigint,) => {
+            const uniffiMakeCall = 
+            ()
+            : void => {
+                const jsCallback = FfiConverterTypeRustDownloadProgressCallback.lift(uniffiHandle);
+                return jsCallback.onProgress(
+                    FfiConverterUInt64.lift(downloaded), 
+                    FfiConverterUInt64.lift(total)
+                )
+            };
+            const uniffiResult = UniffiResult.ready<void>();
+            const uniffiHandleSuccess = (obj: any) => {};
+            const uniffiHandleError = (code: number, errBuf: UniffiByteArray) => {
+                UniffiResult.writeError(uniffiResult, code, errBuf);
+            };
+            uniffiTraitInterfaceCall(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*lowerString:*/ FfiConverterString.lower
+            )
+            return uniffiResult;
+        },
+        uniffiFree: (uniffiHandle: UniffiHandle): void => {
+            // RustDownloadProgressCallback: this will throw a stale handle error if the handle isn't found.
+            FfiConverterTypeRustDownloadProgressCallback.drop(uniffiHandle);
+        },
+        uniffiClone: (uniffiHandle: UniffiHandle): UniffiHandle => {
+            return FfiConverterTypeRustDownloadProgressCallback.clone(uniffiHandle);
+        }
+    },
+    register: () => {
+        nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rustdownloadprogresscallback(
+            uniffiCallbackInterfaceRustDownloadProgressCallback.vtable
+        );
+    },
+};
+
+// FfiConverter protocol for callback interfaces
+const FfiConverterTypeRustDownloadProgressCallback = new FfiConverterCallback<RustDownloadProgressCallback>();
 
 
 
@@ -2891,6 +2955,10 @@ const uniffiTypeSamplerConfigObjectFactory: UniffiObjectFactory<SamplerConfigInt
 const FfiConverterTypeSamplerConfig =  new FfiConverterObject(uniffiTypeSamplerConfigObjectFactory);
 
 
+// FfiConverter for RustDownloadProgressCallback | undefined
+const FfiConverterOptionalTypeRustDownloadProgressCallback = new FfiConverterOptional(FfiConverterTypeRustDownloadProgressCallback);
+
+
 // FfiConverter for PendingToolCall | undefined
 const FfiConverterOptionalTypePendingToolCall = new FfiConverterOptional(FfiConverterTypePendingToolCall);
 
@@ -2967,7 +3035,7 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_cosine_similarity() !== 63439) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_cosine_similarity");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 63144) {
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 21168) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_model");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_default() !== 10834) {
@@ -3123,10 +3191,14 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json() !== 6867) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_samplerconfig_from_json");
     }
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress() !== 20201) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustdownloadprogresscallback_on_progress");
+    }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call() !== 43958) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rusttoolcallback_call");
     }
 
+    uniffiCallbackInterfaceRustDownloadProgressCallback.register();
     uniffiCallbackInterfaceRustToolCallback.register();
     }
 

--- a/nobodywho/react-native/package-lock.json
+++ b/nobodywho/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-nobodywho",
-  "version": "0.2.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-nobodywho",
-      "version": "0.2.1",
+      "version": "1.0.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "uniffi-bindgen-react-native": "0.30.0-1"

--- a/nobodywho/react-native/src/chat.ts
+++ b/nobodywho/react-native/src/chat.ts
@@ -69,11 +69,13 @@ export class Chat {
     templateVariables?: Record<string, boolean>;
     tools?: Tool[];
     sampler?: SamplerConfig;
+    onDownloadProgress?: (downloaded: number, total: number) => void;
   }): Promise<Chat> {
     const model = await Model.load({
       modelPath: opts.modelPath,
       useGpu: opts.useGpu,
       projectionModelPath: opts.projectionModelPath,
+      onDownloadProgress: opts.onDownloadProgress,
     });
     return new Chat({ model, ...opts });
   }

--- a/nobodywho/react-native/src/cross_encoder.ts
+++ b/nobodywho/react-native/src/cross_encoder.ts
@@ -35,8 +35,13 @@ export class CrossEncoder {
     modelPath: string;
     useGpu?: boolean;
     contextSize?: number;
+    onDownloadProgress?: (downloaded: number, total: number) => void;
   }): Promise<CrossEncoder> {
-    const model = await Model.load({ modelPath: opts.modelPath, useGpu: opts.useGpu });
+    const model = await Model.load({
+      modelPath: opts.modelPath,
+      useGpu: opts.useGpu,
+      onDownloadProgress: opts.onDownloadProgress,
+    });
     return new CrossEncoder({ model, ...opts });
   }
 

--- a/nobodywho/react-native/src/encoder.ts
+++ b/nobodywho/react-native/src/encoder.ts
@@ -31,8 +31,13 @@ export class Encoder {
     modelPath: string;
     useGpu?: boolean;
     contextSize?: number;
+    onDownloadProgress?: (downloaded: number, total: number) => void;
   }): Promise<Encoder> {
-    const model = await Model.load({ modelPath: opts.modelPath, useGpu: opts.useGpu });
+    const model = await Model.load({
+      modelPath: opts.modelPath,
+      useGpu: opts.useGpu,
+      onDownloadProgress: opts.onDownloadProgress,
+    });
     return new Encoder({ model, ...opts });
   }
 

--- a/nobodywho/react-native/src/model.ts
+++ b/nobodywho/react-native/src/model.ts
@@ -39,16 +39,23 @@ export class Model {
    * @param opts.modelPath - Path to the GGUF model file, or a `hf://owner/repo/file.gguf` / `https://` URL to download and cache automatically
    * @param opts.useGpu - Use GPU acceleration if available (default: true)
    * @param opts.projectionModelPath - Path to a multimodal projector file for vision models
+   * @param opts.onDownloadProgress - Invoked with `(downloaded, total)` byte counts while a remote model is being downloaded. Throttled to ~10 Hz with a guaranteed final emit on completion. Not invoked for cached/local files.
    */
   static async load(opts: {
     modelPath: string;
     useGpu?: boolean;
     projectionModelPath?: string;
+    onDownloadProgress?: (downloaded: number, total: number) => void;
   }): Promise<Model> {
+    const cb = opts.onDownloadProgress;
+    const progressCallback = cb
+      ? { onProgress: (d: bigint, t: bigint) => cb(Number(d), Number(t)) }
+      : undefined;
     const inner = await loadModel(
       opts.modelPath,
       opts.useGpu ?? true,
       opts.projectionModelPath,
+      progressCallback,
     );
     return new Model(inner);
   }

--- a/nobodywho/react-native/src/model.ts
+++ b/nobodywho/react-native/src/model.ts
@@ -49,7 +49,7 @@ export class Model {
   }): Promise<Model> {
     const cb = opts.onDownloadProgress;
     const progressCallback = cb
-      ? { onProgress: (d: bigint, t: bigint) => cb(Number(d), Number(t)) }
+      ? { onDownloadProgress: (d: bigint, t: bigint) => cb(Number(d), Number(t)) }
       : undefined;
     const inner = await loadModel(
       opts.modelPath,

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -529,31 +529,14 @@ pub trait RustDownloadProgressCallback: Send + Sync {
 }
 
 /// Bridge a foreign `RustDownloadProgressCallback` into the synchronous closure
-/// that core's `download_file` expects, with ~10 Hz throttling. Core fires the
-/// inner callback per chunk; without throttling we'd burn JSI hops on fast
-/// downloads. Always emits on completion so the UI never sticks at 99%.
+/// core expects, with ~10 Hz throttling provided by
+/// `throttled_progress_callback` (avoids burning JSI hops on fast downloads).
 fn wrap_progress(
     cb: Box<dyn RustDownloadProgressCallback>,
 ) -> nobodywho::llm::DownloadProgressCallback {
-    use std::sync::Mutex;
-    use std::time::{Duration, Instant};
     let cb: Arc<dyn RustDownloadProgressCallback> = Arc::from(cb);
-    let last_emit = Arc::new(Mutex::new(None::<Instant>));
-    Arc::new(move |downloaded: u64, total: u64| {
-        let is_done = total > 0 && downloaded >= total;
-        let emit = {
-            let mut last = last_emit.lock().expect("progress mutex poisoned");
-            let due = last.map_or(true, |t| t.elapsed() >= Duration::from_millis(100));
-            if is_done || due {
-                *last = Some(Instant::now());
-                true
-            } else {
-                false
-            }
-        };
-        if emit {
-            cb.on_progress(downloaded, total);
-        }
+    nobodywho::llm::throttled_progress_callback(move |downloaded, total| {
+        cb.on_progress(downloaded, total);
     })
 }
 

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -249,7 +249,7 @@ pub async fn load_model(
         projection_model_path
     );
 
-    let model = nobodywho::llm::get_model_async(model_path.clone(), use_gpu, projection_model_path)
+    let model = nobodywho::llm::get_model_async(model_path.clone(), use_gpu, projection_model_path, None)
         .await
         .map_err(|e| {
             let msg = format!("Failed to load model '{}': {}", model_path, e);

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -240,6 +240,7 @@ pub async fn load_model(
     model_path: String,
     use_gpu: bool,
     projection_model_path: Option<String>,
+    progress_callback: Option<Box<dyn RustDownloadProgressCallback>>,
 ) -> Result<Arc<RustModel>, NobodyWhoError> {
     init_logging();
     log::info!(
@@ -249,7 +250,8 @@ pub async fn load_model(
         projection_model_path
     );
 
-    let model = nobodywho::llm::get_model_async(model_path.clone(), use_gpu, projection_model_path, None)
+    let progress = progress_callback.map(wrap_progress);
+    let model = nobodywho::llm::get_model_async(model_path.clone(), use_gpu, projection_model_path, progress)
         .await
         .map_err(|e| {
             let msg = format!("Failed to load model '{}': {}", model_path, e);
@@ -515,6 +517,44 @@ impl RustTokenStream {
 #[uniffi::export(callback_interface)]
 pub trait RustToolCallback: Send + Sync {
     fn call(&self, arguments_json: String) -> String;
+}
+
+/// Callback interface for download progress reporting. Implement this in your
+/// language to receive `(downloadedBytes, totalBytes)` events while a remote
+/// model is being downloaded. Throttled to ~10 Hz with a guaranteed final emit
+/// on completion. Not invoked for cached/local files.
+#[uniffi::export(callback_interface)]
+pub trait RustDownloadProgressCallback: Send + Sync {
+    fn on_progress(&self, downloaded: u64, total: u64);
+}
+
+/// Bridge a foreign `RustDownloadProgressCallback` into the synchronous closure
+/// that core's `download_file` expects, with ~10 Hz throttling. Core fires the
+/// inner callback per chunk; without throttling we'd burn JSI hops on fast
+/// downloads. Always emits on completion so the UI never sticks at 99%.
+fn wrap_progress(
+    cb: Box<dyn RustDownloadProgressCallback>,
+) -> nobodywho::llm::DownloadProgressCallback {
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+    let cb: Arc<dyn RustDownloadProgressCallback> = Arc::from(cb);
+    let last_emit = Arc::new(Mutex::new(None::<Instant>));
+    Arc::new(move |downloaded: u64, total: u64| {
+        let is_done = total > 0 && downloaded >= total;
+        let emit = {
+            let mut last = last_emit.lock().expect("progress mutex poisoned");
+            let due = last.map_or(true, |t| t.elapsed() >= Duration::from_millis(100));
+            if is_done || due {
+                *last = Some(Instant::now());
+                true
+            } else {
+                false
+            }
+        };
+        if emit {
+            cb.on_progress(downloaded, total);
+        }
+    })
 }
 
 /// A pending tool call waiting for resolution from the language binding.

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -240,7 +240,7 @@ pub async fn load_model(
     model_path: String,
     use_gpu: bool,
     projection_model_path: Option<String>,
-    progress_callback: Option<Box<dyn RustDownloadProgressCallback>>,
+    on_download_progress: Option<Box<dyn RustDownloadProgressCallback>>,
 ) -> Result<Arc<RustModel>, NobodyWhoError> {
     init_logging();
     log::info!(
@@ -250,7 +250,7 @@ pub async fn load_model(
         projection_model_path
     );
 
-    let progress = progress_callback.map(wrap_progress);
+    let progress = on_download_progress.map(wrap_progress);
     let model = nobodywho::llm::get_model_async(
         model_path.clone(),
         use_gpu,
@@ -530,7 +530,7 @@ pub trait RustToolCallback: Send + Sync {
 /// on completion. Not invoked for cached/local files.
 #[uniffi::export(callback_interface)]
 pub trait RustDownloadProgressCallback: Send + Sync {
-    fn on_progress(&self, downloaded: u64, total: u64);
+    fn on_download_progress(&self, downloaded: u64, total: u64);
 }
 
 /// Bridge a foreign `RustDownloadProgressCallback` into the synchronous closure
@@ -541,7 +541,7 @@ fn wrap_progress(
 ) -> nobodywho::llm::DownloadProgressCallback {
     let cb: Arc<dyn RustDownloadProgressCallback> = Arc::from(cb);
     nobodywho::llm::throttled_progress_callback(move |downloaded, total| {
-        cb.on_progress(downloaded, total);
+        cb.on_download_progress(downloaded, total);
     })
 }
 

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -251,13 +251,18 @@ pub async fn load_model(
     );
 
     let progress = progress_callback.map(wrap_progress);
-    let model = nobodywho::llm::get_model_async(model_path.clone(), use_gpu, projection_model_path, progress)
-        .await
-        .map_err(|e| {
-            let msg = format!("Failed to load model '{}': {}", model_path, e);
-            log::error!("{}", msg);
-            NobodyWhoError::Error { message: msg }
-        })?;
+    let model = nobodywho::llm::get_model_async(
+        model_path.clone(),
+        use_gpu,
+        projection_model_path,
+        progress,
+    )
+    .await
+    .map_err(|e| {
+        let msg = format!("Failed to load model '{}': {}", model_path, e);
+        log::error!("{}", msg);
+        NobodyWhoError::Error { message: msg }
+    })?;
 
     log::info!("load_model SUCCESS for {}", model_path);
     Ok(Arc::new(RustModel {


### PR DESCRIPTION
Callbacks to show progress bar when downloading YEAH

I added it to all of the bindings:

### Flutter

Because `Option<...callable thingy...>` is not supported by FRB, this defaults to a no-op callback (not the indicatif one). Otherwise you can pass a callback that takes two ints (downloaded so far and total). This one blocks on async functions, so if the async function is slow, it may slow down the download.

### Python

passing `None` to the progress callback param defaults to an indicatif progess bar. otherwise the regular callback is invoked with two ints

### React Native

A regular js callback is passed in, called with two ints. If an async function is called, it is not awaited (fire-and-forget). Defaults to the indicatif progress bar.

### Godot

This one is a bit trickier, since you can only emit signals on the main thread. I pass in a callback that has a queue on it, and then call select in a loop to emit the stuff on a signal.
Godot is signal-based, not callbacks.