### PR TITLE
fix: Two embeddings issues

### DIFF
--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -2,8 +2,9 @@ use crate::errors::{EncoderWorkerError, InitWorkerError};
 use crate::llm;
 use crate::llm::{Worker, WorkerGuard};
 use llama_cpp_2::context::params::LlamaPoolingType;
+use llama_cpp_2::model::LlamaModel;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct Encoder {
@@ -80,11 +81,44 @@ fn process_worker_msg(
     Ok(())
 }
 
-struct EncoderWorker {}
+struct EncoderWorker {
+    pooling: LlamaPoolingType,
+}
 
 impl llm::PoolingType for EncoderWorker {
     fn pooling_type(&self) -> LlamaPoolingType {
-        LlamaPoolingType::Cls
+        self.pooling
+    }
+}
+
+/// Read `<arch>.pooling_type` from the GGUF metadata. Falls back to `Unspecified`
+/// (which makes llama.cpp resolve the pooling type itself) when the metadata is
+/// missing or unparseable, so models without an explicit pooling key still work.
+fn read_pooling_type_metadata(model: &LlamaModel) -> LlamaPoolingType {
+    let arch = match model.meta_val_str("general.architecture") {
+        Ok(arch) => arch,
+        Err(e) => {
+            warn!(error = %e, "general.architecture missing from GGUF; using Unspecified pooling");
+            return LlamaPoolingType::Unspecified;
+        }
+    };
+    let key = format!("{arch}.pooling_type");
+    match model.meta_val_str(&key) {
+        Ok(val) => match val.parse::<i32>() {
+            Ok(n) => {
+                let pt = LlamaPoolingType::from(n);
+                info!(?pt, %key, "Encoder pooling type from GGUF metadata");
+                pt
+            }
+            Err(e) => {
+                warn!(error = %e, %key, %val, "Couldn't parse pooling_type as i32; using Unspecified");
+                LlamaPoolingType::Unspecified
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, %key, "pooling_type missing from GGUF; using Unspecified");
+            LlamaPoolingType::Unspecified
+        }
     }
 }
 
@@ -93,7 +127,8 @@ impl<'a> Worker<'a, EncoderWorker> {
         model: &llm::Model,
         n_ctx: u32,
     ) -> Result<Worker<'_, EncoderWorker>, InitWorkerError> {
-        Worker::new_with_type(model, n_ctx, true, EncoderWorker {})
+        let pooling = read_pooling_type_metadata(&model.language_model);
+        Worker::new_with_type(model, n_ctx, true, EncoderWorker { pooling })
     }
 
     pub fn get_embedding(&self) -> Result<Vec<f32>, llama_cpp_2::EmbeddingsError> {

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -489,6 +489,7 @@ pub(crate) struct Worker<'a, S> {
     pub(crate) small_batch: LlamaBatch<'a>,
     pub(crate) projection_model: Option<&'a ProjectionModel>,
     pub(crate) tokenizer: Tokenizer<'a>,
+    pub(crate) use_embeddings: bool,
 
     pub(crate) extra: S,
 }
@@ -574,6 +575,7 @@ where
             projection_model,
             extra,
             tokenizer,
+            use_embeddings,
         };
         Ok(state)
     }
@@ -672,8 +674,12 @@ where
             self.big_batch.clear();
             let seq_ids = &[0];
             for (i, token) in (0..).zip(tokens.iter()) {
-                // Only compute logits for the last token to save computation
-                let output_logits = i == n_tokens - 1;
+                // For LLM workers only the last token's logits are needed (sampling).
+                // For encoder workers every token must be marked as an output so the
+                // pooling layer has hidden states to work with — otherwise llama.cpp
+                // logs "embeddings required but some input tokens were not marked as
+                // outputs -> overriding" and silently flips them on for us.
+                let output_logits = self.use_embeddings || i == n_tokens - 1;
                 self.big_batch
                     .add(*token, self.n_past + i as i32, seq_ids, output_logits)?;
             }


### PR DESCRIPTION
1. Llama.cpp would emit a warning log when running embeddings with not all tokens marked with "output logits". The ctx.decode call would auto-fix this, but the warning is still annoying.
2. The pooling type was hardcoded, and not read from the GGUF file. This attempts to read a pooling type from the gguf metadata.

I have tested that it works with the qwen3 embeddings model and the harrier-oss model from microsoft, but these both have `architecture=qwen3`, maybe we should test its behavior on a few more models to make sure the metadata reads well.

EDIT: the tests suite already runs embeddings test on a non-qwen3 embeddings model.