### PR TITLE
get_cached_models

### DIFF
--- a/docs/docs-flutter/downloading-models.md
+++ b/docs/docs-flutter/downloading-models.md
@@ -12,11 +12,11 @@ The `modelPath` argument to `Chat.fromPath`, `downloadModel`, and friends accept
 
 | Form | Example | Notes |
 | ---- | ------- | ----- |
-| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
 | HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
-| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+| Local path | `./model.gguf` | Used as-is |
 
-Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
 ## Tracking download progress
 

--- a/docs/docs-flutter/downloading-models.md
+++ b/docs/docs-flutter/downloading-models.md
@@ -1,0 +1,77 @@
+---
+title: Downloading models
+description: How NobodyWho downloads, caches, and inspects GGUF models in Flutter
+sidebar_position: 1
+---
+
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `modelPath` argument to `Chat.fromPath`, `downloadModel`, and friends accepts:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+
+Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+
+## Tracking download progress
+
+When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```dart
+final chat = await nobodywho.Chat.fromPath(
+  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+  onDownloadProgress: (downloaded, total) {
+    print('$downloaded / $total bytes');
+  },
+);
+```
+
+## Downloading a gated model
+
+Some HuggingFace models are private or gated by a license you need to accept. In both cases you need to be authorized to download the model weights.
+
+You can manually download the GGUF file via your web browser and then point `Chat.fromPath` at the local path:
+
+```dart
+final chat = await nobodywho.Chat.fromPath(
+  modelPath: './model.gguf',
+);
+```
+
+Or use `downloadModel` with an `Authorization` header:
+
+```dart
+import 'package:nobodywho/nobodywho.dart' as nobodywho;
+
+final modelPath = await nobodywho.downloadModel(
+  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+  headers: {'Authorization': 'Bearer your_hf_token'},
+);
+
+final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
+```
+
+You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Inspecting the model cache
+
+`getCachedModels` returns every `.gguf` model that lives in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `downloadModel` and by `Chat.fromPath`'s `huggingface:` paths. The call is synchronous.
+
+```dart
+import 'package:nobodywho/nobodywho.dart' as nobodywho;
+
+final models = nobodywho.getCachedModels();
+for (final (path, size) in models) {
+  print('$path: ${size ~/ BigInt.from(1024 * 1024)} MiB');
+}
+```
+
+- Paths are absolute.
+- Sizes are `BigInt` byte counts (the underlying Rust `usize`).
+- The list is empty if nothing has been downloaded yet.
+- Throws if the cache directory cannot be read.

--- a/docs/docs-flutter/index.md
+++ b/docs/docs-flutter/index.md
@@ -44,46 +44,6 @@ print(msg); // Yes, indeed, water is wet!
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
-## Downloading gated model
-
-Some HuggingFace models are either private or gated by a license that you need to accept.
-For both scenarios, you need to be authorized to download the model weights.
-
-In that case, you can resort to manually accessing the model page through your web browser,
-getting the GGUF file downloaded and then pointing our chat instance to the path where you have stored it:
-```dart
-final chat = await nobodywho.Chat.fromPath(
-  modelPath: './model.gguf',
-);
-```
-
-Or you can use the `downloadModel` function, where you can pass in the authorization token:
-```dart
-import 'package:nobodywho/nobodywho.dart' as nobodywho;
-
-final modelPath = await nobodywho.downloadModel(
-  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-  headers: {'Authorization': 'Bearer your_hf_token'},
-);
-
-final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
-```
-
-The token can be then generated in [your account settings](https://huggingface.co/settings/tokens).
-
-## Tracking download progress
-
-When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
-
-```dart
-final chat = await nobodywho.Chat.fromPath(
-  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-  onDownloadProgress: (downloaded, total) {
-    print('$downloaded / $total bytes');
-  },
-);
-```
-
 To get a full overview of the functionality provided by NobodyWho, simply keep reading. You can also have a look at our [flutter starter app repository](https://github.com/nobodywho-ooo/flutter-starter-example).
 
 ## Minimum recommended specs

--- a/docs/docs-godot/downloading-models.md
+++ b/docs/docs-godot/downloading-models.md
@@ -14,10 +14,10 @@ The `model_path` field on `NobodyWhoModel` (and `projection_model_path` for visi
 | Godot resource path | `res://models/my-model.gguf` | Bundled with your game export |
 | User data path | `user://downloaded.gguf` | Written by your game at runtime |
 | Absolute filesystem path | `/opt/models/foo.gguf` | Local file |
-| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
 | HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
 
-Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
 
 ## Showing download progress
 

--- a/docs/docs-godot/downloading-models.md
+++ b/docs/docs-godot/downloading-models.md
@@ -1,0 +1,72 @@
+# Downloading models
+_How NobodyWho downloads, caches, and inspects GGUF models in Godot._
+
+---
+
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `model_path` field on `NobodyWhoModel` (and `projection_model_path` for vision models) accepts several forms:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| Godot resource path | `res://models/my-model.gguf` | Bundled with your game export |
+| User data path | `user://downloaded.gguf` | Written by your game at runtime |
+| Absolute filesystem path | `/opt/models/foo.gguf` | Local file |
+| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+
+Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
+
+## Showing download progress
+
+`NobodyWhoModel` emits a `download_progress(downloaded, total)` signal while a remote model is downloading, throttled to roughly 10 Hz with a guaranteed final emit on completion. Connect it if you'd like to drive a progress bar:
+
+```gdscript
+model.download_progress.connect(func(downloaded: int, total: int):
+    print("%d / %d bytes" % [downloaded, total])
+)
+```
+
+The signal is not emitted for local files or already-cached downloads.
+
+## Downloading a gated model
+
+Some HuggingFace models are private or gated by a license you need to accept. In both cases you need to be authorized to download the model weights.
+
+You can manually download the GGUF file via your web browser and then point your `NobodyWhoModel` at the local path.
+
+Alternatively, use the `NobodyWhoDownloader` node, which lets you pass an authorization header:
+
+```gdscript
+var dl = NobodyWhoDownloader.new()
+dl.model_path = "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf"
+dl.headers = {"Authorization": "Bearer your_hf_token"}
+dl.download_complete.connect(func(local_path: String):
+    get_node("../ChatModel").model_path = local_path
+)
+dl.download_failed.connect(func(error: String):
+    push_error("Download failed: " + error)
+)
+dl.start_download()
+add_child(dl)
+```
+
+You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Inspecting the model cache
+
+`NobodyWhoModel.get_cached_models()` is a static function that returns every `.gguf` model in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `NobodyWhoDownloader` and by `NobodyWhoModel`'s `huggingface:` paths.
+
+```gdscript
+for entry in NobodyWhoModel.get_cached_models():
+    print("%s: %d bytes" % [entry["path"], entry["size"]])
+```
+
+Each entry is a `Dictionary` with two keys:
+
+- `"path"` — absolute path to the cached `.gguf` file
+- `"size"` — size in bytes
+
+The array is empty if nothing has been downloaded yet. On error the function returns `null` and logs a Godot error to the console.

--- a/docs/docs-python/downloading-models.md
+++ b/docs/docs-python/downloading-models.md
@@ -12,11 +12,11 @@ The `model_path` argument to `Chat`, `download_model`, and friends accepts:
 
 | Form | Example | Notes |
 | ---- | ------- | ----- |
-| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
 | HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
-| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+| Local path | `./model.gguf` | Used as-is |
 
-Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
 ## Tracking download progress
 

--- a/docs/docs-python/downloading-models.md
+++ b/docs/docs-python/downloading-models.md
@@ -1,0 +1,75 @@
+---
+title: Downloading models
+description: How NobodyWho downloads, caches, and inspects GGUF models in Python
+sidebar_position: 1
+---
+
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `model_path` argument to `Chat`, `download_model`, and friends accepts:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+
+Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+
+## Tracking download progress
+
+When loading a remote model, pass an `on_download_progress` callback to observe the download. It receives `(downloaded_bytes, total_bytes)` and is not called for cached or local files. If you don't pass anything, NobodyWho prints a default terminal progress bar.
+
+```python
+from nobodywho import download_model
+
+model_path = download_model(
+    'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+    on_download_progress=lambda downloaded, total: print(f"{downloaded}/{total} bytes"),
+)
+```
+
+## Downloading a gated model
+
+Some HuggingFace models are private or gated by a license you need to accept. In both cases you need to be authorized to download the model weights.
+
+You can manually download the GGUF file via your web browser and then point `Chat` at the local path:
+
+```python
+from nobodywho import Chat
+
+chat = Chat('./model.gguf')
+```
+
+Or use `download_model` with an `Authorization` header:
+
+```python
+from nobodywho import Chat, download_model
+
+model_path = download_model(
+    'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+    headers={ "Authorization": "Bearer your_hf_token" }
+)
+
+chat = Chat(model_path)
+```
+
+You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Inspecting the model cache
+
+`get_cached_models` returns every `.gguf` model that lives in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `download_model` and by `Chat`'s `huggingface:` paths.
+
+```python
+from nobodywho import get_cached_models
+
+for path, size in get_cached_models():
+    print(f"{path}: {size / 1024 / 1024:.1f} MiB")
+```
+
+- Paths are absolute.
+- Sizes are in bytes.
+- The list is empty if nothing has been downloaded yet.
+- Raises `RuntimeError` if the cache directory cannot be read.

--- a/docs/docs-python/index.md
+++ b/docs/docs-python/index.md
@@ -38,44 +38,4 @@ print(full_response)
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
-## Downloading gated model
-
-Some huggingface models are either private or gated by a license that you need to accept.
-For both scenarios, you need to be authorized to download the model weights.
-
-In that case, you can resort to manually accessing the model page through your web browser,
-getting the GGUF file downloaded and then pointing our chat instance to the path where you have stored it:
-```python
-from nobodywho import Chat
-
-chat = Chat('./model.gguf')
-```
-
-Or you can use the `download_model` function, where you can pass in the authorization token:
-```python
-from nobodywho import Chat, download_model
-
-model_path = download_model(
-    'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-    headers={ "Authorization": "Bearer your_hf_token" }
-)
-
-chat = Chat(model_path)
-```
-
-The token can be then generated in [your account settings](https://huggingface.co/settings/tokens).
-
-## Tracking download progress
-
-When loading a remote model, pass an `on_download_progress` callback to observe the download. It receives `(downloaded_bytes, total_bytes)` and is not called for cached or local files. If you don't pass anything, NobodyWho prints a default terminal progress bar.
-
-```python
-from nobodywho import download_model
-
-model_path = download_model(
-    'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-    on_download_progress=lambda downloaded, total: print(f"{downloaded}/{total} bytes"),
-)
-```
-
 To get a full overview of the functionality provided by NobodyWho, simply keep reading.

--- a/docs/docs-react-native/downloading-models.md
+++ b/docs/docs-react-native/downloading-models.md
@@ -1,0 +1,78 @@
+---
+title: Downloading models
+description: How NobodyWho downloads, caches, and inspects GGUF models in React Native
+sidebar_position: 1
+---
+
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `modelPath` option to `Chat.fromPath` and `downloadModel` accepts:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+
+Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+
+## Tracking download progress
+
+When loading a remote model, pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```typescript
+const chat = await Chat.fromPath({
+  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
+  onDownloadProgress: (downloaded, total) => {
+    console.log(`${downloaded} / ${total} bytes`);
+  },
+});
+```
+
+## Downloading a gated model
+
+Some HuggingFace models are private or gated by a license you need to accept. In both cases you need to be authorized to download the model weights.
+
+You can manually download the GGUF file via your web browser, place it on the device, and then point `Chat.fromPath` at the local path:
+
+```typescript
+import { Chat } from "react-native-nobodywho";
+
+const chat = await Chat.fromPath({ modelPath: "./model.gguf" });
+```
+
+Or use `downloadModel` with an `Authorization` header:
+
+```typescript
+import { downloadModel, Chat } from "react-native-nobodywho";
+
+const modelPath = await downloadModel({
+  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
+  headers: { Authorization: "Bearer your_hf_token" },
+});
+
+const chat = await Chat.fromPath({ modelPath });
+```
+
+You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Inspecting the model cache
+
+`getCachedModels()` returns every `.gguf` model in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `downloadModel` and by `Chat.fromPath`'s `huggingface:` paths.
+
+```typescript
+import { getCachedModels } from "react-native-nobodywho";
+
+for (const model of getCachedModels()) {
+  console.log(`${model.path}: ${Number(model.size)} bytes`);
+}
+```
+
+Each entry has:
+
+- `path: string` — absolute path to the cached `.gguf` file
+- `size: bigint` — size in bytes (the underlying Rust `u64`, exposed as JavaScript `bigint`)
+
+The array is empty if nothing has been downloaded yet. The call throws if the cache directory cannot be read.

--- a/docs/docs-react-native/downloading-models.md
+++ b/docs/docs-react-native/downloading-models.md
@@ -12,11 +12,11 @@ The `modelPath` option to `Chat.fromPath` and `downloadModel` accepts:
 
 | Form | Example | Notes |
 | ---- | ------- | ----- |
-| HuggingFace reference | `huggingface:owner/repo/file.gguf` or `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
 | HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
-| Local path | `./model.gguf`, `/abs/path/to/model.gguf` | Used as-is |
+| Local path | `./model.gguf` | Used as-is |
 
-Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
 ## Tracking download progress
 

--- a/docs/docs-react-native/index.md
+++ b/docs/docs-react-native/index.md
@@ -29,46 +29,6 @@ console.log(response); // Yes, indeed, water is wet!
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
 
-## Downloading gated model
-
-Some HuggingFace models are either private or gated by a license that you need to accept.
-For both scenarios, you need to be authorized to download the model weights.
-
-In that case, you can resort to manually accessing the model page through your web browser,
-getting the GGUF file downloaded to the device, and then pointing our chat instance to the path where you have stored it:
-```typescript
-import { Chat } from "react-native-nobodywho";
-
-const chat = await Chat.fromPath({ modelPath: "./model.gguf" });
-```
-
-Or you can use the `downloadModel` function, where you can pass in the authorization token:
-```typescript
-import { downloadModel, Chat } from "react-native-nobodywho";
-
-const modelPath = await downloadModel({
-  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
-  headers: { Authorization: "Bearer your_hf_token" },
-});
-
-const chat = await Chat.fromPath({ modelPath });
-```
-
-The token can be then generated in [your account settings](https://huggingface.co/settings/tokens).
-
-## Tracking download progress
-
-When loading a remote model (e.g. via a `huggingface:` or `https://` path), pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
-
-```typescript
-const chat = await Chat.fromPath({
-  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
-  onDownloadProgress: (downloaded, total) => {
-    console.log(`${downloaded} / ${total} bytes`);
-  },
-});
-```
-
 To get a full overview of the functionality provided by NobodyWho, simply keep reading.
 
 ## Android requirements

--- a/docs/docs-swift/downloading-models.md
+++ b/docs/docs-swift/downloading-models.md
@@ -12,11 +12,11 @@ The `modelPath` argument to `Chat.fromPath` and `Model.downloadModel` accepts:
 
 | Form | Example | Notes |
 | ---- | ------- | ----- |
-| HuggingFace reference | `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
 | HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
-| Local path | `/abs/path/to/model.gguf` | Used as-is |
+| Local path | `./model.gguf` | Used as-is |
 
-Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
 ## Tracking download progress
 

--- a/docs/docs-swift/downloading-models.md
+++ b/docs/docs-swift/downloading-models.md
@@ -1,0 +1,76 @@
+---
+title: Downloading models
+description: How NobodyWho downloads, caches, and inspects GGUF models in Swift
+sidebar_position: 1
+---
+
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `modelPath` argument to `Chat.fromPath` and `Model.downloadModel` accepts:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| HuggingFace reference | `hf://owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+| Local path | `/abs/path/to/model.gguf` | Used as-is |
+
+Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+
+## Tracking download progress
+
+When loading from a remote URL, pass a progress closure to `Chat.fromPath`. It receives `(downloaded, total)` byte counts and is not called for cached or local files.
+
+```swift
+let chat = try await Chat.fromPath(
+    modelPath: "hf://NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf"
+) { downloaded, total in
+    print("Downloaded \(downloaded)/\(total) bytes")
+}
+```
+
+## Downloading a gated model
+
+Some HuggingFace models are private or gated by a license you need to accept. In both cases you need to be authorized to download the model weights.
+
+You can manually download the GGUF file via your web browser and then point `Chat.fromPath` at the local path:
+
+```swift
+let chat = try await Chat.fromPath(modelPath: "./model.gguf")
+```
+
+Or use `Model.downloadModel` with an `Authorization` header:
+
+```swift
+import NobodyWho
+
+let modelPath = try await Model.downloadModel(
+    modelPath: "hf://NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
+    headers: ["Authorization": "Bearer your_hf_token"]
+)
+
+let chat = try await Chat.fromPath(modelPath: modelPath)
+```
+
+You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Inspecting the model cache
+
+`getCachedModels()` returns every `.gguf` model in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `Model.downloadModel` and by `Chat.fromPath`'s `hf://` paths.
+
+```swift
+import NobodyWho
+
+let models = try getCachedModels()
+for model in models {
+    print("\(model.path): \(model.size) bytes")
+}
+```
+
+Each `CachedModel` has:
+
+- `path: String` — absolute path to the cached `.gguf` file
+- `size: UInt64` — size in bytes
+
+The array is empty if nothing has been downloaded yet. The call throws if the cache directory cannot be read.

--- a/docs/docs-swift/index.md
+++ b/docs/docs-swift/index.md
@@ -39,16 +39,6 @@ let chat = try await Chat.fromPath(
 let chat = try await Chat.fromPath(modelPath: "/path/to/model.gguf")
 ```
 
-When loading from a remote URL, you can track download progress:
-
-```swift
-let chat = try await Chat.fromPath(
-    modelPath: "hf://NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf"
-) { downloaded, total in
-    print("Downloaded \(downloaded)/\(total) bytes")
-}
-```
-
 Once you have a `Chat`, call `.ask` to get a response!
 
 ```swift
@@ -57,31 +47,6 @@ print(response) // Yes, indeed, water is wet!
 ```
 
 This is a super simple example, but we believe that examples which do simple things, should be simple!
-
-## Downloading gated model
-
-Some HuggingFace models are either private or gated by a license that you need to accept.
-For both scenarios, you need to be authorized to download the model weights.
-
-In that case, you can resort to manually accessing the model page through your web browser,
-getting the GGUF file downloaded and then pointing our chat instance to the path where you have stored it:
-```swift
-let chat = try await Chat.fromPath(modelPath: "./model.gguf")
-```
-
-Or you can use the `Model.downloadModel` function, where you can pass in the authorization token:
-```swift
-import NobodyWho
-
-let modelPath = try await Model.downloadModel(
-    modelPath: "hf://NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
-    headers: ["Authorization": "Bearer your_hf_token"]
-)
-
-let chat = try await Chat.fromPath(modelPath: modelPath)
-```
-
-The token can be then generated in [your account settings](https://huggingface.co/settings/tokens).
 
 To get a full overview of the functionality provided by NobodyWho, simply keep reading.
 

--- a/docs/sidebars/flutter.ts
+++ b/docs/sidebars/flutter.ts
@@ -3,6 +3,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   flutter: [
     'index',
+    'downloading-models',
     'chat',
     'tool-calling',
     'vision',

--- a/docs/sidebars/godot.ts
+++ b/docs/sidebars/godot.ts
@@ -4,6 +4,7 @@ const sidebars: SidebarsConfig = {
   godot: [
     'install',
     'getting-started',
+    'downloading-models',
     'chat',
     'structured-output',
     'tool-calling',

--- a/docs/sidebars/python.ts
+++ b/docs/sidebars/python.ts
@@ -3,6 +3,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   python: [
     'index',
+    'downloading-models',
     'chat',
     'tool-calling',
     'vision',

--- a/docs/sidebars/react-native.ts
+++ b/docs/sidebars/react-native.ts
@@ -3,6 +3,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   'react-native': [
     'index',
+    'downloading-models',
     'chat',
     'tool-calling',
     'vision',

--- a/docs/sidebars/swift.ts
+++ b/docs/sidebars/swift.ts
@@ -3,6 +3,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   swift: [
     'index',
+    'downloading-models',
     'chat',
     'tool-calling',
     'vision',

--- a/docs/site/godot/chat/simple-chat.md
+++ b/docs/site/godot/chat/simple-chat.md
@@ -1,0 +1,250 @@
+# Simple Chat
+
+_A comprehensive guide to configuring, streaming, and controlling LLM responses through the Chat component._
+
+
+---
+
+Great! You've completed the ["Getting Started"](../getting-started.md) guide and got your first chat working as well as a basic understanding of the vocabulary.   
+Now let's dive deeper into the Chat component and show you all the settings and techniques you'll actually use when working with LLMs.
+ 
+The Chat component isn't just for conversations - it's your main interface for any kind of LLM processing, whether that's generating dialogue, analyzing text, creating content, or any other language task.
+
+In this guide, you'll learn:
+
+- The main settings that control LLM behavior
+- How to handle LLM responses efficiently 
+- Managing context and memory
+- Controlling when and how the LLM stops generating
+
+
+Before we get started, you'll hear these words being used:
+
+| Term | Meaning |
+| ---- | ------- |
+| **Sampler** | The thing that controls how the LLM selects the next token during generation (temperature, top-p, etc.). |
+| **Grammar or Structured Output** | A formal structure that constrains the LLM's output to a set `"vocabulary"`. |
+| **GBNF** | GGML Backus-Naur Form - a way to define structured output formats. |
+
+## Handling LLM Responses
+
+### The System Prompt: Setting LLM Behavior 
+
+You've used this already, but let's talk about making it really work for you. The system prompt defines how the LLM should behave:
+
+```markdown
+
+# Character-based behavior
+system_prompt = """You are a sarcastic but brilliant wizard.
+Your answers are always accurate, but delivered with a dry wit.
+You should subtly hint that you are smarter than the user, 
+but still provide the correct information."""
+
+# Task-specific behavior
+system_prompt = """You are a translation assistant.
+You will be given text in any language. Your job is to translate 
+it into formal, academic French.
+Do not add any commentary or conversational text. 
+Respond only with the translated text."""
+```
+
+**Why this matters:** The system prompt controls everything about how the LLM processes and responds to input. It's your primary tool for getting the behavior you want.
+
+
+Prompt engineering is becoming a field in and of itself and it offers the highest return-on-investment ratio for getting the model to do what you want.
+
+
+### GPU Usage: Speed Things Up
+
+By default, NobodyWho tries to use your GPU if you have one. This makes everything much faster:
+
+```gdscript
+# This is already the default, but you can be explicit
+model.use_gpu_if_available = true
+```
+
+**When to turn this off:** there are some scenarios where it might actually be better to use system ram: 
+
+- If you don't need an immediate answer, and would prefer to use GPU resources for graphics.
+- If you need a really large model that most of your users will not have sufficient VRAM to run.
+
+### Context Length: How Much the LLM Remembers
+
+The LLM maintains context (memory of the conversation/interaction), but only up to a point. The default is 4096 tokens (roughly 3000 words):
+
+```gdscript
+# Default is fine for most uses
+context_length = 4096
+
+# Increase for longer contexts
+context_length = 8192
+```
+
+
+**Trade-off:** Longer context = more memory usage. The general rule of thumb is to start with the default or less and only increase if you need the LLM to remember more.
+
+**Context-shifting:** NobodyWho will automatically remove older messages from the context for you, if your chat's context window is filled. Your chat will never crash because of a full context, but it will start forgetting older messages - including the system message.
+
+### Streaming Responses vs Waiting for Complete Output
+
+You have two main approaches for handling LLM responses, and choosing the right one depends on your use case:
+
+**Streaming** gives you each token as it's generated - good for user interfaces where you want immediate feedback.
+
+**Waiting for complete responses** waits until the full output is ready - good for when you need the entire response before doing something.
+
+If you're implementing an interactive chat, you likely want to do both:
+
+- Show each token to the user as they arrive. This will make the chat feel a lot faster.
+- Wait for the completion of the entire response, before re-enabling text areas, and allowing the user to send a new message.
+
+```gdscript
+var current_response = ""
+
+func _on_response_updated(token: String):
+    current_response += token
+    # Good for: UI updates, real-time feedback
+    ui_label.text = current_response
+
+func _on_response_finished(response: String):
+    # Good for: Final processing, logging, triggering next actions
+    print(response)
+    response = response.replace("<player>", player.name)
+    trigger_next_game_event()
+```
+
+**When to use streaming:**
+- Interactive dialogue where users expect immediate feedback
+- Long responses where you want to show progress
+
+**When to wait for complete responses:**
+- When you need to make decisions based on the full LLM output
+- Content generation where partial results are useless (like JSON or structured output answers).
+
+You most likely end up using both; having the response_updated to stream to your UI and then triggering the next step in your program when you get the full response.
+
+## Managing Context and Memory
+
+Sometimes you need to reset the LLM's memory or manage what it remembers.
+
+### Starting Fresh
+
+```gdscript
+# Clear all context, it will still have all the settings that you 
+# have set up before (including the system prompt)
+reset_context()
+```
+
+This is useful when:
+- Starting a new task that's unrelated to previous ones, where the previous history is irrelevant
+- The LLM gets confused as it has context shifted too much
+
+### Advanced Context Management
+
+If you need more control over what the LLM remembers:
+
+```gdscript
+# See what's in the context
+var messages = await get_chat_history()
+for message in messages:
+    print(message.role, ": ", message.content)
+
+# Set a custom context (useful for templates or saved states)
+var task_context = [
+    {"role": "user", "content": "Analyze the following data:"},
+    {"role": "assistant", "content": "I'm ready to analyze data. Please provide it."},
+    {"role": "user", "content": "Here's the data: " + data_to_analyze}
+]
+set_chat_history(task_context)
+```
+
+### Stop Words: Controlling LLM Output
+
+Some LLMs can be very verbose and you might want the LLM to limit its verbosity and stop generating at specific words or phrases:
+
+```gdscript
+chat.system_prompt = "Always answer with a question, no matter what."
+chat.stop_words = PackedStringArray(["?"])
+chat.say("I think we should plan something special for Sarah's birthday. any ideas?")
+
+# The LLM will generate something like:
+# llm: "What do you think about a surprise party?" (stops here)
+```
+
+This is useful when you want to prevent the LLM from running on. You can end generation prematurely, conditioned on specific words.
+
+### Enforce Structured Output (JSON)
+
+For reliable data extraction, you can force the LLM to output a response that strictly follows a basic JSON structure. This is incredibly useful for parsing LLM output into usable data without complex string matching.
+
+When you enable grammar without providing a custom grammar string, the system defaults to a built-in JSON grammar that ensures valid JSON output.
+
+```gdscript
+# configure the sampler to use the json preset
+chat.sampler.set_preset_json()
+
+# Tell the LLM to provide structured data
+chat.system_prompt = """You are a character creator. 
+Generate a character with name, weapon, and armor properties."""
+chat.say("Create a fantasy character")
+
+# Expected output will be valid JSON, like:
+# {"name": "Eldara", "weapon": "enchanted bow", "armor": "leather vest"}
+```
+
+**Note:** For advanced use cases where you need a very specific JSON structure or structured output that is not JSON, you can provide your own custom GBNF grammar by setting the `gbnf_grammar` property (Godot) or `grammar` field (Unity). This is covered in the [Structured Output](structured-output.md) guide.
+
+## Performance and Memory Tips
+
+### Start the Worker Early
+
+In a real-time application, you don't want the user's first interaction to trigger a long loading time. Starting the worker early, like during a splash screen or initial setup, pre-loads the model into memory so the first response is fast.
+
+```gdscript
+# In your _ready() function, set up everything before the app starts.
+func _ready():
+    # 1. Configure the chat behavior
+    self.system_prompt = "You are a helpful assistant."
+    self.model_node = get_node("../SharedModel")
+
+    # 2. Start the worker *before* the user can interact.
+    # This pre-loads the model so the first interaction isn't slow.
+    start_worker()
+
+    # 3. Now other setup can happen
+    print("Assistant chat is ready.")
+```
+
+**Why:** Starting the worker loads the model into memory. It's slow the first time, but then all LLM operations are much faster. 
+You should definitely think about when to do this to not ruin the UX too much.
+
+### Share Models Between Components
+
+An application might need to use an LLM for several different tasks. Instead of loading the same heavy model multiple times, you can have multiple `Chat` components that all share a single `Model` component. Each `Chat` can have its own system prompt and configuration, directing it to perform a different task.
+
+```gdscript
+# An application with multiple LLM-powered behaviors, all sharing one model.
+
+func _ready():
+    # 1. Get the single, shared model
+    var shared_model = get_node("../SharedModel")
+
+    # 2. Configure a chat component for general conversation
+    var casual_chat = get_node("CasualChat")
+    casual_chat.model_node = shared_model
+    casual_chat.system_prompt = "You are a friendly and helpful assistant. Keep your answers concise."
+    casual_chat.start_worker()
+
+    # 3. Configure another chat component for structured data extraction
+    var extractor_chat = get_node("ExtractorChat")
+    extractor_chat.model_node = shared_model
+    extractor_chat.system_prompt = "Extract the key information from the user's text and provide it in JSON format."
+    # This one would likely use a grammar to enforce JSON output.
+    extractor_chat.start_worker()
+
+    # Now you can use both for different tasks without loading two models!
+    casual_chat.say("Can you tell me about your capabilities?")
+    extractor_chat.say("My name is Jane Doe and my email is jane@example.com.")
+```
+
+**Memory savings:** Instead of loading multiple models, you load one and share it. Much more efficient!  

--- a/docs/site/godot/chat/structured-output.md
+++ b/docs/site/godot/chat/structured-output.md
@@ -1,0 +1,532 @@
+# Structured Output
+_Getting reliable, structured responses from your models_
+
+---
+
+Congratulations - you have understood the basics of having a large language models generate text for you. 
+You are now ready for some more juicy and complex options.
+
+Here are the key terms you should know:
+
+| Term | Meaning |
+| ---- | ------- |
+| **GBNF** | GGML Backus-Naur Form - a way to define strict rules for output format |
+| **Grammar** | The set of rules that define what valid output looks like |
+| **Token** | A piece of text (word, punctuation, etc.) that the model generates, generally 1 to 4 characters long |
+| **Encoder** | Translates text into tokens that the model can understand |
+
+
+## My model is so stupid that it can not even write json
+
+Yeah, most models will fail to generate valid json at some point if you just ask it to. 
+But fret not dear friend, the solution you are looking for is called :star: **STRUCTURED OUTPUT** :star:. 
+
+It is pretty much what it claims to be; A system that constrains the model's vocabulary to one that you determine.
+This can be useful for a myriad of things, from forcing the LLM to never use modern words, to using the LLM
+as the engine for your own procedural generation dungeon room.
+
+This section will take you through creating your own grammar that the model will have to use.
+
+### Why GBNF Beats Prompt Engineering
+
+You've probably tried this before:
+
+```
+""" Please respond in JSON format with name, level, and class fields
+Only use those fields.
+Only use valid json.
+All json attributes should have " around them.
+Please do not deviate from the instructions.
+You will lose 10 points if you use other fields than level, class and name.
+Do not write a message just json.
+If you do not respond in valid json I will lose my job and my kids will starve.
+"""
+```
+
+And got back something like:
+```
+Sure! Here's a character: {"name": "Eldara", "level": 15, "class": Wizard} - hope this helps!
+```
+
+Notice the problems? Missing quotes around "Wizard", extra text before and after. Your JSON parser explodes. 💥
+
+GBNF fixes this by making it **impossible** for the model to generate anything except the format you define:
+
+```json
+{"name": "Eldara", "level": 15, "class": "Wizard"}
+```
+
+Valid :clap: every :clap: time :clap:.
+
+## Understanding GBNF Grammar Rules
+
+### The Absolute Basics
+
+A GBNF grammar is made up of **rules**. Each rule says "this thing can be made from these parts":
+
+```
+rule-name ::= what-it-can-be
+```
+
+### Your First Grammar: Hello World
+
+Let's start with the simplest possible grammar:
+
+```
+root ::= "Hello World"
+```
+
+This says: "The output must be exactly the text 'Hello World'". That's it. The model can't say anything else.
+
+Try this and the model will always output: `Hello World`
+
+### Adding Choices with `|`
+
+What if we want some variety? Use `|` (pipe) to give options:
+
+```
+root ::= "Hello World" | "Hi there" | "Greetings"
+```
+
+Now the model can choose between these three options, but nothing else.
+
+### Building Blocks with Multiple Rules
+
+Here's where it gets interesting. You can break things into smaller pieces:
+
+```
+root ::= greeting " " name
+greeting ::= "Hello" | "Hi" | "Hey"
+name ::= "World" | "Friend" | "There"
+```
+
+This creates outputs like:
+- `Hello World`
+- `Hi Friend`
+- `Hey There`
+
+The model picks one option from `greeting`, adds a space, then picks one option from `name`.
+
+### Character Classes
+
+Instead of listing every letter, use character classes:
+
+```
+root ::= letter letter letter
+letter ::= [a-z]
+```
+
+`[a-z]` means "any lowercase letter from a to z". This generates random 3-letter combinations like `cat`, `how`, `dog`.
+so letter letter letter will make a three letter word
+
+Common character classes:
+- `[a-z]` - lowercase letters
+- `[A-Z]` - uppercase letters  
+- `[0-9]` - digits
+- `[a-zA-Z]` - any letter
+- `[a-zA-Z0-9]` - letters and numbers
+
+
+### Repetitions
+
+
+This quickly becomes tedious if you want to create either long words or just any word. This is where repetitions come in:
+
+- `*` means "zero or more"
+- `+` means "one or more"  
+- `?` means "optional (zero or one)"
+
+- `{n}` means "exactly n times"
+- `{n,}` means "at least n times"
+- `{n,m}` means "at least n and at most m times"
+
+```
+root ::= letter+
+```
+
+This means "one or more lowercase letters" - so you get words like `hello`, `a`, `supercalifragilisticexpialidocious`.
+
+```
+root ::= [a-z]+ [0-9]*
+```
+
+This means "letters followed by optional numbers" - so you get `hello`, `test123`, `word`.
+
+
+### Building JSON Step by Step
+
+Now that you have been tricked into learning the basics of regex, we should build a small JSON generator. Start simple:
+
+```
+root ::= "{" "}"
+```
+
+This only generates: `{}`
+
+Add one field:
+
+```
+root ::= "{" "\"name\"" ":" string "}"
+string ::= "\"" [a-zA-Z]+ "\""
+```
+
+This generates: `{"name":"Bob"}` (where Bob is any sequence of letters)
+
+Add more fields:
+
+```
+root ::= "{" "\"name\"" ":" string "," "\"level\"" ":" number "}"
+string ::= "\"" [a-zA-Z]+ "\""
+number ::= [0-9]+
+```
+
+This generates: `{"name":"Alice","level":"25"}`
+
+### Making It Flexible
+
+Use repetition to handle variable numbers of fields:
+
+```
+root ::= "{" pair ("," pair)* "}"
+pair ::= word ":" word
+word ::= "\"" [a-zA-Z]+ "\""
+```
+
+The `("," pair)*` means "zero or more additional pairs, each preceded by a comma". This generates:
+- `{"name":"Bob"}`
+- `{"name":"Alice","job":"Wizard"}`
+- `{"name":"Charlie","job":"Knight","weapon":"Sword"}`
+
+### Whitespace: Making It Readable
+
+Add optional whitespace to make output prettier:
+
+```
+root ::= "{" ws pair (ws "," ws pair)* ws "}"
+pair ::= string ws ":" ws string
+string ::= "\"" [a-zA-Z ]+ "\""
+ws ::= [ \t\n]*
+```
+
+The `ws` rule means "whitespace" - zero or more spaces, tabs, or newlines. Now you get nicely formatted JSON.
+
+### Advanced: Specific Values
+
+Control exactly what values are allowed:
+
+```
+root ::= "{" "\"class\"" ":" class-type "}"
+class-type ::= "\"Warrior\"" | "\"Mage\"" | "\"Rogue\"" | "\"Cleric\""
+```
+
+This only allows those four specific classes - no hallucinated "Tank-operator" in your neolithic era game!
+
+### Nested Structures
+
+Build complex nested data:
+
+```
+root ::= "{" "\"character\"" ":" character-object "}"
+character-object ::= "{" "\"name\"" ":" string "," "\"stats\"" ":" stats-object "}"
+stats-object ::= "{" "\"hp\"" ":" number "," "\"mp\"" ":" number "}"
+string ::= "\"" [a-zA-Z ]+ "\""
+number ::= [0-9]+
+```
+
+This creates nested JSON like:
+```json
+{"character":{"name":"Gandalf","stats":{"hp":"100","mp":"200"}}}
+```
+
+## Performance Optimization: Compact Formats
+
+Now that you understand GBNF with JSON, let's talk optimization. JSON is verbose and every token costs time. For high-performance applications, you can create much more compact formats.
+
+### Why Compact Formats Matter
+
+**JSON Format:**
+```json
+{"name":"Gandalf","level":15,"class":"Mage","hp":100,"mp":80}
+```
+*60 characters, ~38 tokens*
+
+**Compact Format:**
+```
+Gandalf|High|Mage|Low|High
+```
+*22 characters, ~10 tokens*
+
+**That's ~4 times faster while maintaining the same information!**
+
+### Building Compact Formats
+
+Start with pipe-separated values:
+
+```
+root ::= [A-Z][a-z]+ "|" [1-9][0-9]? "|" class-type
+class-type ::= "Warrior" | "Mage" | "Rogue" | "Cleric"
+```
+
+This generates: `Gandalf|15|Mage` (semantically clear - no ambiguity about what "Mage" means!)
+
+**Why not single letters?** If you used `"W" | "M" | "R" | "C"`, the LLM has no inherent knowledge that "M" means "Mage" rather than "Monk" or "Mercenary". The model generates tokens based on semantic understanding, not arbitrary mappings.
+
+### Different delimiters for different levels
+
+Use different separators for different levels:
+
+```
+root ::= character ("|" character)*
+character ::= [A-Z][a-z]+ ":" stats ":" equipment
+stats ::= stats-range "," stats-range "," stats-range
+stats-range ::= "low" | "medium" | "high" 
+equipment ::= weapon-type "," armor-type
+weapon-type ::= "Sword" | "Axe" | "Staff" | "Dagger"
+armor-type ::= "Leather" | "Robes" | "Chain" | "Plate"
+```
+
+This generates: `Gandalf:high,low,low:Staff,Robes|Aragorn:low,high,medium:Sword,Plate` which in JSON would be:
+
+```json
+[
+  {
+    "name": "Gandalf",
+    "stats": {
+      "hp": "high",
+      "mp": "low",
+      "level": "low"
+    },
+    "equipment": {
+      "weapon": "Staff",
+      "armor": "Robes"
+    }
+  },
+  {
+    "name": "Aragorn", 
+    "stats": {
+      "hp": "low",
+      "mp": "high",
+      "level": "medium"
+    },
+    "equipment": {
+      "weapon": "Sword",
+      "armor": "Plate"
+    }
+  }
+]
+```
+
+### Semantic Soundness
+
+One advantage of using JSON is the hints it gives the LLM. 
+If it sees `"name": "Gandalf"`, instead of just `Gandalf` it might be more inclined to generate a wizard class or give the character a staff.
+The same goes for numbers, the llm does not inherently understand what a good number for a high level or mana pool is - but it understands high vs low.
+
+When designing compact formats:
+
+✅ **Good:** `"Warrior" | "Mage" | "Rogue"`  
+✅ **Good:** `"Sword" | "Staff" | "Dagger"`  
+✅ **Good:** `"Leather" | "Robes" | "Chain"`  
+✅ **Good:** `"Low" | "Medium" | "High"`  
+
+❌ **Bad:** `"WAR" | "MAG" | "ROG"` - abbreviated and potentially ambiguous  
+❌ **Bad:** `"W" | "M" | "R"` - arbitrary single letters  
+❌ **Bad:** `"1" | "2" | "3"` - numeric values  
+
+The LLM generates text based on semantic understanding. Use full words that align perfectly with how language models think about concepts.  
+You should additionally provide the right context and single or few shots prompting to make it more robust.
+
+### Underscores footgun
+
+The GBNF format does not support `_`. According to the [the GBNF format documentation](https://github.com/ggml-org/llama.cpp/tree/master/grammars#json-schemas--gbnf), only lowercase characters and dashes are allowed for naming nonterminals.
+
+## Practical Example: Legendary Weapon Generator
+
+Let's build a weapon generation system that creates legendary weapons for your RPG. We'll start simple and add complexity step by step, showing you how GBNF grammars work in practice.
+
+### Why Use GBNF for Weapon Generation?
+
+Traditional random generators often create nonsensical combinations like "Flaming Sword of Ice", with 8 fire damage and a random generic backstory as well an ice ability. More advanced systems exist but they rely on lookup tables which can become tedious very quickly.
+LLMs with GBNF understand semantic coherence - they'll generate "Flamebrand, Ancient Sword of Solar Wrath" instead. 
+Which has 8 fire damage, and a meaningful backstory based on how you got it 
+or the lore from your game as well as an ability that is chosen based on the backstory, damage and name.
+
+### Step 1: Dynamic Weapon Name Generator
+
+Let's start with a weapon generator that builds weapon names:
+
+**Grammar:**
+```
+root ::= weapon-name " (" weapon-type ")"
+weapon-name ::= name-prefix name-suffix
+name-prefix ::= "Flame" | "Frost" | "Shadow" | "Storm" | "Light" | "Dark"
+name-suffix ::= "brand" | "fang" | "bane" | "call" | "ward" | "rend"
+weapon-type ::= "Sword" | "Axe" | "Dagger" | "Staff" | "Bow" | "Hammer"
+```
+
+```gdscript
+extends Node
+
+@onready var model = $Model # Your NobodyWhoModel node
+@onready var chat = $Chat   # Your NobodyWhoChat node
+
+func _ready():
+    # Configure the weapon generator
+    model.model_path = "res://models/your-model.gguf"
+    chat.model_node = model
+    chat.system_prompt = "You are a legendary weapon generator for a fantasy RPG."
+    
+    # Start the worker so it's ready
+    chat.start_worker()
+    
+    # Connect to handle responses
+    chat.response_finished.connect(_on_weapon_generated)
+
+func _input(event):
+    if event is InputEventKey and event.pressed and event.keycode == KEY_SPACE:
+        generate_weapon()
+
+func generate_weapon():
+    chat.sampler.set_preset_grammar(grammar_string)
+
+    # Reset context to avoid new weapons to be influenced by already generated ones.
+    chat.reset_context()
+    chat.say("Generate a weapon:")
+
+func _on_weapon_generated(weapon_name: String):
+    print(weapon_name)
+    # Here you could add the weapon to inventory, display it in UI, etc.
+```
+
+**Output examples:**
+
+- `Flamebrand (Sword)`
+- `Shadowfang (Dagger)`
+- `Stormcall (Staff)`
+- `Darkward (Bow)`
+
+This is more or less just a random number generator, but more GPU expensive...
+
+### Step 2: Adding Weapon Stats
+
+Let's add damage and abilities to make weapons more interesting for gameplay, this is where we deviate from a random weapon generator to a semantic weapon generator:
+
+**Grammar:**
+```
+root ::= weapon-name " (" weapon-type ") - " damage-level " damage, " ability-name " ability. "  backstory
+weapon-name ::= name-prefix name-suffix
+name-prefix ::= "Flame" | "Frost" | "Shadow" | "Storm" | "Light" | "Dark"
+name-suffix ::= "brand" | "fang" | "bane" | "call" | "ward" | "rend"
+weapon-type ::= "Sword" | "Axe" | "Dagger" | "Staff" | "Bow" | "Hammer"
+damage-level ::= "Low" | "Medium" | "High" | "Legendary"
+ability-name ::= "Flame Strike" | "Frost Bite" | "Shadow Step" | "Lightning Bolt" | "Healing Aura" | "Poison Cloud"
+backstory ::= [a-zA-Z0-9 ]+ "."
+```
+
+Be careful not to add too many symbols in your backstory. If the model can not write a `.` it will increase the chance that it will end the sentence instead of writing paragraph upon paragraph of text.
+
+```gdscript
+func generate_weapon():
+    chat.sampler.set_preset_grammar(grammar_string)
+
+    # Reset context to avoid new weapons to be influenced by already generated ones.
+    chat.reset_context()
+    chat.say("Generate a weapon:")
+
+func _on_weapon_generated(weapon_data: String):
+    print(weapon_data)
+```
+
+**Output examples:**
+
+- `Shadowfang (Sword) - Legendary damage, Shadow Step ability. Shadowfang is a legendary sword that was forged by the ancient shadow realm.`
+
+See how the examples will match flame and brand to a sword, will give it the flame strike ability as well as a thematic backstory. It feels like there is intent behind the creation of this weapon.
+
+### Step 3: Enhanced Backstories
+
+Let's expand the backstory system to allow for richer, more detailed weapon lore:
+
+**Grammar:**
+```
+root ::= weapon-name " (" weapon-type ") - " damage-level " damage, " ability-name " ability. Story: " backstory
+weapon-name ::= name-prefix name-suffix
+name-prefix ::= "Flame" | "Frost" | "Shadow" | "Storm" | "Light" | "Dark"
+name-suffix ::= "brand" | "fang" | "bane" | "call" | "ward" | "rend"
+weapon-type ::= "Sword" | "Axe" | "Dagger" | "Staff" | "Bow" | "Hammer"
+damage-level ::= "Low" | "Medium" | "High" | "Legendary"
+ability-name ::= "Flame Strike" | "Frost Bite" | "Shadow Step" | "Lightning Bolt" | "Healing Aura" | "Poison Cloud"
+backstory ::= [a-zA-Z0-9 ]{50,200} "."
+```
+
+When doing this we want to also inject some of our lore. We will borrow from  Lord of the rings here - replace with your own lore.
+
+```gdscript
+
+func _ready():
+  # Configure the weapon generator 
+  chat.model_node = model
+  chat.system_prompt = "Generate a weapon a backstory in the LOTR universe"
+    # ... rest of the setup
+
+
+func generate_weapon():
+    var sampler = NobodyWhoSampler.new()
+    sampler.use_grammar = true
+    sampler.gbnf_grammar = grammar_string
+    # Generate random seed for variety
+    sampler.seed = randi()
+    chat.sampler = sampler
+    
+    # Reset context to avoid new weapons to be influenced by already generated ones.
+    chat.reset_context()
+    chat.say("The party just found a new weapon after travelling through the mines of Moria:")
+
+func _on_weapon_generated(weapon_data: String):
+    print(weapon_data)
+```
+
+**Output examples:**
+- `Shadowfang (Sword) - Legendary damage, Shadow Step ability. The sword is made from the dark shards that were once part of the Balrog`
+- `Flamebrand (Sword) - High damage, Flame Strike ability. Backstory involves a fallen dwarf lord named Drakon who was corrupted by the Balrogs and used the sword to slay an enemy.`
+
+### Step 4: Compact Format for Performance
+
+For games that generate many weapons or even very complex weapons, you want maximum efficiency. Let's create a compact pipe-separated format:
+
+**Grammar:**
+```
+root ::= weapon-name "|" weapon-type "|" damage-level "|" ability-name "|" weight "|" throwable "|" damage-type "|" durability "|" rarity "|" enchantment "|" material "|" short-story
+weapon-name ::= name-prefix name-suffix
+name-prefix ::= "Flame" | "Frost" | "Shadow" | "Storm" | "Light" | "Dark"
+name-suffix ::= "brand" | "fang" | "bane" | "call" | "ward" | "rend"
+weapon-type ::= "Sword" | "Axe" | "Dagger" | "Staff" | "Bow" | "Hammer"
+damage-level ::= "Low" | "Medium" | "High" | "Legendary"
+ability-name ::= "Flame Strike" | "Frost Bite" | "Shadow Step" | "Lightning Bolt" | "Healing Aura" | "Poison Cloud"
+weight ::= "Heavy" | "Light"
+throwable ::= "Throwable" | "Non-throwable"
+damage-type ::= "Sharp" | "Pierce" | "Blunt"
+durability ::= "Fragile" | "Sturdy" | "Unbreakable"
+rarity ::= "Common" | "Rare" | "Epic" | "Legendary"
+enchantment ::= "Glowing" | "Humming" | "Pulsing" | "Silent"
+material ::= "Steel" | "Mithril" | "Obsidian" | "Crystal"
+backstory ::= [a-zA-Z0-9 ]{50,200} "."
+```
+
+**Note:** So-called "thinking" or "reasoning" models will strongly prefer to start every generation with a block of text inside `<think>` tags. If your grammar doesn't naturally allow the output to be prefixed with a "thinking" section like this, it will try to squeeze it into free-text sections (e.g. like the backstory section in the example above). If relying a lot on structured generation, you may prefer to use a "non-thinking" model. If you prefer to keep the "thinking" ability, you could begin your grammar with a section like `"<think>" [a-zA-Z0-9 ]{10,1000} "." "</think>` to allow it to get it's reasoning section out of the way.
+Furthermore, the current implementation of GBNF has some performance issues with using specifc ranges (eg: word{10,20}) - so it might be smarter to have a non grammarized model generate the short story.
+
+**Output examples:**
+- `Flamebrand|Sword|High|Flame Strike|Heavy|Non-throwable|Sharp|Sturdy|Epic|Glowing|Steel|Forged by fire elementals in ancient volcano`
+
+or with thinking models (demonstrating that it will squeeze in the "thinking" section wherever possible:
+
+- `Shadowfang|Axe|Legendary|Shadow Step|Light|Throwable|Sharp|Sturdy|Epic|Silent|Steel|The Shadowfang is a legendary axe that is said to have been forged in the depths of the Shadowspire Mountains by the elusive Night Hunter.`
+- `Stormcall|Staff|Legendary|Lightning Bolt|Light|Non-throwable|Blunt|Unbreakable|Legendary|Pulsing|Crystal|The user wants me to generate a short story for the weapon. I will think...`
+
+---
+
+This is quite a powerful system for procedural generation of anything being weapons, levels, questlines or whatever you can think of, and even better 
+You get to influence the generation meaningfully with the prompt that you send, while keeping the variety offered by the system.
+
+This complete system generates weapons with all the attributes your game systems might need, from combat mechanics (damage type, weight) to visual effects (enchantment, material) and lore (story).

--- a/docs/site/godot/chat/tool-calling.md
+++ b/docs/site/godot/chat/tool-calling.md
@@ -1,0 +1,166 @@
+# Tool Calling
+_Triggering actions from within the model._
+
+---
+
+Welcome to the tool calling page!
+
+Now that you have some of the basics understood (if not, please read [Simple Chat](simple-chat.md)), 
+we can move on to adding one of the truly powerful and fun components to our model; Tool/Function Calling.
+
+Tool calling is a way to give your model actions to perform in your game world.  
+
+The model can:
+
+* Check data - "What's my health?"
+* Change the world - "Open the north gate."
+* Run helper logic - damage rolls, crafting math, random loot.
+
+We'll start with a small and simple tool, add arguments, then increase accuracy using schema and adding constraints.
+
+**Note that not all models support tool calling**
+
+---
+
+## A simple tool
+
+This is an example of how to give the model access to a function we have created that gets the player's current stats (health, mana, gold).
+
+    
+```gdscript
+extends NobodyWhoChat
+
+func get_player_stats() -> String:
+    var player = GameManager.get_local_player()
+    return JSON.stringify({
+        "health": player.health,
+        "mana":   player.mana,
+        "gold":   player.gold
+    })
+
+func _ready():
+    add_tool(get_player_stats, "Returns the local player's health, mana, and gold.")
+```
+
+Ask "How hurt am I?" - the model calls your tool and answers with real numbers.
+
+---
+
+
+## But I need arguments, you say:
+
+Sure - that is possible, but only primitives are currently implemented in NobodyWho:
+Allowed primitive types: `int`, `float`, `bool`, `String`/`string`, `Array`/`string[]`
+
+Models operate with JSON as an abstract layer instead of using a specific language (like Godot) when calling tools. 
+When NobodyWho receives a function or a delegate it will deconstruct the name and parameters and use them 
+to construct a JSON schema that we can pass to the model.
+
+In the example below the generated json will look something like this:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "amount": {
+      "type": "integer",
+      "description": ""
+    }
+  },
+  "required": ["amount"]
+}
+```
+
+This is then used to construct a lazy-loadable gbnf grammar, so the models always pass the correct number and set of arguments.
+A limitation of this is that we cannot extract the description from a given argument. 
+Therefore it might be advantageous to write your own schema for maximum precision.
+
+```gdscript
+func heal_player(amount: int) -> String:
+    GameManager.get_local_player().heal(amount)
+    return "Healed %d HP" % amount
+
+add_tool(heal_player, "Heals the local player by a number of hit-points")
+```
+*Godot auto-builds the JSON schema from the type hints.*  
+Therefore you must ensure that all parameters are listed and return type is defined from the method.
+
+---
+
+
+## Your model is now ready to interact with the world
+
+Have the model open a door.
+
+```gdscript
+func open_door(door_id: String) -> String:
+    DoorManager.open(door_id)
+    return "Opened door %s" % door_id
+
+add_tool(open_door, "Opens a door in the world by id")
+
+chat.say("can you open the door")
+```
+
+The model will pause any generation until the tool is completed.
+
+
+---
+
+## Multiple Tools & Resetting
+
+You can add as many tools as like, but you need to reset the context before they will be taken into account.
+
+```gdscript
+add_tool(get_player_stats, "Player stats")
+add_tool(open_door,        "Open a door")
+reset_context()
+```
+
+---
+
+## But I don't want it to hallucinate random strings
+
+Don't worry, we've got you. 
+As I mentioned before, we are using the OpenSchema specification, which goes like this:
+
+```jsonschema
+{
+  "type": "object",
+  "properties": {
+    "color": {
+      "type": "string",
+      "description": "A specific color for the button",
+      "enum": ["red", "blue", "green"]
+    }
+  },
+  "required": ["color"],
+}
+```
+
+The type must always be an `object`, the properties are a dictionary of where the key is the parameter name, and the value describes the data for the parameter. Ie. type determines whether it is a string, a list or something else. Description describes how the parameter is used. 
+
+If the properties are not a part of the `required` list, the model will see them as optional parameter.
+
+```gdscript
+# `press_button_schema` holds the JSON shown above.
+func press_button(color: String) -> String:
+    ButtonManager.press(color)
+    return "Pressed %s button" % color
+
+add_tool_with_schema(press_button,
+                     press_button_schema,
+                     "Press one of the three coloured buttons (red, blue, green)")
+```
+
+Result: the model **cannot** request any color other than *red*, *blue*, or *green*.  Use the same pattern for item rarities, quest tiers, etc...
+
+**Heads-up** – NobodyWho turns that schema into a GBNF grammar using the open-source [`richardanaya/gbnf`](https://github.com/richardanaya/gbnf) converter.  It currently supports the common bits: primitive types, `enum`, `required`, flat `oneOf`, and simple arrays.  Exotic keywords (`minimum`, `pattern`, deeply-nested refs) may be ignored until the library grows.
+
+---
+
+A note on descriptions:
+
+The description helps the model pick the right tool and pass the right arguments. Be explicit. Explain when to use the tool, explain what the tool does.
+Bad: **"Door"**  
+Good: **"Use this function when the assistant is blocked or needs to close a door. This tool opens or closes the door with the given id, if -1 is given, the nearest door will be interacted with."**

--- a/docs/site/godot/embeddings.md
+++ b/docs/site/godot/embeddings.md
@@ -1,0 +1,167 @@
+# Understanding Text with Embeddings
+_A complete guide to using embeddings for semantic text comparison and natural language understanding._
+
+---
+
+Cool, you've got the basics of chat working! Now let's explore embeddings, which let you understand what text means rather than just matching exact words.
+
+Embeddings are like a smart way to measure how similar two pieces of text are, even if they use completely different words. 
+Instead of looking for exact matches, embeddings understand meaning.   
+For example, "Hand me the red potion" and "Give me the scarlet flask" would be recognized as very similar, even though they share no common words.
+
+Here are the key terms for working with embeddings:
+
+| Term | Meaning |
+| ---- | ------- |
+| **Embedding Model (GGUF)** | A specialized `*.gguf` file trained to convert text into numerical vectors that represent meaning. |
+| **Embedding** | A list of numbers (vector) that represents the meaning of a piece of text. |
+| **Cosine Similarity** | A mathematical way to compare how similar two embeddings are, returning a value between 0 (completely different) and 1 (identical meaning). |
+| **Semantic Search** | Finding text that means the same thing, even if the words are different. |
+| **Vector** | The array of numbers that represents your text's meaning. |
+
+Let's show you how to use embeddings to understand what your players really mean when they type commands.
+
+## Download an Embedding Model
+
+Embedding models are different from chat models. You need a model specifically trained for embeddings.
+
+We normally use [bge-small-en-v1.5-q8_0.gguf](https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf).
+
+
+## Practical Example: Quest & Reputation System
+
+A good way to visualize the practicality of embeddings is through an example. 
+In this example we will guide you through how to make a quest trigger or lowering the user's reputation based on what they say.
+
+We'll build it step by step, but for the impatient; The complete script is copyable in the bottom of the page.
+
+### Step 1: Set up your basic structure and variables
+
+The first step is to setup our components. We will add some statements for quests and some for hostile behavior - these are not exhaustive lists. 
+
+**Do note** that it will take a longer time to embed a lot of sentences (depending on model and hardware of course), so depending on how complex your statements need to be, 
+you might be better off having a handful and tuning the sensitivity of the trigger instead.
+
+First, create your script that extends `NobodyWhoEmbedding` and define your statement categories:
+
+```gdscript
+extends NobodyWhoEmbedding
+
+var quest_triggers= [
+    "I know where the dragon rests",
+    "The druid told me the proper way to meet the dragon",
+    "I discovered the ritual needed to gain the dragon's audience",
+    "I know about the sacred grove"
+]
+
+var hostile_statements = [
+    "I want to kill the dragon",
+    "I'm going to destroy everything",
+    "I hate this place and everyone in it",
+    "I will burn down the village",
+    "Everyone here deserves to die"
+]
+
+var helpful_embeddings = []
+var hostile_embeddings = []
+var player_reputation = 0
+```
+
+### Step 2: Initialize the embedding system
+
+
+Set up the embedding model and start the worker:
+
+```gdscript
+func _ready():
+    # Create and configure the embedding model
+    var embedding_model = NobodyWhoModel.new()
+    embedding_model.model_path = "res://models/bge-small-en-v1.5-q8_0.gguf"
+    get_parent().add_child(embedding_model)
+    
+    # Link to the embedding model
+    self.model_node = embedding_model
+    self.embedding_finished.connect(_on_embedding_finished)
+    self.start_worker()
+    
+    # Pre-generate embeddings for all statement types
+    precompute_all_embeddings()
+```
+
+
+### Step 3: Precompute reference embeddings
+
+Generate embeddings for all your reference statements:
+
+```gdscript
+func precompute_all_embeddings():
+    # Generate embeddings for helpful statements
+    for statement in quest_triggers:
+        embed(statement)
+        var embedding = await self.embedding_finished
+        helpful_embeddings.append(embedding)
+    
+    # Generate embeddings for hostile statements
+    for statement in hostile_statements:
+        embed(statement)
+        var embedding = await self.embedding_finished
+        hostile_embeddings.append(embedding)
+```
+
+
+### Step 4: Add input handling for testing
+
+
+Add a simple test trigger using the enter key:
+
+```gdscript
+func _input(event):
+    # Handle enter key press to send hardcoded test message
+    if event is InputEventKey and event.pressed:
+        if event.keycode == KEY_ENTER:
+            var test_message = "I know the location of the dragon"
+            print("Sending test message: ", test_message)
+            analyze_player_statement(test_message)
+```
+
+### Step 5: Analyze player statements
+
+
+Compare the player's message against your reference embeddings:
+
+```gdscript
+func analyze_player_statement(player_text: String):
+    # Generate embedding for player input
+    embed(player_text)
+    var player_embedding = await self.embedding_finished
+    
+    # Compare against both categories
+    var best_helpful_similarity = get_best_similarity(player_embedding, helpful_embeddings)
+    var best_hostile_similarity = get_best_similarity(player_embedding, hostile_embeddings)
+    
+    print("Helpful similarity: ", best_helpful_similarity)
+    print("Hostile similarity: ", best_hostile_similarity)
+    
+    # Use similarity threshold of 0.8 and compare categories
+    if best_helpful_similarity > 0.8 and best_helpful_similarity > best_hostile_similarity:
+        handle_helpful_information(player_text)
+    elif best_hostile_similarity > 0.8 and best_hostile_similarity > best_helpful_similarity:
+        handle_hostile_intent(player_text)
+    else:
+        print("Unclear intent - no strong match found")
+```
+
+### Step 6: Handle the results
+
+
+Trigger appropriate game systems based on detected intent:
+
+```gdscript
+func handle_helpful_information(text: String):
+    # Trigger game systems based on detected intent
+    print("🐉 Triggering quest: 'Audience with the Ancient Dragon'!")
+
+func handle_hostile_intent(text: String):
+    player_reputation -= 15
+    print("Player expressed hostile intent! Reputation -15 (now: ", player_reputation, ")")
+```

--- a/docs/site/godot/getting-started.md
+++ b/docs/site/godot/getting-started.md
@@ -25,10 +25,10 @@ Let's show you how to use the plugin to get a large language model to answer you
 ## Download a GGUF Model
 
 The first step is to get a model.
-If you're in a hurry, just download [Qwen3 0.6B Q4_K_M](https://huggingface.co/NobodyWho/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf).
-It's super small and fast, and works for well for simple use-cases.
+If you're in a hurry, just download [Qwen_Qwen3-4B-Q4_K_M.gguf](https://huggingface.co/bartowski/Qwen_Qwen3-4B-GGUF/resolve/main/Qwen_Qwen3-4B-Q4_K_M.gguf). 
+It's pretty good and we will base our tutorials around this model. 
 
-Otherwise, check out our [recommended models](/docs/model-selection) or if you have a non-standard use case, shoot us a question in Discord.
+Otherwise, check out our [recommended models](../model-selection.md) or if you have a non-standard use case, shoot us a question in Discord.
 
 ## Load the GGUF model
 
@@ -37,26 +37,10 @@ At this point you should have downloaded the model and put it into your project 
 
 Add a `NobodyWhoModel` node to your scene tree.
 
-Set the model path to point to your GGUF model. 
-![set model path](/img/godot_model_selection.png)
+Set the model path to point to your GGUF model. (1)
+{ .annotate }
 
-`model_path` accepts local paths (`res://`, `user://`, or an absolute filesystem path) as well as `huggingface:` / `hf://` references and `https://` URLs that are downloaded and cached on first use. See [Downloading models](./downloading-models) for the full list of supported formats, download progress signals, gated/private models, and inspecting the local cache.
-
-### Knowing when the worker is ready
-
-`start_worker()` returns immediately. The worker finishes loading in the background (including any download). Connect to the new signals if your game logic needs to wait:
-
-```gdscript
-chat.worker_started.connect(func():
-    print("Ready to chat!")
-)
-chat.worker_failed.connect(func(err):
-    push_error("Model load failed: " + err)
-)
-chat.start_worker()
-```
-
-You can also call `ask()` straight away — prompts issued before the worker is ready are queued and dispatched as soon as loading completes. The same applies to `NobodyWhoEncoder.encode()` and `NobodyWhoCrossEncoder.rank()`.
+1. ![set model path](assets/godot_model_selection.png)
 
 
 ## Create a new Chat
@@ -83,10 +67,10 @@ func _ready():
     # Start the worker, this is not required, but recommended to do in
     # the beginning of the program to make sure it is ready
     # when the user prompts the chat the first time. This will be called
-    # under the hood when you use `ask()` as well.
+    # under the hood when you use `say()` as well.
     self.start_worker()
 
-    self.ask("How are you?")
+    self.say("How are you?")
 
 func _on_response_updated(token):
     # this will print every time a new token is generated

--- a/docs/site/godot/install.md
+++ b/docs/site/godot/install.md
@@ -1,0 +1,32 @@
+# Installation
+_How to install NobodyWho and start building._
+
+---
+
+### Via Asset Library
+
+- **Open Godot 4.5** (or any newer 4.x release).
+- Switch to the **Asset Library** tab.
+- Search for **“NobodyWho”** and select the entry.
+- Click **Download**, tick **Ignore asset root**, then choose **Install**.
+- Godot puts the plugin in `res://addons/nobodywho`. Open *Create Node* and you should see **`NobodyWhoChat`**. If it’s missing, restart Godot and try again. 
+
+(1)
+{ .annotate }
+
+1. ![Installing NobodyWho from the Asset Library](assets/godot_asset_library.gif)
+
+### Via GitHub
+
+- Download the latest ZIP from the [GitHub releases](https://github.com/nobodywho-ooo/nobodywho/releases).
+- In Godot, open **AssetLib ▸ Import** and pick the ZIP.
+- Tick **Ignore asset root** and finish the import. 
+
+(1)
+{ .annotate }
+
+1. ![Importing the ZIP in Godot](assets/godot_github.gif)
+
+---
+
+After installation, NobodyWho’s nodes should appear in your editor. If not, retrace your steps above or reach out on Discord or GitHub - we are there to help.

--- a/docs/site/godot/rag.md
+++ b/docs/site/godot/rag.md
@@ -1,0 +1,375 @@
+# Adding long term memory to your characters
+_Build AI systems that can search through your game's lore, dialog, or knowledge base and find the most relevant information._
+
+---
+
+Great! You've got chat and embeddings working. Now let's add something useful: the ability to look up specific lore, dialogues, questlines etc.
+
+## Why Your Game Needs Smart Document Search
+
+Picture this: Your player is 40 hours into your RPG and asks an npc "Where do I find that crystal for the sword upgrade?" 
+Your LLM, without reranking, might give a generic answer or worse - make something up - leading to a bad player experience. 
+There are several ways to combat this, one is to load a lot of information into the context (i.e. the system prompt) but with a limited context, it might 'forget' the important information
+or be confused by too much information. Instead we want to add a "long term memory" module to our language model.
+
+To do this in the llm space you are going to use RAG (retrieval augmented generation) we are enriching the knowledge of the LLM by allowing it to search through a database of info we fed it. 
+There are many ways to do this. In NobodyWho we currently expose two major ways, one is embeddings; converting a sentence to a vector and then find the vectors that are closest to it.
+This is powerful as you can save the vectors to a database or a file beforehand and then use the really fast and cheap cosine similarity to compare them. Another more expensive but more accurate way is to use a cross-encoder that figures out the relationship between the question and the document rather that just how similar they are. 
+
+This approach is often called reranking, due to how it is used as a step two, for sorting and filtering large knowledge databases accessed by LLMs. We'll call it ranking as we are working with a small enough dataset that we do not need a first pass to filter out irrelevant info.
+
+Take this example:
+
+```
+Query: "Where do I find crystals for my sword upgrade?"
+Documents: [
+           "You asked the blacksmith: Where do I find crystals for my sword upgrade?",
+           "The blacksmith said: Magic crystals are found in the Northern Mountains.",
+           "You heard in the tavern: Magic crystals are not found in the Southern Desert."
+]
+```
+
+If we rely just on comparing the query with the embeddings using cosine similarity (as we did with the embeddings), we will get back the document "You asked the blacksmith: Where do I find crystals for my sword upgrade?" as it is the most similar sentence to our query. This gave us no useful information and we have just wasted valuable context. 
+
+But with ranking, the cross-encoder model has been trained on knowing that the answer to the question is not the question itself, and thus ranks the document "The blacksmith said: Magic crystals are found in the Northern Mountains." the highest.
+
+
+Here are the key terms you'll need:
+
+| Term | Meaning |
+| ---- | ------- |
+| **Document Ranking** | Sorting text documents by how well they match or answer a question. |
+| **RAG (Retrieval-Augmented Generation)** | A system that finds relevant documents first, then uses them to generate better LLM responses. |
+| **Cross-encoder** | The type of model used for reranking - it reads both the query and document together to score relevance. |
+
+
+
+
+Let's show you how to build smart search systems for your game.
+
+## Download a Reranker Model
+
+Reranking models are different from chat and embedding models. You need one specifically trained for document ranking.
+
+We recommend [bge-reranker-v2-m3-Q8_0.gguf](https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf) - it works well for most games and supports multiple languages.
+
+Note that the current qwen3 reranker does not work, due to how they created the template as it has some missing fields.
+
+## Practical Example: Smart NPC with Knowledge Base
+
+Let's build a tavern keeper NPC that can answer player questions by searching through their personal knowledge. This NPC knows about the local area, quests, and rumors - perfect for creating more immersive and helpful characters.
+
+We'll build it step by step, but for the impatient - the complete script is at the bottom.
+
+### Step 1: Set up your NPC's knowledge base
+
+First, let's create a knowledge base for our tavern keeper - everything this specific NPC would realistically know:
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+    extends NobodyWhoChat
+
+    @onready var reranker = $"../Rerank"
+    @onready var chat_model = $"../ChatModel"  
+
+    # The tavern keeper's knowledge - ~50 pieces of local information way more than could fit in a standard 4096 sized context.
+    var tavern_keeper_knowledge = PackedStringArray([
+        "The lake contains a special clay that blacksmiths use to forge superior weapons.",
+        "Ancient oak trees in the sacred grove provide wood that naturally resists dark magic.",
+        "Silver veins run through the mountain caves, valuable for crafting blessed weapons.",
+        "Rare moonflowers bloom in the ruins only once per season and have powerful magical properties.",
+        "The mill pond contains perfect stones for sharpening blades to razor sharpness.",
+        "Wild honey from forest bees makes potions more potent when used as a base ingredient.",
+        "A hooded stranger was seen asking questions about the old castle ruins last week.",
+        "Someone has been leaving fresh flowers at the grave of the village's first mayor.",
+        "Strange animal tracks were found near the well that don't match any known creature.",
+        "The church bell rang by itself three nights ago at exactly midnight.",
+        "Farmers found crop circles in their wheat fields after the last thunderstorm.",
+        "A merchant claims he saw lights moving through the abandoned mine from the hill road.",
+        "Children report hearing music coming from the forest when they play near the edge of town.",
+        "The weather has been unusually warm this winter, and the old-timers are worried.",
+        "Someone broke into the general store but only stole a map of the local cave systems.",
+        "A wolf with unusual blue eyes has been spotted watching the town from the tree line.",
+        "Old Sarah runs the bakery and makes the best apple pies in three kingdoms. Her grandson Tom went missing last week.",
+        "Blacksmith Gareth is always looking for quality iron ore and magic crystals. He pays double for rare materials.",
+        "Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.",
+        "Father Benedict runs the small chapel and knows ancient blessings that can ward off evil spirits.",
+        "Widow Martha owns the general store and knows every piece of gossip in town within hours.",
+        "Young apprentice Jake works for the blacksmith but dreams of becoming an adventurer himself.",
+        "Doctor Thorne treats injuries and illnesses. He keeps rare healing herbs in his back garden.",
+        "Stable master Owen knows every horse in the region and can track animals through the wilderness.",
+        "Mayor Thompson inherited his position from his father and struggles with the town's growing problems.",
+        "The old mine north of town has been abandoned for years. Strange sounds echo from deep inside at night.",
+        "The forest path to the east is safe during the day, but wolves hunt there after sunset.",
+        "Crystal Mines to the south produce valuable gems but have become dangerous recently.",
+        "The ancient stone bridge over Miller's Creek was built by dwarves centuries ago and still stands strong.",
+        "Darkwood Forest harbors bandits who prey on merchant caravans traveling the main road.",
+        "The Whispering Caves get their name from the wind that creates eerie sounds through the rock formations.",
+        "Lake Serenity freezes solid in winter, making it possible to cross on foot to the northern settlements.",
+        "The old watchtower on Crow's Hill offers a view of the entire valley but hasn't been manned in decades.",
+        "Sacred Grove is where the druids once practiced their rituals before they disappeared from the region.",
+        "The ruins of Castle Blackrock still stand on the mountain, though none dare venture there anymore.",
+        "Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.",
+        "Tom the baker's grandson disappeared near the Crystal Mines while collecting rare stones.",
+        "Strange lights have been appearing in the Whispering Caves during moonless nights.",
+        "Farmers report their livestock going missing near the edge of Darkwood Forest.",
+        "The old mill wheel stopped working after something large damaged it upstream.",
+        "Merchants complain about increased bandit activity on the eastern trade route.",
+        "Several townsfolk have reported seeing ghostly figures near the abandoned mine at midnight.",
+        "The village well's water tastes strange since the earthquake last month.",
+        "Wild animals have been acting aggressively and fleeing deeper into the mountains.",
+        "Ancient runes appeared overnight on the sacred standing stones outside town.",
+        "The town was founded by refugees fleeing the Great Dragon War three hundred years ago.",
+        "Legend says a powerful wizard once lived in the castle ruins and cursed the land before vanishing.",
+        "The crystal mines were discovered when a shepherd boy fell through a sinkhole and found glowing stones.",
+        "Local folklore claims the Whispering Caves connect to an underground realm of spirits.",
+        "The stone bridge was payment from dwarf king Thorin for safe passage through human lands.",
+        "Bards sing of a hidden treasure buried somewhere within the sacred grove by ancient druids.",
+        "The watchtower was built to watch for dragon attacks during the old wars.",
+        "Village elders say the standing stones mark the boundary between the mortal world and fairy realm.",
+        "The lake got its name from a tragic love story between a knight and a water nymph.",
+        "Old maps show secret tunnels connecting the mine, caves, and castle ruins underground.",
+        "Red mushrooms grow near the village well and are perfect for brewing healing potions.",
+        "The finest iron ore comes from the abandoned northern mine, though it's dangerous to retrieve.",
+        "Magic crystals form naturally in the southern mines but require special tools to extract safely.",
+        "Medicinal herbs grow wild in the forest but should only be picked during the full moon.",
+    ])
+
+    var ranked_docs = []
+    ```
+
+### Step 2: Configure your components
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+
+    func _ready():
+        # Set up the chat for generating helpful responses
+        self.model_node = chat_model
+        reranker.connect("ranking_finished", func(result): ranked_docs = result)
+        reranker.start_worker()
+
+        self.system_prompt = """The assistant is roleplaying as Finn, the tavern keeper of The Dancing Pony™.
+
+        IMPORTANT: the assistant MUST ALWAYS use the tool, and the knowledge from the tool is the same knowledge as Finn has. 
+        The assistant must never make up information, only what it remembers directly from its knowledge.
+        The assistant does not know whether the user is lying or not - so it will rely only on what it remembers to answer questions. 
+        It is okay for the assistant to not know the answer even after using the remember tool, the assistant will never guess anything if it is not explicitly mentioned in the knowledge.
+
+        The assistant must always speak like a tavern keeper.
+
+        """
+        # Add the tool to remember stuff
+        self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+        self.connect("response_finished", func(response: String): print("Finn says: ", response))
+        start_worker()
+    ```
+
+
+### Step 3: Set up a simple input system
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+    func _process(delta):
+        if Input.is_action_just_pressed("enter"):
+            var test_question = "Where is strider?"
+            print("Player asks Finn: ", test_question)
+            say(test_question)
+    ```
+
+
+### Step 4: Use ranked results to generate smart answers
+
+=== ":simple-godotengine: Godot"
+
+    ```gdscript
+ 
+    
+    func remember(query: String) -> String:
+        print("🔍 Finn searches his memory for: ", query)
+        ranked_docs = "\n".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+        print("🔍 Finn found: ", ranked_docs)
+
+        return ranked_docs
+
+    func _ready():
+        ....
+        # Add the tool to the llm to allow it to search for the most relevant lore.
+        self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+        self.connect("response_finished", func(response: String): print("Finn says: ", response))
+        start_worker()
+
+    ```
+
+When we run this we will get the response:
+
+>Finn says: <think>
+>Okay, let's see. The user asked about trading in the area.
+
+```
+🔍 Finn searches his memory for: What is trading like in the area?
+.... goes through and ranks all the documents
+🔍 Finn found: 
+Merchants complain about increased bandit activity on the eastern trade route.
+Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.
+Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.
+```
+
+> From the tool response, I remember a few key points. First, merchants are complaining about bandits on the eastern trade route. That's a problem for traders. Then there's Merchant Elena who sells spices and silk every second Tuesday. That's a specific thing to mention. Also, Trader Gareth's caravan was attacked in Darkwood Forest. So the answer should include these points.
+>
+>I need to present this information clearly. Start by mentioning the bandit issue, then note Elena's schedule, and mention Gareth's attack. Make sure it's in a friendly, tavern keeper style. Check if there's anything else, but the tool response only gave these three points. Don't add anything extra. Alright, structure the response with those details.
+></think>
+
+and when good ole Finn is done thinking:
+
+>Trading in the area is... if you'll forgive the blunt truth, *dangerous*. Merchants swear the eastern trade route is littered with bandits, and last week a caravan was ambushed in Darkwood Forest. But there are still opportunities! Merchant Elena brings rare spices and silk every second Tuesday—she’s a reliable seller. Just be wary of the roads. And if you spot a caravan with a single rider, don’t engage. They’re probably bandits.
+
+
+---
+
+### Complete Scripts
+
+<details markdown>
+<summary markdown>:simple-godotengine: Complete Godot Script (Click to expand)</summary>
+
+```gdscript
+extends NobodyWhoChat
+
+@onready var reranker = $"../Rerank"
+@onready var chat_model = $"../ChatModel"  
+
+# The tavern keeper's knowledge - ~50 pieces of local information way more than could fit in a standard 4096 sized context.
+var tavern_keeper_knowledge = PackedStringArray([
+    "The lake contains a special clay that blacksmiths use to forge superior weapons.",
+    "Ancient oak trees in the sacred grove provide wood that naturally resists dark magic.",
+    "Silver veins run through the mountain caves, valuable for crafting blessed weapons.",
+    "Rare moonflowers bloom in the ruins only once per season and have powerful magical properties.",
+    "The mill pond contains perfect stones for sharpening blades to razor sharpness.",
+    "Wild honey from forest bees makes potions more potent when used as a base ingredient.",
+    "A hooded stranger was seen asking questions about the old castle ruins last week.",
+    "Someone has been leaving fresh flowers at the grave of the village's first mayor.",
+    "Strange animal tracks were found near the well that don't match any known creature.",
+    "The church bell rang by itself three nights ago at exactly midnight.",
+    "Farmers found crop circles in their wheat fields after the last thunderstorm.",
+    "A merchant claims he saw lights moving through the abandoned mine from the hill road.",
+    "Children report hearing music coming from the forest when they play near the edge of town.",
+    "The weather has been unusually warm this winter, and the old-timers are worried.",
+    "Someone broke into the general store but only stole a map of the local cave systems.",
+    "A wolf with unusual blue eyes has been spotted watching the town from the tree line.",
+    "Old Sarah runs the bakery and makes the best apple pies in three kingdoms. Her grandson Tom went missing last week.",
+    "Blacksmith Gareth is always looking for quality iron ore and magic crystals. He pays double for rare materials.",
+    "Merchant Elena travels between towns selling exotic spices and silk. She arrives every second Tuesday.",
+    "Father Benedict runs the small chapel and knows ancient blessings that can ward off evil spirits.",
+    "Widow Martha owns the general store and knows every piece of gossip in town within hours.",
+    "Young apprentice Jake works for the blacksmith but dreams of becoming an adventurer himself.",
+    "Doctor Thorne treats injuries and illnesses. He keeps rare healing herbs in his back garden.",
+    "Stable master Owen knows every horse in the region and can track animals through the wilderness.",
+    "Mayor Thompson inherited his position from his father and struggles with the town's growing problems.",
+    "The old mine north of town has been abandoned for years. Strange sounds echo from deep inside at night.",
+    "The forest path to the east is safe during the day, but wolves hunt there after sunset.",
+    "Crystal Mines to the south produce valuable gems but have become dangerous recently.",
+    "The ancient stone bridge over Miller's Creek was built by dwarves centuries ago and still stands strong.",
+    "Darkwood Forest harbors bandits who prey on merchant caravans traveling the main road.",
+    "The Whispering Caves get their name from the wind that creates eerie sounds through the rock formations.",
+    "Lake Serenity freezes solid in winter, making it possible to cross on foot to the northern settlements.",
+    "The old watchtower on Crow's Hill offers a view of the entire valley but hasn't been manned in decades.",
+    "Sacred Grove is where the druids once practiced their rituals before they disappeared from the region.",
+    "The ruins of Castle Blackrock still stand on the mountain, though none dare venture there anymore.",
+    "Trader Gareth's caravan was attacked by bandits hiding somewhere in Darkwood Forest.",
+    "Tom the baker's grandson disappeared near the Crystal Mines while collecting rare stones.",
+    "Strange lights have been appearing in the Whispering Caves during moonless nights.",
+    "Farmers report their livestock going missing near the edge of Darkwood Forest.",
+    "The old mill wheel stopped working after something large damaged it upstream.",
+    "Merchants complain about increased bandit activity on the eastern trade route.",
+    "Several townsfolk have reported seeing ghostly figures near the abandoned mine at midnight.",
+    "The village well's water tastes strange since the earthquake last month.",
+    "Wild animals have been acting aggressively and fleeing deeper into the mountains.",
+    "Ancient runes appeared overnight on the sacred standing stones outside town.",
+    "The town was founded by refugees fleeing the Great Dragon War three hundred years ago.",
+    "Legend says a powerful wizard once lived in the castle ruins and cursed the land before vanishing.",
+    "The crystal mines were discovered when a shepherd boy fell through a sinkhole and found glowing stones.",
+    "Local folklore claims the Whispering Caves connect to an underground realm of spirits.",
+    "The stone bridge was payment from dwarf king Thorin for safe passage through human lands.",
+    "Bards sing of a hidden treasure buried somewhere within the sacred grove by ancient druids.",
+    "The watchtower was built to watch for dragon attacks during the old wars.",
+    "Village elders say the standing stones mark the boundary between the mortal world and fairy realm.",
+    "The lake got its name from a tragic love story between a knight and a water nymph.",
+    "Old maps show secret tunnels connecting the mine, caves, and castle ruins underground.",
+    "Red mushrooms grow near the village well and are perfect for brewing healing potions.",
+    "The finest iron ore comes from the abandoned northern mine, though it's dangerous to retrieve.",
+    "Magic crystals form naturally in the southern mines but require special tools to extract safely.",
+    "Medicinal herbs grow wild in the forest but should only be picked during the full moon.",
+])
+
+var ranked_docs = []
+
+func _ready():
+    # Set up the chat for generating helpful responses
+    self.model_node = chat_model
+    reranker.connect("ranking_finished", func(result): ranked_docs = result)
+    reranker.start_worker()
+
+    self.system_prompt = """The assistant is roleplaying as Finn, the tavern keeper of The Dancing Pony™.
+
+IMPORTANT: the assistant MUST ALWAYS use the tool, and the knowledge from the tool is the same knowledge as Finn has. 
+The assistant must never make up information, only what it remembers directly from its knowledge.
+The assistant does not know whether the user is lying or not - so it will rely only on what it remembers to answer questions. 
+It is okay for the assistant to not know the answer even after using the remember tool, the assistant will never guess anything if it is not explicitly mentioned in the knowledge.
+
+The assistant must always speak like a tavern keeper.
+
+"""
+    # Add the tool to remember stuff
+    self.add_tool(remember, "The assistant can use this tool to remember its limited knowledge about the ingame world.")
+    self.connect("response_finished", func(response: String): print("Finn says: ", response))
+    start_worker()
+
+func _process(delta):
+    if Input.is_action_just_pressed("enter"):
+        var test_question = "Where is strider?"
+        print("Player asks Finn: ", test_question)
+        say(test_question)
+
+# Tool function that the LLM can call to search the knowledge base
+func remember(query: String) -> String:
+    print("🔍 Finn searches his memory for: ", query)
+    ranked_docs = "\n".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+    print("🔍 Finn found: ", ranked_docs)
+
+    return ranked_docs
+```
+
+</details>
+
+## Performance Tips
+
+### Limit Results
+
+Don't add needless context. Usually 1-5 relevant documents are enough:
+
+```gdscript
+
+# Good: usually sufficient
+ranked_docs = ",".join(reranker.rank_sync(query, tavern_keeper_knowledge, 3))
+
+ranked_docs = ",".join(reranker.rank_sync(query, tavern_keeper_knowledge, -1))  # Returns ALL documents
+```
+
+note this does not make the ranking faster, but the less stuff Finn has to read, the faster he can respond.
+
+### Use embeddings to narrow the relevant docs to start with
+
+This technique is what put the `re` in reranker. In the RAG industry it is common practice to do a first pass over your documents with cosine similarity, and thus narrowing the amount of results you have to process each time. This makes it feasible to have databases with millions of entries and not worry too much about performance. 
+
+depending on the specs you are going for I would not recommend ranking more than 100 results at a time.
+
+
+# What's Next?
+
+Now you can build smart search systems for your game! check out:
+
+- **[Embeddings](embeddings.md)** for getting a better understanding of the basics
+- **[Tool Calling](chat/tool-calling.md)** for letting the LLM trigger game actions

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,0 +1,22 @@
+## What is NobodyWho?
+
+NobodyWho is a lightweight, open-source inference engine for running open-weights LLMs inside your software.
+We provide a simple, efficient, offline and privacy forward way of interacting with LLMs. No infrastructure needed!
+
+In short, if you want to run a LLM, and integrate it with [tools](./python/tool-calling.md), configure its output,
+enable real-time streaming of tokens, or maybe use it for creation of embeddings, NobodyWho makes it easy.
+
+All of this is enabled by [Llama.cpp](https://github.com/ggml-org/llama.cpp), while having nice, simple Python API.
+
+No need to mess around with docker containers, GPU servers, API keys, etc. We make it easy to run local LLMs in Python and Godot with more integrations coming soon!
+
+## Code documentation 
+
+If you are already familiar with the basics of LLMs we suggest you go straight to the documentation of your selected integration. 
+
+- [Godot](godot/index.md)
+- [Python](python/index.md)
+
+## Basic LLM concepts
+
+If you are unfamiliar with the basics of LLMs or are just intestered we also provide a simple introduction to the most important concepts you need to know in order to get the most out of NobodyWho. 

--- a/docs/site/llm-basics.md
+++ b/docs/site/llm-basics.md
@@ -1,0 +1,73 @@
+---
+title: LLM Basics
+description: Essential concepts for working with language models in NobodyWho
+sidebar_title: LLM Basics
+order: 2
+---
+
+Our goal with NobodyWho is to make it easy to run local LLMs. For this reason we have made it possible to use NobodyWho with minimal knowledge of how LLM works. However you still need to know some basic concepts, so for these we provide some brief explanations. The concepts covered are tokens, context, samplers and tools. 
+
+## Tokens
+
+Tokens are the basic units that LLMs process. A token is typically a word, part of a word, or a punctuation mark. For example, "hello" is one token, while "understanding" might be split into two tokens: "understand" and "ing". It is worth noting that the vocabulary of tokens used is different for each model as it is defined during training. 
+
+When the model generates text, it produces one token at a time. This is why the default response object of NobodyWho is a stream of tokens and why you can read the response token-by-token.
+
+## Context
+
+Context refers to all the text the model can "see" when generating a response. This includes:
+- Previous messages in the conversation
+- The current user prompt
+- Any system instructions
+
+Essentially the context acts as the models memory of the current conversation, available tools etc. This is important to remember as once your chosen model has been initialized most of  your interactions with the model will happen through the context.
+
+### Context Size
+
+Every model has a maximum context size (also called context window or context length), measured in tokens. Common sizes range from 2048 to 128,000 tokens.
+
+Once you reach the context limit, you must either:
+- Start a new conversation
+- Remove old messages from the history
+- Summarize earlier parts of the conversation
+
+Currently NobodyWho resolves this issue automatically by removing old messages from the context.
+Having a larger context allows for longer and more complex conversations, but it also slows down the response time, as the model has to process a more tokens each time it generates a response.
+
+## Samplers
+
+LLMs don't output text directly. Instead, they generate a probability distribution over all possible next tokens. Since the model weigths are static after training, this means that the same input tokens always generate the same distribution. Depending on the use case however, there are many possible ways of choosing a next token from this distribution. This is configured using a **sampler**. A **sampler** splits the process of choosing a next token into two parts: Shiftingh the distribution and Sampling the distribution.
+
+### Shifting the Distribution
+Before sampling the distribution to get the next token, it is possible to adjust the distribution provided by the LLM to encourage certain behavior. Examples of these adjustments are:
+
+- **Temperature**: Higher values make output more creative/random, lower values make it more focused/deterministic.
+- **Top-k/Top-p**: Limit which tokens are considered, filtering out unlikely options
+- **Penalties**: Lower the probalities of tokens already present in the context.
+
+It is important to note that the steps in this part of the process can be chained. So it is possible to first apply a Temperature shift and then Top-k.
+
+
+### Sampling the distribution
+Once the distribution has been shifted the next step is to actually sample the distribution. This can also be done a few different ways:
+
+- **Dist**: Sample the distribution randomly 
+- **Greedy**: Always pick the most likely token (deterministic but sometimes repetitive)
+- **Mirostat**: Advanced sampling presented in this [article](https://arxiv.org/abs/1904.09751)
+
+Since this part actually chooses the next token, these cannot be chained.
+
+
+NobodyWho also supports more advanced ways of configuraing a sampler, like for example follow a JSON Schema.
+
+## Tools
+
+Tools (also called function calling) allow the LLM to request external actions. Instead of just generating text, the model can indicate it wants to:
+- Search a database
+- Perform a calculation
+- Fetch data from an API
+- Execute custom code
+
+You define available tools, and the model decides when to use them based on the conversation. After a tool executes, you provide the result back to the model so it can continue the conversation.
+
+This enables LLMs to go beyond pure text generation and interact with your application's functionality.

--- a/docs/site/model-selection.md
+++ b/docs/site/model-selection.md
@@ -1,0 +1,95 @@
+---
+title: Model Selection
+description: NobodyWho is a lightweight, open-source AI engine for local LLM inference. Simple, privacy oriented with no infrastructure needed.
+sidebar_title: Model Selection
+order: 7
+---
+
+Choosing the right language model can make or break your project. In general you want to go as small as possible while still having the capabilities you need for your application.
+
+## TL;DR
+
+If you just want a ~2GB chat model that works well, try [Qwen3 4B Q4_K_M](https://huggingface.co/Qwen/Qwen3-4B-GGUF/blob/main/Qwen3-4B-Q4_K_M.gguf).
+
+
+## Which models are compatible with NobodyWho?
+
+Broadly: almost anything in the `.gguf` file format.
+
+For chatting, it should be an instruction-tuned GGUF file that includes a jinja2 chat template in the metadata.
+This description fits the vast majority of GGUF files out there. If in doubt, try it. NobodyWho will throw you a descriptive error message if something is wrong.
+
+For embeddings or cross-encoding, you need to use models specific for embedding or cross-encoding. They will be named as such. Although notice that cross-encoding models are sometimes called "reranking" models.
+
+
+## Understanding model names
+
+Model files have names that look something like this: `Qwen_Qwen3-0.6B-Q4_K_M.gguf`
+
+Let's break it down.
+
+- `Qwen` is the name of the organization that trained the model.
+- `Qwen3` is the name of the model release.
+- `0.6B` refers to the parameter count of the model, in billions of parameters. This model has 0.6 billion parameters (aka 600 million parameters).
+- `Q4` refers to the quantization level, i.e. the number of bits per parameter.
+- `K_M` refers to details about the quantization techniques used. Don't worry too much about this for now. `S` means faster and less precise, `L` means slower and more precise, `M` is medium both.
+
+
+## Quantization
+
+Quantization refers to the practice of reducing the number of bits per weight.
+This can make the model faster and smaller, with a relatively small loss in response quality.
+
+Generally speaking, you can used models quantized down the Q4 or Q5 levels (4 or 5 bits per weight respectively),
+without losing *too much* accuracy.
+
+Look at the plot below to get a feel for how quantization levels differ.
+It shows the models' ability to predict text on the y-axis versus the number of bits per weight on the x-axis.
+
+![Perplexity/Quantization curve](./assets/quantcurve.png)
+
+In general, it's preferable to use a model with more parameters and fewer bits per parameter, as compared to a model with fewer parameters and more bits per parameter.
+Your results may vary.
+
+
+## Estimating Memory Usage
+
+The memory requirement of a model is roughly its parameter count multiplied by its quantization level.
+
+Here's a few examples:
+
+- 2B @ Q8 ~= 2GB
+- 2B @ Q4 ~= 1GB
+- 14B @ Q4 ~= 7GB
+- 14B @ Q2 ~= 3.5GB
+- ..and so on
+
+
+## Comparing Models
+
+There are many places online for comparing benchmark scores of different LLMs, here's a few of them:
+
+**[LLM-Stats.com](https://llm-stats.com/)**
+- Includes filters for open models and small models.
+- Compares recent models on a few different benchmarks.
+
+**[OpenEvals on huggingface](https://huggingface.co/spaces/OpenEvals/find-a-leaderboard)**
+- A collection of benchmark leaderboards in different domains.
+- Includes both inaccessible proprietary models and open models.
+
+Remember that you need an open model, in order to be able to find a GGUF download and run it locally (e.g. Gemma is open, but Gemini isn't).
+
+
+## Finding a GGUF Download
+
+Once you have decided on an LLM you want to try, you can usually find it on one of the big HuggingFace pages:
+
+- https://huggingface.co/bartowski
+- https://huggingface.co/unsloth/models
+
+You can also just search "<modelname> GGUF" in your favorite search engine.
+
+
+---
+
+*Need help choosing between specific models? Check our [community Discord](https://discord.gg/nobodywho).* 

--- a/docs/site/python/chat.md
+++ b/docs/site/python/chat.md
@@ -1,0 +1,133 @@
+---
+title: Chat
+description: A concise introduction to the Chat functionality of NobodyWho.
+sidebar_title: Chat
+order: 1
+---
+
+As you may have noticed in the [welcome guide](./index.md), every interaction with your LLM starts by instantiating a `Chat` object.
+In the following sections, we talk about which configuration options it has, and when to use them.
+
+## Prompts and responses
+
+The `Chat.ask()` function is central to NobodyWho. This function sends your message to the LLM, which then starts generating a response.
+
+```python
+from nobodywho import Chat, TokenStream
+chat = Chat("./model.gguf")
+response: TokenStream = chat.ask("Is water wet?")
+```
+
+The return type of `ask` is a `TokenStream`.
+If you want to start reading the response as soon as possible, you can just iterate over the `TokenStream`.
+Each token is either an individual word or fragments of a word.
+
+```{.python continuation}
+for token in response:
+   print(token, end="")
+print("\n")
+```
+
+If you just want to get the complete response, you can call `TokenStream.completed()`.
+This will block until the model is done generating its entire response.
+
+```{.python continuation}
+full_response: str = response.completed()
+```
+
+All of your messages and the model's responses are stored in the `Chat` object, so the next time you call `Chat.ask()`, it will remember the previous messages.
+
+## Chat history
+
+If you want to inspect the messages inside the `Chat` object, you can use `get_chat_history`.
+
+```{.python continuation}
+msgs: list[dict] = chat.get_chat_history()
+print(msgs[0]["content"]) # "Is water wet?"
+```
+
+Similarly, if you want to edit what messages are in the context, you can use `set_chat_history`:
+
+
+```{.python continuation}
+chat.set_chat_history([{"role": "user", "content": "What is water?"}])
+```
+
+## System prompt
+
+A system prompt is a special message put into the chat context, which should guide its overall behavior.
+Some models ship with a built-in system prompt. If you don't specify a system prompt yourself, NobodyWho will fall back to using the model's default system prompt.
+
+You can specify a system prompt when initializing a `Chat`:
+
+```python
+from nobodywho import Chat
+chat = Chat("./model.gguf", system_prompt="You are a mischievous assistant!")
+```
+
+This `system_prompt` is then persisted until the chat context is `reset`.
+
+
+
+## Context
+
+The context is the text window which the LLM currently considers. Specifically this is the number of tokens the LLM keeps in memory for your current conversation.
+As bigger context size means more computational overhead, it makes sense to constrain it. This can be done with `n_ctx` setting, again at the time of creation:
+
+```python
+chat = Chat("./model.gguf", n_ctx=4096)
+```
+
+The default value is `4096`, however this is mainly useful for short and simple conversations. Choosing the right context size is quite important and depends heavily on your use case. A good place to start is to look at your selected models documentation and see what their recommended context size is.
+
+Even with properly selected context size it might happen that you fill up your entire context during a conversation. When this happens, NobodyWho will shrink the context for you. Currently this is done by removing old messages (apart from the system prompt and the first user message) from the chat history, until the size reaches `n_ctx / 2`. The KV cache is also updated automatically. In the future we plan on adding more advanced methods of context shrinking.
+
+Again, `n_ctx` is fixed to the `Chat` instance, so it is currently not possible to change the size after `Chat` is created. To reset the current context content, just call `.reset()` with the new system prompt and potentially changed tools.
+
+```{.python continuation}
+chat.reset(system_prompt="New system prompt", tools=[])
+```
+
+If you don't want to change the already set defaults (`system_prompt`, `tools`), but only reset the context, then go for `reset_history`.
+
+## Sharing model between contexts
+
+There are scenarios where you would like to keep separate chat contexts (e.g. for every user of your app), but have only one model loaded. With plain `Chat` this is not possible.
+
+For this use case, instead of the path to the `.gguf` model, you can pass in `Model` object, which can be shared between multiple `Chat` instances.
+
+```python
+from nobodywho import Model
+
+model = Model('./model.gguf')
+chat1 = Chat(model)
+chat2 = Chat(model)
+...
+```
+
+NobodyWho will then take care of the separation, such that your chat histories won't collide or interfere with each other, while having only one model loaded.
+
+## GPU
+Instantiating `Model` is also useful, when enabling GPU acceleration. This can be done as:
+```python
+Model('./model.gguf', use_gpu_if_available=True)
+```
+So far, NobodyWho relies purely on [Vulkan](https://www.vulkan.org), however support
+of more architectures is planned (for details check out our [issues](https://github.com/nobodywho-ooo/nobodywho/issues) or join us on [Discord](https://discord.gg/qhaMc2qCYB)).
+
+## Reasoning
+
+To enhance cognitive performance, allowing reasoning can be a good idea:
+```python
+chat = Chat("./model.gguf", allow_thinking=True)
+```
+Note that `Chat` has thinking set to `True` by default. You can also change the setting
+of an already existing chat instance:
+```{.python continuation}
+chat.set_allow_thinking(True)
+```
+With the next message send, the setting will be propagated.
+
+!!! info ""
+    Note that **not every model** supports reasoning. If the model does not have
+    such an option, the `allow_thinking` setting will be ignored.

--- a/docs/site/python/embeddings-and-rag.md
+++ b/docs/site/python/embeddings-and-rag.md
@@ -1,0 +1,292 @@
+---
+title: Embeddings & RAG
+description: Learn how to use embeddings and cross-encoders to build retrieval-augmented generation (RAG) systems with NobodyWho.
+sidebar_title: Embeddings & RAG
+order: 5
+---
+
+When you want your LLM to search through documents, understand semantic similarity, or build retrieval-augmented generation (RAG) systems, you'll need embeddings and cross-encoders.
+
+## Understanding Embeddings
+
+Embeddings convert text into vectors (lists of numbers) that capture semantic meaning. Texts with similar meanings have similar vectors, even if they use different words.
+
+For example, "Schedule a meeting for next Tuesday" and "Book an appointment next week" would have very similar embeddings, despite using different words.
+
+## The Encoder
+
+The `Encoder` object converts text into embedding vectors. You'll need a specialized embedding model (different from chat models).
+
+We recommend you first try [bge-small-en-v1.5-q8_0.gguf](https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf).
+
+```python
+from nobodywho import Encoder
+
+encoder = Encoder('./embedding-model.gguf')
+embedding = encoder.encode("What is the weather like?")
+print(f"Vector with {len(embedding)} dimensions")
+```
+
+The resulting embedding is a list of floats (typically 384 or 768 dimensions depending on the model).
+
+### Comparing Embeddings
+
+To measure how similar two pieces of text are, compare their embeddings using cosine similarity:
+
+```python
+from nobodywho import Encoder, cosine_similarity
+
+encoder = Encoder('./embedding-model.gguf')
+
+query = encoder.encode("How do I reset my password?")
+doc1 = encoder.encode("You can reset your password in the account settings")
+doc2 = encoder.encode("The password requirements include 8 characters minimum")
+
+similarity1 = cosine_similarity(query, doc1)
+similarity2 = cosine_similarity(query, doc2)
+
+print(f"Document 1 similarity: {similarity1:.3f}")  # Higher score
+print(f"Document 2 similarity: {similarity2:.3f}")  # Lower score
+```
+
+Cosine similarity returns a value between -1 and 1, where 1 means identical meaning and -1 means opposite meaning.
+
+### Practical Example: Finding Relevant Documents
+
+```python
+from nobodywho import Encoder, cosine_similarity
+
+encoder = Encoder('./embedding-model.gguf')
+
+# Your knowledge base
+documents = [
+    "Python supports multiple programming paradigms including object-oriented and functional",
+    "JavaScript is primarily used for web development and runs in browsers",
+    "SQL is a domain-specific language for managing relational databases",
+    "Git is a version control system for tracking changes in source code"
+]
+
+# Pre-compute document embeddings
+doc_embeddings = [encoder.encode(doc) for doc in documents]
+
+# Search query
+query = "What language should I use for database queries?"
+query_embedding = encoder.encode(query)
+
+# Find the most relevant document
+similarities = [cosine_similarity(query_embedding, doc_emb) for doc_emb in doc_embeddings]
+best_idx = similarities.index(max(similarities))
+
+print(f"Most relevant: {documents[best_idx]}")
+print(f"Similarity score: {similarities[best_idx]:.3f}")
+```
+
+## The CrossEncoder for Better Ranking
+
+While embeddings work well for initial filtering, cross-encoders provide more accurate relevance scoring. They directly compare a query against documents to determine how well the document answers the query.
+
+The key difference: embeddings compare vector similarity, while cross-encoders understand the relationship between query and document.
+
+### Why CrossEncoder Matters
+
+Consider this example:
+
+```
+Query: "What are the office hours for customer support?"
+Documents: [
+    "Customer asked: What are the office hours for customer support?",
+    "Support team responds: Our customer support is available Monday-Friday 9am-5pm EST",
+    "Note: Weekend support is not available at this time"
+]
+```
+
+Using embeddings alone, the first document scores highest (most similar to the query) even though it provides no useful information. A cross-encoder correctly identifies that the second document actually answers the question.
+
+### Using CrossEncoder
+
+```python
+from nobodywho import CrossEncoder
+
+# Download a reranking model like bge-reranker-v2-m3-Q8_0.gguf
+crossencoder = CrossEncoder('./reranker-model.gguf')
+
+query = "How do I install Python packages?"
+documents = [
+    "Someone previously asked about Python packages",
+    "Use pip install package-name to install Python packages",
+    "Python packages are not included in the standard library"
+]
+
+# Get relevance scores for each document
+scores = crossencoder.rank(query, documents)
+print(scores)  # [0.23, 0.89, 0.45] - second doc scores highest
+```
+
+### Automatic Sorting
+
+For convenience, use `rank_and_sort` to get documents sorted by relevance:
+
+```{.python continuation}
+# Returns list of (document, score) tuples, sorted by score
+ranked_docs = crossencoder.rank_and_sort(query, documents)
+
+for doc, score in ranked_docs:
+    print(f"[{score:.3f}] {doc}")
+```
+
+This returns documents ordered from most to least relevant.
+
+## Building a RAG System
+
+Retrieval-Augmented Generation (RAG) combines document search with LLM generation. The LLM uses retrieved documents to ground its responses in your knowledge base.
+
+Here's a complete example building a customer service assistant with access to company policies:
+
+```python
+from nobodywho import Chat, CrossEncoder
+
+# Initialize the cross-encoder for document ranking
+crossencoder = CrossEncoder('./reranker-model.gguf')
+
+# Your knowledge base
+knowledge = [
+    "Our company offers a 30-day return policy for all products",
+    "Free shipping is available on orders over $50",
+    "Customer support is available via email and phone",
+    "We accept credit cards, PayPal, and bank transfers",
+    "Order tracking is available through your account dashboard"
+]
+
+# Create a tool that searches the knowledge base
+from nobodywho import tool
+
+@tool(description="Search the knowledge base for relevant information")
+def search_knowledge(query: str) -> str:
+    # Rank all documents by relevance to the query
+    ranked = crossencoder.rank_and_sort(query, knowledge)
+    
+    # Return top 3 most relevant documents
+    top_docs = [doc for doc, score in ranked[:3]]
+    return "\n".join(top_docs)
+
+# Create a chat with access to the knowledge base
+chat = Chat(
+    './model.gguf',
+    system_prompt="You are a customer service assistant. Use the search_knowledge tool to find relevant information from our policies before answering customer questions.",
+    tools=[search_knowledge]
+)
+
+# The chat will automatically search the knowledge base when needed
+response = chat.ask("What is your return policy?").completed()
+print(response)
+```
+
+The LLM will call the `search_knowledge` tool, receive the most relevant documents, and use them to generate an accurate answer.
+
+## Async API
+
+For non-blocking operations, use `EncoderAsync` and `CrossEncoderAsync`:
+
+```python
+import asyncio
+from nobodywho import EncoderAsync, CrossEncoderAsync
+
+async def main():
+    encoder = EncoderAsync('./embedding-model.gguf')
+    crossencoder = CrossEncoderAsync('./reranker-model.gguf')
+    
+    # Generate embeddings asynchronously
+    embedding = await encoder.encode("What is the weather?")
+    
+    # Rank documents asynchronously
+    query = "What is our refund policy?"
+    docs = ["Refunds processed within 5-7 business days", "No refunds on sale items", "Contact support to initiate refund"]
+    ranked = await crossencoder.rank_and_sort(query, docs)
+    
+    for doc, score in ranked:
+        print(f"[{score:.3f}] {doc}")
+
+asyncio.run(main())
+```
+
+
+## Recommended Models
+
+### For Embeddings
+- [bge-small-en-v1.5-q8_0.gguf](https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf) - Good balance of speed and quality (~25MB)
+- Supports English text with 384-dimensional embeddings
+
+### For Cross-Encoding (Reranking)
+- [bge-reranker-v2-m3-Q8_0.gguf](https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf) - Multilingual support with excellent accuracy
+
+## Best Practices
+
+**Precompute embeddings**: If you have a fixed knowledge base, generate embeddings once and reuse them. Don't re-encode the same documents repeatedly.
+
+**Use embeddings for filtering**: When working with large document collections (1000+ documents), use embeddings to narrow down to the top 50-100 candidates, then use a cross-encoder to rerank them.
+
+**Limit cross-encoder inputs**: Cross-encoders are more expensive than embeddings. Don't pass thousands of documents to `rank()` - filter first with embeddings.
+
+**Choose appropriate context size**: The `n_ctx` parameter (default 2048) should match your model's recommended context size. Check the model documentation.
+
+```python
+# For longer documents, increase context size
+encoder = Encoder('./embedding-model.gguf', n_ctx=4096)
+crossencoder = CrossEncoder('./reranker-model.gguf', n_ctx=4096)
+```
+
+## Complete RAG Example
+
+Here's a full example showing a two-stage retrieval system:
+
+```python
+from nobodywho import Chat, Encoder, CrossEncoder, cosine_similarity, tool
+
+# Initialize models
+encoder = Encoder('./embedding-model.gguf')
+crossencoder = CrossEncoder('./reranker-model.gguf')
+
+# Large knowledge base
+knowledge_base = [
+    "Python 3.11 introduced performance improvements through faster CPython",
+    "The Django framework is used for building web applications",
+    "NumPy provides support for large multi-dimensional arrays",
+    "Pandas is the standard library for data manipulation and analysis",
+    # ... 100+ more documents
+]
+
+# Precompute embeddings for all documents
+doc_embeddings = [encoder.encode(doc) for doc in knowledge_base]
+
+@tool(description="Search the knowledge base for information relevant to the query")
+def search(query: str) -> str:
+    # Stage 1: Fast filtering with embeddings
+    query_embedding = encoder.encode(query)
+    similarities = [
+        (doc, cosine_similarity(query_embedding, doc_emb))
+        for doc, doc_emb in zip(knowledge_base, doc_embeddings)
+    ]
+    # Get top 20 candidates
+    candidates = sorted(similarities, key=lambda x: x[1], reverse=True)[:20]
+    candidate_docs = [doc for doc, _ in candidates]
+    
+    # Stage 2: Precise ranking with cross-encoder
+    ranked = crossencoder.rank_and_sort(query, candidate_docs)
+    
+    # Return top 3 most relevant
+    top_results = [doc for doc, score in ranked[:3]]
+    return "\n---\n".join(top_results)
+
+# Create RAG-enabled chat
+chat = Chat(
+    './model.gguf',
+    system_prompt="You are a technical documentation assistant. Always use the search tool to find relevant information before answering programming questions.",
+    tools=[search]
+)
+
+# The chat automatically searches and uses retrieved documents
+response = chat.ask("What Python libraries are best for data analysis?").completed()
+print(response)
+```
+
+This two-stage approach combines the speed of embeddings with the accuracy of cross-encoders, making it efficient even for large knowledge bases.

--- a/docs/site/python/index.md
+++ b/docs/site/python/index.md
@@ -1,0 +1,31 @@
+---
+title: Getting started
+description:  How to setup NobodyWho in Python
+sidebar_title: Getting started
+order: 0
+---
+
+
+
+## How do I get started?
+
+First, install `nobodywho`.
+```bash
+pip install nobodywho
+```
+
+Next, download a GGUF model you like - if you don't have a specific model in mind, try [this one](https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q5_0.gguf?download=true). Read more about [model selection](../model-selection.md).
+
+Once you have the `.gguf` file, make a `Chat` object and call `.ask()`!
+
+```python
+from nobodywho import Chat
+
+chat = Chat('./model.gguf')
+response = chat.ask('Hello world?').completed()
+print(response) # Hello world!
+```
+
+This is a super simple example, but we believe that examples which do simple things, should be simple!
+
+To get a full overview of the functionality provided by NobodyWho, simply keep reading.

--- a/docs/site/python/logging-and-troubleshooting.md
+++ b/docs/site/python/logging-and-troubleshooting.md
@@ -1,0 +1,19 @@
+---
+title: Logging and Troubleshooting
+sidebar_title: Logging
+order: 6
+---
+
+# Logging and troubleshooting
+
+The python bindings for NobodyWho integrate with python's standard `logging` utilities.
+
+In short, to enable debug logs:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+This can be useful for getting some insight into what the model is choosing to do and when.
+For example when tool calls are made, when context shifting happens, etc.

--- a/docs/site/python/sampling.md
+++ b/docs/site/python/sampling.md
@@ -1,0 +1,85 @@
+---
+title: Sampling
+description: A description of how samplers can be configured in NobodyWho
+sidebar_title: Sampling
+order: 3
+---
+
+The model does not produce tokens but rather a probability distribution over all possible tokens. We must then choose how to pick the next token from the distribution. This is the job of a **sampler**, which using NobodyWho you can freely modify,
+to achieve better quality outputs or constrain the outputs to some known format (e.g. JSON).
+
+## Sampler presets
+
+To get a quick start, NobodyWho offers a couple of well-known presets, which you can quickly utilize.
+For example, if you want to increase or decrease the "creativity" of your model, select our `temperature` preset:
+```python
+from nobodywho import SamplerPresets
+
+Chat("./model.gguf", sampler=SamplerPresets.temperature(0.2))
+```
+Setting `temperature` to `0.2`, will then affect the sampler when choosing the next token, making the distribution less flat and therefore the model will favour more probable tokens.
+
+To see the whole list of presets, check out the `SamplerPresets` class:
+```python
+class SamplerPresets:
+    def default() -> SamplerConfig: ...
+    def dry() -> SamplerConfig: ...
+    def grammar(grammar: str) -> SamplerConfig: ...
+    def greedy() -> SamplerConfig: ...
+    def json() -> SamplerConfig: ...
+    def temperature(temperature: float) -> SamplerConfig: ...
+    def top_k(top_k: int) -> SamplerConfig: ...
+    def top_p(top_p: float) -> SamplerConfig: ...
+    ...
+```
+
+## Structured output
+
+One of the most useful presets to have, is to be able to generate structured output,
+such as JSON. This way, you dont have to rely on your model being clever enough to
+generate syntactically valid JSON, but instead you are strictly guaranteed that the
+output will be right. For plain JSON, it suffices to:
+```python
+Chat('./model.gguf', sampler=SamplerPresets.json())
+```
+
+Still, you might have more advanced needs, such as generating CSVs or JSON with some specific keys. This can be supported by creating custom grammars, such as this one for CSV:
+```python
+sampler = SamplerPresets.grammar("""
+    file ::= record (newline record)* newline?
+    record ::= field ("," field)*
+    field ::= quoted_field | unquoted_field
+    unquoted_field ::= unquoted_char*
+    unquoted_char ::= [^,"\n\r]
+    quoted_field ::= "\"" quoted_char* "\""
+    quoted_char ::= [^"] | "\"\""
+    newline ::= "\r\n" | "\n"
+""")
+```
+The format that NobodyWho utilizes is called GBNF, which is a Llama.cpp native format.
+See the [GBNF specification](https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md).
+
+
+## Defining your own samplers
+
+Sampler presets abstract away some control, that you might want - for example, if you
+want to chain samplers, change more "advanced" parameters, etc. For that use case,
+we provide `SamplerBuilder` class:
+```python
+from nobodywho import SamplerBuilder
+
+Chat(
+    "./model.gguf",
+    sampler=SamplerBuilder()
+        .temperature(0.8)
+        .top_k(5)
+        .dist()
+)
+```
+With `SamplerBuilder` you can chain multiple steps together and then select how do you
+want to sample from the distribution. Keep in mind, that `SamplerBuilder` provides two
+types of methods: ones which modify the distribution (returning again the instance of
+`SamplerBuilder`) and ones which sample from the distribution (returning `SamplerConfig`).
+So in order to have the sampler working properly and not giving you type errors, be careful
+to always end the chain with one of the sampling steps (e.g. `dist`, `greedy`, `mirostat_v2`, etc.).
+

--- a/docs/site/python/streaming-and-async-api.md
+++ b/docs/site/python/streaming-and-async-api.md
@@ -1,0 +1,55 @@
+---
+title: Streaming & Async API
+description: Illustrating the differences between Sync & Async in NobodyWho
+sidebar_title: Streaming & Async API
+order: 4
+---
+
+Synchronously waiting for the full response to arrive can be costly. If your application
+domain allows you to, you would ideally want to stream the tokens to the user as soon
+as they arrive, and spend the time in between doing useful work, rather than just waiting.
+
+## Streaming tokens
+
+Allowing streaming is super simple. Instead of calling the `.completed()` method, just iterate
+over the response object:
+```python
+chat = Chat('./model.gguf')
+response = chat.ask('How are you?')
+for token in response:
+    print(token)
+```
+
+Still, bear in mind that for the individual tokens, you are waiting synchronously.
+
+## Async API
+
+If you don't want to wait synchronously, swap out the `Chat` object for a `ChatAsync`. All of the API stays the same, so either you can opt for a full, completed message:
+```python
+import asyncio
+from nobodywho import ChatAsync
+
+async def main():
+    chat = ChatAsync('./model.gguf')
+    response = await chat.ask('How are you?').completed()
+    print(response)
+
+asyncio.run(main())
+```
+Or again stream tokens:
+```python
+import asyncio
+from nobodywho import ChatAsync
+
+async def main():
+    chat = ChatAsync('./model.gguf')
+    response = chat.ask('How are you?')
+    async for token in response:
+        print(token)
+
+asyncio.run(main())
+```
+
+Similarly, the other model types we support also implement async behaviour, so
+you can go for `EncoderAsync` and `CrossEncoderAsync`, which are
+both part of the [embeddings & rag functionality](./embeddings-and-rag.md).

--- a/docs/site/python/tool-calling.md
+++ b/docs/site/python/tool-calling.md
@@ -1,0 +1,90 @@
+---
+title: Tool Calling
+description: An introduction to tools in NobodyWho
+sidebar_title: Tool Calling
+order: 2
+---
+
+To give your LLM the ability to interact with the outside world, you will need tool calling.
+
+!!! info ""
+    Note that **not every model** supports tool calling. If the model does not have
+    such an option, it might not call your tools.
+    For reliable tool calling, we recommend trying the [Qwen](https://huggingface.co/Qwen/models) family of models.
+
+## Declaring a tool
+
+A tool can be created from any (synchronous) python function, which returns a string.
+To perform the conversion, you simply need to use the `@tool` decorator. To get
+a good sense of how such a tool can look like, consider this geometry example:
+
+```python
+import math
+from nobodywho import tool, Chat
+
+@tool(description="Calculates the area of a circle given its radius")
+def circle_area(radius: float) -> str:
+    area = math.pi * radius ** 2
+    return f"Circle with radius {radius} has area {area:.2f}"
+```
+
+As you can see, every `@tool` definition has to be complemented by a description
+of what such tool does. To let your LLM use it, simply add it when creating `Chat`:
+
+```{.python continuation}
+chat = Chat('./model.gguf', tools=[circle_area])
+```
+
+NobodyWho then figures out the right tool calling format, inspects the names and types of the parameters,
+and configures the sampler.
+
+Naturally, more tools can be defined and the model can chain the calls for them:
+
+```python
+import os
+from pathlib import Path
+from nobodywho import Chat, tool
+
+@tool(description="Gets path of the current directory")
+def get_current_dir() -> str:
+    return os.getcwd()
+
+@tool(description="Lists files in the given directory", params={"path": "a relative or absolute path to a directory"})  
+def list_files(path: str) -> str:
+    files = [f.name for f in Path(path).iterdir() if f.is_file()]
+    return f"Files: {', '.join(files)}"
+
+@tool(description="Gets the size of a file in bytes")
+def get_file_size(filepath: str) -> str:
+    size = Path(filepath).stat().st_size
+    return f"File size: {size} bytes"
+
+chat = Chat('./model.gguf', tools=[get_current_dir, list_files, get_file_size])
+response = chat.ask('What is the biggest file in my current directory?').completed()
+print(response) # The largest file in your current directory is `model.gguf`.
+```
+
+## Providing parameter descriptions
+
+When a tool call is declared, information about the description, the types and the parameters is provided to the model, so it knows it can use it. Crucially, also parameter names are provided.
+
+If those are not enough, you can decide to provide additional information by the `params` parameter:
+```python
+from nobodywho import tool
+@tool(
+    description="Given a longitude and latitude, gets the current temperature.",
+    params={
+        "lon": "Longitude - that is the vertical one!",
+        "lat": "Latitude - that is the horizontal one!"
+    }
+)
+def get_current_temperature(lon: str, lat: str) -> str:
+    ...
+```
+These will be then appended to the information provided to model, so it can better navigate itself
+when using the tool.
+
+
+## Tool calling and the context
+
+As with everything made to improve response quality, using tool calls fills up the context faster than simply chatting with an LLM. So be aware that you might need to use a larger context size than expected when using tools.

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -8277,6 +8277,10 @@ rec {
             packageId = "ureq";
             features = [ "rustls" ];
           }
+          {
+            name = "walkdir";
+            packageId = "walkdir";
+          }
         ];
 
       };

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -40,6 +40,7 @@ ahash = "0.8.12"
 indexmap = "2.13.0"
 ureq = { version = "3", features = ["rustls"] }
 indicatif = "0.18"
+walkdir = "2.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -125,6 +125,28 @@ pub enum LoadModelError {
 
     #[error("Failed to download model: {0}")]
     DownloadError(String),
+    #[error("Could not determine cache directory: {0}")]
+    CacheDir(#[from] GetCacheDirError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetCacheDirError {
+    #[error("Could not determine cache directory")]
+    NoCacheDir,
+    #[cfg(target_os = "android")]
+    #[error("Failed to read /proc/self/cmdline: {0}")]
+    ReadCmdline(#[from] std::io::Error),
+    #[cfg(target_os = "android")]
+    #[error("Could not determine Android package name from /proc/self/cmdline")]
+    NoPackageName,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetCachedModelsError {
+    #[error("Could not determine cache directory: {0}")]
+    CacheDir(#[from] GetCacheDirError),
+    #[error("Failed to walk cache directory: {0}")]
+    Walk(#[from] walkdir::Error),
 }
 
 fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -571,7 +571,7 @@ fn download_model_from_hf(
 }
 
 /// Get the paths and total byte size of every .gguf model in the nobodywho cache.
-pub fn get_cache_information() -> Result<(Vec<std::path::PathBuf>, u64), crate::errors::LoadModelError> {
+pub fn get_cached_models() -> Result<(Vec<std::path::PathBuf>, u64), crate::errors::LoadModelError> {
     let cache_dir = get_cache_dir()?;
     let mut models = Vec::new();
     let mut total_size: u64 = 0;

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -374,31 +374,27 @@ pub fn download_model(
 /// via `dlopen` (not `System.loadLibrary`), so `JNI_OnLoad` is never called.
 ///
 /// On other platforms, uses the `dirs` crate to find the standard cache directory.
-fn get_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
+fn get_cache_dir() -> Result<std::path::PathBuf, crate::errors::GetCacheDirError> {
     let base = get_platform_cache_dir()?;
     Ok(base.join("nobodywho").join("models"))
 }
 
 #[cfg(target_os = "android")]
-fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
+fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::GetCacheDirError> {
+    use crate::errors::GetCacheDirError;
+
     // Read the package name from /proc/self/cmdline. This file contains the process
     // name as a null-terminated string. On Android this is the package name
     // (e.g. "com.example.app"), possibly with a colon suffix for multi-process apps
     // (e.g. "com.example.app:remote").
-    let cmdline = std::fs::read("/proc/self/cmdline").map_err(|e| {
-        LoadModelError::DownloadError(format!("Failed to read /proc/self/cmdline: {e}"))
-    })?;
+    let cmdline = std::fs::read("/proc/self/cmdline")?;
 
     let package_name = cmdline
         .split(|&b| b == 0)
         .next()
         .and_then(|bytes| std::str::from_utf8(bytes).ok())
         .map(|s| s.split(':').next().unwrap_or(s))
-        .ok_or_else(|| {
-            LoadModelError::DownloadError(
-                "Could not determine Android package name from /proc/self/cmdline".into(),
-            )
-        })?;
+        .ok_or(GetCacheDirError::NoPackageName)?;
 
     // Derive the Android user ID from the Unix UID. Android assigns UIDs as:
     //   uid = user_id * 100000 + app_id
@@ -413,9 +409,8 @@ fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadMod
 }
 
 #[cfg(not(target_os = "android"))]
-fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
-    dirs::cache_dir()
-        .ok_or_else(|| LoadModelError::DownloadError("Could not determine cache directory".into()))
+fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::GetCacheDirError> {
+    dirs::cache_dir().ok_or(crate::errors::GetCacheDirError::NoCacheDir)
 }
 
 /// Download a file from a URL to a local path, streaming to disk with progress logging.
@@ -570,28 +565,32 @@ fn download_model_from_hf(
     Ok(target_path)
 }
 
-/// Get the paths and total byte size of every .gguf model in the nobodywho cache.
-pub fn get_cached_models() -> Result<(Vec<std::path::PathBuf>, u64), crate::errors::LoadModelError> {
+/// Every `.gguf` model in the nobodywho cache, paired with its byte size.
+pub fn get_cached_models(
+) -> Result<Vec<(std::path::PathBuf, usize)>, crate::errors::GetCachedModelsError> {
     let cache_dir = get_cache_dir()?;
-    let mut models = Vec::new();
-    let mut total_size: u64 = 0;
-    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>, size: &mut u64) {
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    walk(&path, out, size);
-                } else if path.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    *size += std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-                    out.push(path);
-                }
+    if !cache_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    walkdir::WalkDir::new(&cache_dir)
+        .into_iter()
+        .filter(|res| match res {
+            Ok(e) => {
+                e.file_type().is_file()
+                    && e.path()
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|s| s.eq_ignore_ascii_case("gguf"))
             }
-        }
-    }
-    if cache_dir.exists() {
-        walk(&cache_dir, &mut models, &mut total_size);
-    }
-    Ok((models, total_size))
+            Err(_) => true,
+        })
+        .map(|res| {
+            let entry = res?;
+            let len = entry.metadata()?.len() as usize;
+            Ok((entry.into_path(), len))
+        })
+        .collect()
 }
 
 /// Download a model from a generic HTTP(S) URL and return the local path to it.

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -570,6 +570,30 @@ fn download_model_from_hf(
     Ok(target_path)
 }
 
+/// Get the paths and total byte size of every .gguf model in the nobodywho cache.
+pub fn get_cache_information() -> Result<(Vec<std::path::PathBuf>, u64), crate::errors::LoadModelError> {
+    let cache_dir = get_cache_dir()?;
+    let mut models = Vec::new();
+    let mut total_size: u64 = 0;
+    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>, size: &mut u64) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out, size);
+                } else if path.extension().and_then(|e| e.to_str()) == Some("gguf") {
+                    *size += std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    out.push(path);
+                }
+            }
+        }
+    }
+    if cache_dir.exists() {
+        walk(&cache_dir, &mut models, &mut total_size);
+    }
+    Ok((models, total_size))
+}
+
 /// Download a model from a generic HTTP(S) URL and return the local path to it.
 ///
 /// The file is cached by its URL path components under the cache directory.

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class NobodyWho
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1088055976;
+  int get rustContentHash => 250237116;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -359,6 +359,8 @@ abstract class NobodyWhoApi extends BaseApi {
     FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
         noopOnDownloadProgress,
   });
+
+  List<(String, BigInt)> crateGetCachedModels();
 
   Future<void> crateInitApp();
 
@@ -2771,6 +2773,28 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   );
 
   @override
+  List<(String, BigInt)> crateGetCachedModels() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_record_string_usize,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateGetCachedModelsConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateGetCachedModelsConstMeta =>
+      const TaskConstMeta(debugName: "get_cached_models", argNames: []);
+
+  @override
   Future<void> crateInitApp() {
     return handler.executeNormal(
       NormalTask(
@@ -2779,7 +2803,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2804,7 +2828,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_box_autoadd_usize(maxCommands, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2836,7 +2860,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_opt_box_autoadd_u_64(maxDurationSecs, serializer);
           sse_encode_opt_box_autoadd_usize(maxMemoryBytes, serializer);
           sse_encode_opt_box_autoadd_usize(maxRecursionDepth, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2875,7 +2899,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_String(description, serializer);
           sse_encode_String(runtimeType, serializer);
           sse_encode_Map_String_String_None(parameterDescriptions, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2917,7 +2941,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_64(downloaded, serializer);
           sse_encode_i_64(total, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2946,7 +2970,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             toolCall,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3780,6 +3804,12 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  List<(String, BigInt)> dco_decode_list_record_string_usize(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_record_string_usize).toList();
+  }
+
+  @protected
   Message dco_decode_message(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -3904,6 +3934,16 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
     return (dco_decode_String(arr[0]), dco_decode_String(arr[1]));
+  }
+
+  @protected
+  (String, BigInt) dco_decode_record_string_usize(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (dco_decode_String(arr[0]), dco_decode_usize(arr[1]));
   }
 
   @protected
@@ -4727,6 +4767,20 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  List<(String, BigInt)> sse_decode_list_record_string_usize(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(String, BigInt)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_string_usize(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   Message sse_decode_message(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4880,6 +4934,16 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_field0 = sse_decode_String(deserializer);
     var var_field1 = sse_decode_String(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (String, BigInt) sse_decode_record_string_usize(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_usize(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -5787,6 +5851,18 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  void sse_encode_list_record_string_usize(
+    List<(String, BigInt)> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_string_usize(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_message(Message self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
@@ -5938,6 +6014,16 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.$1, serializer);
     sse_encode_String(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_record_string_usize(
+    (String, BigInt) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_usize(self.$2, serializer);
   }
 
   @protected

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
@@ -449,6 +449,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
 
   @protected
+  List<(String, BigInt)> dco_decode_list_record_string_usize(dynamic raw);
+
+  @protected
   Message dco_decode_message(dynamic raw);
 
   @protected
@@ -486,6 +489,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
+
+  @protected
+  (String, BigInt) dco_decode_record_string_usize(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -872,6 +878,11 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  List<(String, BigInt)> sse_decode_list_record_string_usize(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   Message sse_decode_message(SseDeserializer deserializer);
 
   @protected
@@ -911,6 +922,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   );
+
+  @protected
+  (String, BigInt) sse_decode_record_string_usize(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -1378,6 +1392,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_usize(
+    List<(String, BigInt)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_message(Message self, SseSerializer serializer);
 
   @protected
@@ -1424,6 +1444,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   @protected
   void sse_encode_record_string_string(
     (String, String) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_usize(
+    (String, BigInt) self,
     SseSerializer serializer,
   );
 

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
@@ -451,6 +451,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
 
   @protected
+  List<(String, BigInt)> dco_decode_list_record_string_usize(dynamic raw);
+
+  @protected
   Message dco_decode_message(dynamic raw);
 
   @protected
@@ -488,6 +491,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
+
+  @protected
+  (String, BigInt) dco_decode_record_string_usize(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -874,6 +880,11 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  List<(String, BigInt)> sse_decode_list_record_string_usize(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   Message sse_decode_message(SseDeserializer deserializer);
 
   @protected
@@ -913,6 +924,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   );
+
+  @protected
+  (String, BigInt) sse_decode_record_string_usize(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -1380,6 +1394,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_usize(
+    List<(String, BigInt)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_message(Message self, SseSerializer serializer);
 
   @protected
@@ -1426,6 +1446,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   @protected
   void sse_encode_record_string_string(
     (String, String) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_usize(
+    (String, BigInt) self,
     SseSerializer serializer,
   );
 

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -48,6 +48,12 @@ Future<String> downloadModel({
 double cosineSimilarity({required List<double> a, required List<double> b}) =>
     NobodyWho.instance.api.crateCosineSimilarity(a: a, b: b);
 
+/// Returns every cached .gguf model paired with its byte size.
+///
+/// Each entry is (absolute path, size in bytes).
+List<(String, BigInt)> getCachedModels() =>
+    NobodyWho.instance.api.crateGetCachedModels();
+
 RustTool newToolImpl({
   required FutureOr<String> Function(String) function,
   required String name,

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -150,6 +150,37 @@ void main() {
       );
     });
 
+    test('downloading-models.md:25', () async {
+      final chat = await nobodywho.Chat.fromPath(
+        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+        onDownloadProgress: (downloaded, total) {
+          print('$downloaded / $total bytes');
+        },
+      );
+    });
+
+    test('downloading-models.md:40', () async {
+      final chat = await nobodywho.Chat.fromPath(
+        modelPath: './model.gguf',
+      );
+    });
+
+    test('downloading-models.md:48', () async {
+      final modelPath = await nobodywho.downloadModel(
+        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+        headers: {'Authorization': 'Bearer your_hf_token'},
+      );
+      
+      final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
+    });
+
+    test('downloading-models.md:65', () async {
+      final models = nobodywho.getCachedModels();
+      for (final (path, size) in models) {
+        print('$path: ${size ~/ BigInt.from(1024 * 1024)} MiB');
+      }
+    });
+
     test('embeddings-and-rag.md:21', () async {
       final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
       final embedding = await encoder.encode(text: "What is the weather like?");
@@ -238,11 +269,11 @@ void main() {
     });
 
     test('embeddings-and-rag.md:166', () async {
-      await _doctest_13();
+      await _doctest_17();
     });
 
     test('embeddings-and-rag.md:216', () async {
-      await _doctest_14();
+      await _doctest_18();
     });
 
     test('embeddings-and-rag.md:263', () async {
@@ -266,30 +297,6 @@ void main() {
       );
       final msg = await chat.ask('Is water wet?').completed();
       print(msg); // Yes, indeed, water is wet!
-    });
-
-    test('index.md:54', () async {
-      final chat = await nobodywho.Chat.fromPath(
-        modelPath: './model.gguf',
-      );
-    });
-
-    test('index.md:61', () async {
-      final modelPath = await nobodywho.downloadModel(
-        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-        headers: {'Authorization': 'Bearer your_hf_token'},
-      );
-      
-      final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
-    });
-
-    test('index.md:78', () async {
-      final chat = await nobodywho.Chat.fromPath(
-        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-        onDownloadProgress: (downloaded, total) {
-          print('$downloaded / $total bytes');
-        },
-      );
     });
 
     test('sampling.md:14', () async {
@@ -463,7 +470,7 @@ void main() {
 }
 
 // Extracted from embeddings-and-rag.md:166
-Future<void> _doctest_13() async {
+Future<void> _doctest_17() async {
   // Initialize the cross-encoder for document ranking
   final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');
 
@@ -504,7 +511,7 @@ Future<void> _doctest_13() async {
 }
 
 // Extracted from embeddings-and-rag.md:216
-Future<void> _doctest_14() async {
+Future<void> _doctest_18() async {
   final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
   
   final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1088055976;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 250237116;
 
 // Section: executor
 
@@ -3076,6 +3076,35 @@ fn wire__crate__download_model_impl(
         },
     )
 }
+fn wire__crate__get_cached_models_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_cached_models",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::get_cached_models()?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__init_app_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3998,6 +4027,18 @@ impl SseDecode for Vec<(String, String)> {
     }
 }
 
+impl SseDecode for Vec<(String, usize)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<(String, usize)>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for crate::Message {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4159,6 +4200,15 @@ impl SseDecode for (String, String) {
     }
 }
 
+impl SseDecode for (String, usize) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <usize>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
 impl SseDecode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4225,7 +4275,7 @@ fn pde_ffi_dispatcher_primary_impl(
         28 => wire__crate__RustTokenStream_iter_impl(port, ptr, rust_vec_len, data_len),
         29 => wire__crate__RustTokenStream_next_token_impl(port, ptr, rust_vec_len, data_len),
         63 => wire__crate__download_model_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__init_app_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__init_app_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -4279,11 +4329,12 @@ fn pde_ffi_dispatcher_sync_impl(
         60 => wire__crate__ToolCall_auto_accessor_set_arguments_impl(ptr, rust_vec_len, data_len),
         61 => wire__crate__ToolCall_auto_accessor_set_name_impl(ptr, rust_vec_len, data_len),
         62 => wire__crate__cosine_similarity_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
-        66 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
-        67 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
-        68 => wire__crate__noop_on_download_progress_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__get_cached_models_impl(ptr, rust_vec_len, data_len),
+        66 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
+        67 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__noop_on_download_progress_impl(ptr, rust_vec_len, data_len),
+        70 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5123,6 +5174,16 @@ impl SseEncode for Vec<(String, String)> {
     }
 }
 
+impl SseEncode for Vec<(String, usize)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(String, usize)>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for crate::Message {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5260,6 +5321,14 @@ impl SseEncode for (String, String) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.0, serializer);
         <String>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (String, usize) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <usize>::sse_encode(self.1, serializer);
     }
 }
 

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -531,6 +531,19 @@ pub fn cosine_similarity(a: Vec<f32>, b: Vec<f32>) -> f32 {
     nobodywho::encoder::cosine_similarity(&a, &b)
 }
 
+/// Returns the paths and total byte size of all cached .gguf models.
+///
+/// The tuple contains: (list of absolute path strings, total size in bytes).
+#[flutter_rust_bridge::frb(sync)]
+pub fn get_cached_models() -> Result<(Vec<String>, u64), String> {
+    let (paths, total_size) = nobodywho::llm::get_cached_models().map_err(|e| e.to_string())?;
+    let string_paths = paths
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    Ok((string_paths, total_size))
+}
+
 #[flutter_rust_bridge::frb(opaque)]
 pub struct RustTool {
     tool: nobodywho::tool_calling::Tool,

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -531,17 +531,16 @@ pub fn cosine_similarity(a: Vec<f32>, b: Vec<f32>) -> f32 {
     nobodywho::encoder::cosine_similarity(&a, &b)
 }
 
-/// Returns the paths and total byte size of all cached .gguf models.
+/// Returns every cached .gguf model paired with its byte size.
 ///
-/// The tuple contains: (list of absolute path strings, total size in bytes).
+/// Each entry is (absolute path, size in bytes).
 #[flutter_rust_bridge::frb(sync)]
-pub fn get_cached_models() -> Result<(Vec<String>, u64), String> {
-    let (paths, total_size) = nobodywho::llm::get_cached_models().map_err(|e| e.to_string())?;
-    let string_paths = paths
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
-    Ok((string_paths, total_size))
+pub fn get_cached_models() -> Result<Vec<(String, usize)>, String> {
+    nobodywho::llm::get_cached_models()
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|(path, size)| Ok((path.to_string_lossy().into_owned(), size)))
+        .collect()
 }
 
 #[flutter_rust_bridge::frb(opaque)]

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -186,6 +186,33 @@ impl NobodyWhoModel {
     }
 
     #[func]
+    /// Returns all cached .gguf model paths and their combined byte size.
+    ///
+    /// The dictionary contains:
+    /// - "paths": PackedStringArray of absolute paths to cached model files
+    /// - "total_size": int total size in bytes of all cached models
+    ///
+    /// Returns an empty Dictionary on error.
+    fn get_cached_models() -> VarDictionary {
+        match nobodywho::llm::get_cached_models() {
+            Ok((paths, total_size)) => {
+                let gstrings: Vec<GString> = paths
+                    .iter()
+                    .map(|p| GString::from(p.to_string_lossy().as_ref()))
+                    .collect();
+                let mut dict = VarDictionary::new();
+                dict.set("paths", PackedStringArray::from(gstrings));
+                dict.set("total_size", total_size as i64);
+                dict
+            }
+            Err(e) => {
+                godot_error!("Failed to get cached models: {}", e);
+                VarDictionary::new()
+            }
+        }
+    }
+
+    #[func]
     /// Sets the (global) log level of NobodyWho.
     /// Valid arguments are "TRACE", "DEBUG", "INFO", "WARN", and "ERROR".
     fn set_log_level(level: String) {

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -186,28 +186,27 @@ impl NobodyWhoModel {
     }
 
     #[func]
-    /// Returns all cached .gguf model paths and their combined byte size.
+    /// Returns every cached .gguf model paired with its byte size.
     ///
-    /// The dictionary contains:
-    /// - "paths": PackedStringArray of absolute paths to cached model files
-    /// - "total_size": int total size in bytes of all cached models
+    /// Each entry is a Dictionary with:
+    /// - "path": String absolute path to the cached model file
+    /// - "size": int size in bytes of that file
     ///
-    /// Returns an empty Dictionary on error.
-    fn get_cached_models() -> VarDictionary {
+    /// Returns an empty Array on error.
+    fn get_cached_models() -> Array<Variant> {
         match nobodywho::llm::get_cached_models() {
-            Ok((paths, total_size)) => {
-                let gstrings: Vec<GString> = paths
-                    .iter()
-                    .map(|p| GString::from(p.to_string_lossy().as_ref()))
-                    .collect();
-                let mut dict = VarDictionary::new();
-                dict.set("paths", PackedStringArray::from(gstrings));
-                dict.set("total_size", total_size as i64);
-                dict
-            }
+            Ok(models) => models
+                .into_iter()
+                .map(|(path, size)| {
+                    let mut dict = VarDictionary::new();
+                    dict.set("path", GString::from(path.to_string_lossy().as_ref()));
+                    dict.set("size", size as i64);
+                    Variant::from(dict)
+                })
+                .collect(),
             Err(e) => {
                 godot_error!("Failed to get cached models: {}", e);
-                VarDictionary::new()
+                Array::new()
             }
         }
     }

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -192,21 +192,24 @@ impl NobodyWhoModel {
     /// - "path": String absolute path to the cached model file
     /// - "size": int size in bytes of that file
     ///
-    /// Returns an empty Array on error.
-    fn get_cached_models() -> Array<Variant> {
+    /// Returns nil on error (also logged via godot_error!).
+    fn get_cached_models() -> Variant {
         match nobodywho::llm::get_cached_models() {
-            Ok(models) => models
-                .into_iter()
-                .map(|(path, size)| {
-                    let mut dict = VarDictionary::new();
-                    dict.set("path", GString::from(path.to_string_lossy().as_ref()));
-                    dict.set("size", size as i64);
-                    Variant::from(dict)
-                })
-                .collect(),
+            Ok(models) => {
+                let arr: Array<Variant> = models
+                    .into_iter()
+                    .map(|(path, size)| {
+                        let mut dict = VarDictionary::new();
+                        dict.set("path", GString::from(path.to_string_lossy().as_ref()));
+                        dict.set("size", size as i64);
+                        Variant::from(dict)
+                    })
+                    .collect();
+                Variant::from(arr)
+            }
             Err(e) => {
                 godot_error!("Failed to get cached models: {}", e);
-                Array::new()
+                Variant::nil()
             }
         }
     }

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -1005,6 +1005,17 @@ def download_model(model_path: str |PathLike[str], headers: dict[str, str] | Non
         RuntimeError: If the download fails
     """
 
+def get_cached_models() -> tuple[list[str], int]:
+    """
+    Returns the paths and total byte size of all cached .gguf models.
+    
+    Returns:
+        A tuple of (list[str], int): paths to each cached model file, and their combined size in bytes.
+    
+    Raises:
+        RuntimeError: If the cache directory cannot be read
+    """
+
 def python_tool(max_duration: int | None = None, max_memory: int | None = None, max_recursion_depth: int | None = None) -> Tool:
     """
     Create a built-in tool that lets the LLM run sandboxed Python code.

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -1005,12 +1005,12 @@ def download_model(model_path: str |PathLike[str], headers: dict[str, str] | Non
         RuntimeError: If the download fails
     """
 
-def get_cached_models() -> tuple[list[str], int]:
+def get_cached_models() -> list[tuple[str, int]]:
     """
-    Returns the paths and total byte size of all cached .gguf models.
+    Returns every cached .gguf model paired with its byte size.
     
     Returns:
-        A tuple of (list[str], int): paths to each cached model file, and their combined size in bytes.
+        list[tuple[str, int]]: each entry is (absolute path, size in bytes).
     
     Raises:
         RuntimeError: If the cache directory cannot be read

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -2624,13 +2624,13 @@ pub mod nobodywhopython {
     }
 
     #[pymodule_export]
-    use super::get_cached_models;
-    #[pymodule_export]
     use super::bash_tool;
     #[pymodule_export]
     use super::cosine_similarity;
     #[pymodule_export]
     use super::download_model;
+    #[pymodule_export]
+    use super::get_cached_models;
     #[pymodule_export]
     use super::python_tool;
     #[pymodule_export]

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -2459,22 +2459,20 @@ fn json_value_to_py<'py>(
     }
 }
 
-/// Returns the paths and total byte size of all cached .gguf models.
+/// Returns every cached .gguf model paired with its byte size.
 ///
 /// Returns:
-///     A tuple of (list[str], int): paths to each cached model file, and their combined size in bytes.
+///     list[tuple[str, int]]: each entry is (absolute path, size in bytes).
 ///
 /// Raises:
 ///     RuntimeError: If the cache directory cannot be read
 #[pyfunction]
-fn get_cached_models() -> PyResult<(Vec<String>, u64)> {
-    let (paths, total_size) = nobodywho::llm::get_cached_models()
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-    let string_paths = paths
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
-    Ok((string_paths, total_size))
+fn get_cached_models() -> PyResult<Vec<(String, usize)>> {
+    nobodywho::llm::get_cached_models()
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
+        .into_iter()
+        .map(|(path, size)| Ok((path.to_string_lossy().into_owned(), size)))
+        .collect()
 }
 
 #[pymodule(name = "nobodywho")]

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -2459,6 +2459,24 @@ fn json_value_to_py<'py>(
     }
 }
 
+/// Returns the paths and total byte size of all cached .gguf models.
+///
+/// Returns:
+///     A tuple of (list[str], int): paths to each cached model file, and their combined size in bytes.
+///
+/// Raises:
+///     RuntimeError: If the cache directory cannot be read
+#[pyfunction]
+fn get_cached_models() -> PyResult<(Vec<String>, u64)> {
+    let (paths, total_size) = nobodywho::llm::get_cached_models()
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let string_paths = paths
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    Ok((string_paths, total_size))
+}
+
 #[pymodule(name = "nobodywho")]
 pub mod nobodywhopython {
     use pyo3::prelude::*;
@@ -2607,6 +2625,8 @@ pub mod nobodywhopython {
         crate::PYTHON_LOGGING_AVAILABLE.store(false, std::sync::atomic::Ordering::Release);
     }
 
+    #[pymodule_export]
+    use super::get_cached_models;
     #[pymodule_export]
     use super::bash_tool;
     #[pymodule_export]

--- a/nobodywho/python/tests/test_model_downloading.py
+++ b/nobodywho/python/tests/test_model_downloading.py
@@ -44,6 +44,17 @@ def test_download_model_chat():
 
 
 @pytest.mark.network
+def test_get_cached_models_includes_downloaded_model():
+    """After downloading a model, get_cached_models() lists it with a nonzero size."""
+    nobodywho.Model(HF_MODEL)  # ensure cached
+
+    cached = nobodywho.get_cached_models()
+    assert isinstance(cached, list)
+    assert all(isinstance(p, str) and isinstance(s, int) for p, s in cached)
+    assert any(p.endswith("Qwen_Qwen3-0.6B-Q4_K_M.gguf") and s > 0 for p, s in cached)
+
+
+@pytest.mark.network
 def test_cached_model_loads_offline():
     """After a model has been downloaded, it can be loaded without internet.
 

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -270,6 +270,8 @@ float uniffi_nobodywho_uniffi_fn_func_cosine_similarity(
     RustBuffer a, RustBuffer b, RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_download_model(
     RustBuffer model_path, RustBuffer headers, RustBuffer on_download_progress);
+RustBuffer uniffi_nobodywho_uniffi_fn_func_get_cached_models(
+    RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(
     RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path,
     RustBuffer on_download_progress);
@@ -419,6 +421,7 @@ void ffi_nobodywho_uniffi_rust_future_complete_void(
     /*handle*/ uint64_t handle, RustCallStatus *uniffi_out_err);
 uint16_t uniffi_nobodywho_uniffi_checksum_func_cosine_similarity();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_download_model();
+uint16_t uniffi_nobodywho_uniffi_checksum_func_get_cached_models();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_load_model();
 uint16_t
 uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_grammar();
@@ -3386,6 +3389,17 @@ NativeNobodywho::NativeNobodywho(
             return this->cpp_uniffi_nobodywho_uniffi_fn_func_download_model(
                 rt, thisVal, args, count);
           });
+  props["ubrn_uniffi_nobodywho_uniffi_fn_func_get_cached_models"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_nobodywho_uniffi_fn_func_get_cached_models"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_nobodywho_uniffi_fn_func_get_cached_models(
+                rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_nobodywho_uniffi_fn_func_load_model"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -4084,6 +4098,19 @@ NativeNobodywho::NativeNobodywho(
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this
                 ->cpp_uniffi_nobodywho_uniffi_checksum_func_download_model(
+                    rt, thisVal, args, count);
+          });
+  props["ubrn_uniffi_nobodywho_uniffi_checksum_func_get_cached_models"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt,
+              "ubrn_uniffi_nobodywho_uniffi_checksum_func_get_cached_models"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this
+                ->cpp_uniffi_nobodywho_uniffi_checksum_func_get_cached_models(
                     rt, thisVal, args, count);
           });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model"] =
@@ -6035,6 +6062,18 @@ jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_download_model(
   return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker,
                                                          value);
 }
+jsi::Value
+NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_get_cached_models(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  RustCallStatus status =
+      uniffi::nobodywho::Bridging<RustCallStatus>::rustSuccess(rt);
+  auto value = uniffi_nobodywho_uniffi_fn_func_get_cached_models(&status);
+  uniffi::nobodywho::Bridging<RustCallStatus>::copyIntoJs(
+      rt, callInvoker, status, args[count - 1]);
+
+  return uniffi::nobodywho::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
@@ -6765,6 +6804,14 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_checksum_func_download_model(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_nobodywho_uniffi_checksum_func_download_model();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value
+NativeNobodywho::cpp_uniffi_nobodywho_uniffi_checksum_func_get_cached_models(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_nobodywho_uniffi_checksum_func_get_cached_models();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/nobodywho/react-native/generated/cpp/nobodywho.hpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.hpp
@@ -224,6 +224,9 @@ protected:
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_download_model(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
+  jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_get_cached_models(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -411,6 +414,9 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_download_model(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_get_cached_models(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_load_model(

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -81,6 +81,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_fn_init_callback_vtable_rusttoolcallback(vtable: UniffiVTableCallbackInterfaceRustToolCallback): void;
     ubrn_uniffi_nobodywho_uniffi_fn_func_cosine_similarity(a: Uint8Array, b: Uint8Array, uniffi_out_err: UniffiRustCallStatus): number;
     ubrn_uniffi_nobodywho_uniffi_fn_func_download_model(modelPath: Uint8Array, headers: Uint8Array, onDownloadProgress: Uint8Array): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_func_get_cached_models(uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array, onDownloadProgress: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_constrain_with_grammar(grammar: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_constrain_with_json_schema(schema: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -143,6 +144,7 @@ interface NativeModuleInterface {
     ubrn_ffi_nobodywho_uniffi_rust_future_complete_void(handle: bigint, uniffi_out_err: UniffiRustCallStatus): void;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_cosine_similarity(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_download_model(): number;
+    ubrn_uniffi_nobodywho_uniffi_checksum_func_get_cached_models(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_grammar(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_json_schema(): number;

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -127,6 +127,20 @@ export async function downloadModel(modelPath: string, headers: Map<string, stri
     }
     }
 /**
+ * Returns every cached `.gguf` model paired with its byte size.
+ */
+export function getCachedModels(): Array<CachedModel> /*throws*/ {
+    return FfiConverterArrayTypeCachedModel.lift(
+        uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError),
+            /*caller:*/ (callStatus) => {
+                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_get_cached_models(
+                callStatus);
+            },
+            /*liftString:*/ FfiConverterString.lift,
+    ));
+    }
+/**
  * Load a GGUF model from a local path or remote URL.
  *
  * Accepts local filesystem paths, `hf://owner/repo/file.gguf` for HuggingFace downloads,
@@ -482,6 +496,67 @@ const FfiConverterTypeAsset = (() => {
         allocationSize(value: TypeName): number {
             return FfiConverterString.allocationSize(value.id) + 
             FfiConverterString.allocationSize(value.path);
+            
+        }
+    };
+    return new FFIConverter();
+})();
+
+
+/**
+ * A cached `.gguf` model and its on-disk size.
+ */
+export type CachedModel = {
+    path: string,
+    size: /*u64*/bigint
+}
+
+/**
+ * Generated factory for {@link CachedModel} record objects.
+ */
+export const CachedModel = (() => {
+    const defaults = () => ({
+    });
+    const create = (() => {
+        return uniffiCreateRecord<CachedModel, ReturnType<typeof defaults>>(defaults);
+    })();
+    return Object.freeze({
+        /**
+         * Create a frozen instance of {@link CachedModel}, with defaults specified
+         * in Rust, in the {@link nobodywho} crate.
+         */
+        create,
+
+        /**
+         * Create a frozen instance of {@link CachedModel}, with defaults specified
+         * in Rust, in the {@link nobodywho} crate.
+         */
+        new: create,
+
+        /**
+         * Defaults specified in the {@link nobodywho} crate.
+         */
+        defaults: () => Object.freeze(defaults()) as Partial<CachedModel>,
+
+    });
+})();
+
+const FfiConverterTypeCachedModel = (() => {
+    type TypeName = CachedModel;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            return {
+                path: FfiConverterString.read(from), 
+                size: FfiConverterUInt64.read(from)
+            };
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            FfiConverterString.write(value.path, into);
+            FfiConverterUInt64.write(value.size, into);
+        }
+        allocationSize(value: TypeName): number {
+            return FfiConverterString.allocationSize(value.path) + 
+            FfiConverterUInt64.allocationSize(value.size);
             
         }
     };
@@ -3055,6 +3130,10 @@ const FfiConverterArrayFloat32 = new FfiConverterArray(FfiConverterFloat32);
 const FfiConverterArrayTypeAsset = new FfiConverterArray(FfiConverterTypeAsset);
 
 
+// FfiConverter for Array<CachedModel>
+const FfiConverterArrayTypeCachedModel = new FfiConverterArray(FfiConverterTypeCachedModel);
+
+
 // FfiConverter for Array<ToolCall>
 const FfiConverterArrayTypeToolCall = new FfiConverterArray(FfiConverterTypeToolCall);
 
@@ -3121,6 +3200,9 @@ function uniffiEnsureInitialized() {
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_download_model() !== 31331) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_download_model");
+    }
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_get_cached_models() !== 12002) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_get_cached_models");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 33587) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_model");
@@ -3302,6 +3384,7 @@ export default Object.freeze({
   initialize: uniffiEnsureInitialized,
   converters: {
     FfiConverterTypeAsset,
+    FfiConverterTypeCachedModel,
     FfiConverterTypeMessage,
     FfiConverterTypeNobodyWhoError,
     FfiConverterTypePendingToolCall,

--- a/nobodywho/react-native/src/wrapper.ts
+++ b/nobodywho/react-native/src/wrapper.ts
@@ -23,15 +23,20 @@ export { TokenStream } from "./streaming";
 export type { Message } from "./message";
 
 // Re-export types that don't need wrapping.
+//
+// Note: `getCachedModels` returns `size` as `bigint` (Rust `u64`). Wrap with
+// `Number(m.size)` at the call site if a JS number is needed.
 export {
   SamplerBuilder,
   SamplerConfig,
   cosineSimilarity,
+  getCachedModels,
 } from "./index";
 
 export type {
   Asset,
   ToolCall,
+  CachedModel,
 } from "./index";
 
 // Ergonomic wrapper additions.

--- a/nobodywho/swift/generated/nobodywho.swift
+++ b/nobodywho/swift/generated/nobodywho.swift
@@ -2275,6 +2275,61 @@ public func FfiConverterTypeAsset_lower(_ value: Asset) -> RustBuffer {
 
 
 /**
+ * A cached `.gguf` model and its on-disk size.
+ */
+public struct CachedModel: Equatable, Hashable {
+    public var path: String
+    public var size: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(path: String, size: UInt64) {
+        self.path = path
+        self.size = size
+    }
+
+    
+}
+
+#if compiler(>=6)
+extension CachedModel: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeCachedModel: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CachedModel {
+        return
+            try CachedModel(
+                path: FfiConverterString.read(from: &buf), 
+                size: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: CachedModel, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.path, into: &buf)
+        FfiConverterUInt64.write(value.size, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCachedModel_lift(_ buf: RustBuffer) throws -> CachedModel {
+    return try FfiConverterTypeCachedModel.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCachedModel_lower(_ value: CachedModel) -> RustBuffer {
+    return FfiConverterTypeCachedModel.lower(value)
+}
+
+
+/**
  * A pending tool call waiting for resolution from the language binding.
  */
 public struct PendingToolCall: Equatable, Hashable {
@@ -3269,6 +3324,31 @@ fileprivate struct FfiConverterSequenceTypeAsset: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeCachedModel: FfiConverterRustBuffer {
+    typealias SwiftType = [CachedModel]
+
+    public static func write(_ value: [CachedModel], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeCachedModel.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [CachedModel] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [CachedModel]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeCachedModel.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeToolCall: FfiConverterRustBuffer {
     typealias SwiftType = [ToolCall]
 
@@ -3497,6 +3577,15 @@ public func downloadModel(modelPath: String, headers: [String: String]?, onDownl
         )
 }
 /**
+ * Returns every cached `.gguf` model paired with its byte size.
+ */
+public func getCachedModels()throws  -> [CachedModel]  {
+    return try  FfiConverterSequenceTypeCachedModel.lift(try rustCallWithError(FfiConverterTypeNobodyWhoError_lift) {
+    uniffi_nobodywho_uniffi_fn_func_get_cached_models($0
+    )
+})
+}
+/**
  * Load a GGUF model from a local path or remote URL.
  *
  * Accepts local filesystem paths, `hf://owner/repo/file.gguf` for HuggingFace downloads,
@@ -3643,6 +3732,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_func_download_model() != 31331) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nobodywho_uniffi_checksum_func_get_cached_models() != 12002) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_func_load_model() != 33587) {

--- a/nobodywho/swift/generated/nobodywhoFFI.h
+++ b/nobodywho/swift/generated/nobodywhoFFI.h
@@ -591,6 +591,12 @@ float uniffi_nobodywho_uniffi_fn_func_cosine_similarity(RustBuffer a, RustBuffer
 uint64_t uniffi_nobodywho_uniffi_fn_func_download_model(RustBuffer model_path, RustBuffer headers, RustBuffer on_download_progress
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_GET_CACHED_MODELS
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_GET_CACHED_MODELS
+RustBuffer uniffi_nobodywho_uniffi_fn_func_get_cached_models(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_MODEL
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_MODEL
 uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path, RustBuffer on_download_progress
@@ -924,6 +930,12 @@ uint16_t uniffi_nobodywho_uniffi_checksum_func_cosine_similarity(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_DOWNLOAD_MODEL
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_DOWNLOAD_MODEL
 uint16_t uniffi_nobodywho_uniffi_checksum_func_download_model(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_GET_CACHED_MODELS
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_GET_CACHED_MODELS
+uint16_t uniffi_nobodywho_uniffi_checksum_func_get_cached_models(void
     
 );
 #endif

--- a/nobodywho/swift/src/Exports.swift
+++ b/nobodywho/swift/src/Exports.swift
@@ -12,10 +12,19 @@
 @_exported import struct NobodyWhoGenerated.ToolCall
 @_exported import class NobodyWhoGenerated.SamplerConfig
 @_exported import class NobodyWhoGenerated.SamplerBuilder
+@_exported import struct NobodyWhoGenerated.CachedModel
 
 import NobodyWhoGenerated
 
 /// Compute cosine similarity between two embedding vectors.
 public func cosineSimilarity(a: [Float], b: [Float]) -> Float {
     return NobodyWhoGenerated.cosineSimilarity(a: a, b: b)
+}
+
+/// Returns every cached `.gguf` model paired with its byte size.
+///
+/// Scans the platform model cache directory. Returns an empty array if the cache
+/// directory does not exist yet.
+public func getCachedModels() throws -> [CachedModel] {
+    return try NobodyWhoGenerated.getCachedModels()
 }

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -28,6 +28,7 @@ final class NobodyWhoTests: XCTestCase {
         return value
     }
 
+<<<<<<< HEAD
     // MARK: - Download
 
     func testDownloadModel() async throws {
@@ -46,6 +47,17 @@ final class NobodyWhoTests: XCTestCase {
         let attrs = try FileManager.default.attributesOfItem(atPath: localPath)
         XCTAssertGreaterThan(attrs[.size] as? UInt64 ?? 0, 0)
         XCTAssertTrue(progressCalled, "Progress callback should have been called")
+=======
+    // MARK: - Cached models
+
+    func testGetCachedModels() throws {
+        // Just verify the FFI bridge works — the cache may be empty on CI.
+        let models = try getCachedModels()
+        for m in models {
+            XCTAssertFalse(m.path.isEmpty)
+            XCTAssertGreaterThan(m.size, 0)
+        }
+>>>>>>> 1d0cf69e (add react-native and swift bindings for getCachedModels)
     }
 
     // MARK: - Chat (completion, streaming, tools)

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -682,6 +682,28 @@ pub fn cosine_similarity(a: Vec<f32>, b: Vec<f32>) -> f32 {
     nobodywho::encoder::cosine_similarity(&a, &b)
 }
 
+/// A cached `.gguf` model and its on-disk size.
+#[derive(uniffi::Record, Clone)]
+pub struct CachedModel {
+    pub path: String,
+    pub size: u64,
+}
+
+/// Returns every cached `.gguf` model paired with its byte size.
+#[uniffi::export]
+pub fn get_cached_models() -> Result<Vec<CachedModel>, NobodyWhoError> {
+    let models = nobodywho::llm::get_cached_models().map_err(|e| NobodyWhoError::Error {
+        message: e.to_string(),
+    })?;
+    Ok(models
+        .into_iter()
+        .map(|(path, size)| CachedModel {
+            path: path.to_string_lossy().into_owned(),
+            size: size as u64,
+        })
+        .collect())
+}
+
 // ---------- RustCrossEncoder ----------
 // Wrapper intended to be wrapped again in the target language (e.g. as `CrossEncoder`).
 


### PR DESCRIPTION
Addresses #501 

Adds a small function to core, exposed in integrations, which lists the path of all currently cached models (those downloaded by Nobodywho), as well as the size they take in bytes. 

People *can* probably get these without our help... this is just a somewhat more convenient solution for them... that way, they don't have to guess out where exactly nobodywho caches their models.

This PR also includes some re-structuring of the errors emitted during model downloading, since the get_cached_models function now also calls the get_cache_dir function.