### PR TITLE
feat: Llama-3.x + LFM2.5 family tool calling

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2634,9 +2634,14 @@ mod tests {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
-        // Use a very small context size to force shifting
+        // Use a very small context size to force shifting. Bumped n_messages
+        // from 10 -> 20 because passing tools to the chat template as
+        // pre-serialized JSON strings (see commit a26dfc79) reduced the
+        // per-render token count enough that 10 exchanges no longer overflow
+        // n_ctx=1024 with the test_chat-model GGUF — context_shift then
+        // skipped, leaving messages_after.len() == messages_before.
         let n_ctx = 1024;
-        let n_messages = 10;
+        let n_messages = 20;
         let mut worker = Worker::new_chat_worker(
             &model,
             ChatConfig {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -50,7 +50,7 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::hash::Hasher;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, MutexGuard};
 use tracing::{debug, error, info, trace, trace_span};
 
@@ -1643,11 +1643,21 @@ impl Worker<'_, ChatWorker> {
             },
         );
 
+        // Tracks whether any iteration's Done event was forwarded to the outer
+        // callback. Shared across every `wrap_respond` instance built below so
+        // the terminal-Done epilogue can run only when no Done has reached the
+        // consumer yet (e.g. parser-only paths that exit before producing an
+        // iter-2 generation). Keeps raw `Fn(WriteOutput)` consumers — godot
+        // binding, direct ask_channel users — from receiving two Done events
+        // per `ask` call.
+        let done_forwarded = Arc::new(AtomicBool::new(false));
+
         // get the finished response
         let mut response: String = self.wrapped_update_context_and_generate_response(
             sampler.clone(),
             respond.clone(),
             tool_call_begin.clone(),
+            done_forwarded.clone(),
         )?;
 
         // Process tool calls if tool format is configured
@@ -1691,6 +1701,7 @@ impl Worker<'_, ChatWorker> {
                     sampler.clone(),
                     respond.clone(),
                     tool_call_begin.clone(),
+                    done_forwarded.clone(),
                 )?;
             }
         } // Close if let Some(tool_format)
@@ -1702,18 +1713,18 @@ impl Worker<'_, ChatWorker> {
 
         self.extra.context.chunks = self.render_as_chunks(true)?;
 
-        // Terminal Done. Guarantees the consumer's TokenStream::completed
-        // (or any Fn(WriteOutput) callback) ALWAYS receives a final Done
-        // event, even when the chat-loop exits early because
-        // `extract_tool_calls` returned None on a parser-only path that
-        // never produced an iter-2 generation. `wrap_respond` suppresses
-        // Done after the begin_token in iter 1, which used to surface as
-        // `WorkerCrashed` for LFM2.5 and other parser-only handlers.
-        // `TokenStream::next_token` short-circuits when
-        // `completed_response.is_some()`, so a multi-iteration flow
-        // (Qwen3 etc.) that already received its iter-N Done simply
-        // ignores this one — no double-process.
-        respond(llm::WriteOutput::Done(response));
+        // Terminal Done failsafe. Fires only when no iteration forwarded a Done
+        // — i.e. parser-only paths where `extract_tool_calls` returned None
+        // after `wrap_respond` already suppressed iter-1's Done past the
+        // begin_token. That used to surface as `WorkerCrashed` for LFM2.5 and
+        // other parser-only handlers. Skipping this when a Done was already
+        // forwarded prevents a double Done for raw `Fn(WriteOutput)` consumers
+        // (godot binding, direct ask_channel users); `TokenStream` consumers
+        // were already shielded by the `completed_response.is_some()`
+        // short-circuit, but external callback users were not.
+        if !done_forwarded.load(Ordering::SeqCst) {
+            respond(llm::WriteOutput::Done(response));
+        }
 
         Ok(self)
     }
@@ -1757,6 +1768,7 @@ impl Worker<'_, ChatWorker> {
         sampler: SamplerConfig,
         respond: F,
         tool_call_begin_token: Option<String>,
+        done_forwarded: Arc<AtomicBool>,
     ) -> Result<String, WrappedResponseError>
     where
         F: Fn(llm::WriteOutput) + Clone,
@@ -1768,7 +1780,8 @@ impl Worker<'_, ChatWorker> {
 
         // wrap the response callback to keep a copy of the completed response
         // and to avoid emitting tool calls
-        let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
+        let (wrapped_respond, resp_receiver) =
+            wrap_respond(respond.clone(), tool_call_begin_token, done_forwarded);
 
         // llm go brrr
         self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
@@ -1965,12 +1978,15 @@ impl Worker<'_, ChatWorker> {
     }
 }
 
-/// wraps a response function in a closure to do two things:
+/// wraps a response function in a closure to do three things:
 /// 1. save a copy of the response (using a channel) before sending it out
 /// 2. skip emitting once a tool_call_begin_token has been seen
+/// 3. record whether a Done was forwarded to the outer callback (so the caller
+///    can decide whether a terminal-Done epilogue is still needed)
 fn wrap_respond<F>(
     respond: F,
     tool_call_begin_token: Option<String>,
+    done_forwarded: Arc<AtomicBool>,
 ) -> (
     impl FnMut(llm::WriteOutput),
     std::sync::mpsc::Receiver<String>,
@@ -1990,6 +2006,9 @@ where
                 resp_sender
                     .send(resp.clone())
                     .expect("Failed sending response");
+                if emitting {
+                    done_forwarded.store(true, Ordering::SeqCst);
+                }
             }
             llm::WriteOutput::Token(_) => (),
         }
@@ -2049,6 +2068,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Regression test for the terminal-Done epilogue: `Worker::ask` must
+    /// emit exactly ONE Done event per call for raw `Fn(WriteOutput)`
+    /// callback consumers (godot binding, direct ask_channel users).
+    /// `TokenStream` consumers were already shielded by the
+    /// `completed_response.is_some()` short-circuit, but external callback
+    /// users were not — a second Done from the unconditional terminal
+    /// epilogue used to double-fire here.
+    #[test]
+    fn test_done_emitted_exactly_once_per_ask() -> Result<(), Box<dyn std::error::Error>> {
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                n_ctx: 1024,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        let done_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_inner = Arc::clone(&done_count);
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let callback = move |x: llm::WriteOutput| {
+            if let llm::WriteOutput::Done(resp) = x {
+                count_inner.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // tolerate a closed channel — count is the assertion target,
+                // recv-side just unblocks once.
+                let _ = sender.send(resp);
+            }
+        };
+
+        worker.ask("Say hi.".into(), callback)?;
+
+        // First Done: confirm a callback arrived (proves wiring).
+        let _ = receiver.recv_timeout(std::time::Duration::from_secs(60))?;
+
+        // `Worker::ask` returns synchronously after invoking its callback for
+        // the final time, so by here the count is final — no race window.
+        let count = done_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            count, 1,
+            "Worker::ask should emit exactly ONE Done per call, observed {count}."
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1698,9 +1698,22 @@ impl Worker<'_, ChatWorker> {
         debug_assert!(tool_call_begin
             .as_ref()
             .is_none_or(|t| !response.contains(t.as_str())));
-        self.add_assistant_message(response);
+        self.add_assistant_message(response.clone());
 
         self.extra.context.chunks = self.render_as_chunks(true)?;
+
+        // Terminal Done. Guarantees the consumer's TokenStream::completed
+        // (or any Fn(WriteOutput) callback) ALWAYS receives a final Done
+        // event, even when the chat-loop exits early because
+        // `extract_tool_calls` returned None on a parser-only path that
+        // never produced an iter-2 generation. `wrap_respond` suppresses
+        // Done after the begin_token in iter 1, which used to surface as
+        // `WorkerCrashed` for LFM2.5 and other parser-only handlers.
+        // `TokenStream::next_token` short-circuits when
+        // `completed_response.is_some()`, so a multi-iteration flow
+        // (Qwen3 etc.) that already received its iter-N Done simply
+        // ignores this one — no double-process.
+        respond(llm::WriteOutput::Done(response));
 
         Ok(self)
     }
@@ -2292,6 +2305,129 @@ mod tests {
         println!("{}", result);
         assert!(result.contains("13.37"));
         assert!(result.contains("0.15"));
+    }
+
+    /// Mirrors the python `test_tool_with_sets` failure that crashed
+    /// LFM2.5-350M and LFM2.5-1.2B-Instruct on host pytest with
+    /// `Worker thread terminated before completing the response`.
+    /// Single tool with a set-of-int schema; prompt contains literal
+    /// Python set syntax `{12,5,7,3,4}` to force the crash path.
+    /// Ignored by default — invoke with:
+    ///   TEST_MODEL=…/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
+    ///     cargo test --release --lib chat::tests::test_lfm2_5_set_tool_repro -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn test_lfm2_5_set_tool_repro() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        fn set_intersection_tool() -> Tool {
+            Tool {
+                name: "set_intersection".into(),
+                description: "Returns the intersection of set1 and set2".into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "set1": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                        "set2": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                    },
+                    "required": ["set1", "set2"],
+                }),
+                function: Arc::new(|args: serde_json::Value| {
+                    let s1: std::collections::HashSet<i64> = args
+                        .get("set1")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let s2: std::collections::HashSet<i64> = args
+                        .get("set2")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let inter: Vec<i64> = s1.intersection(&s2).copied().collect();
+                    format!("{:?}", inter)
+                }),
+            }
+        }
+
+        // Mirror python fixture: 6 tools registered, model picks one.
+        fn dummy_tool(name: &str, description: &str, prop: &str, json_type: &str) -> Tool {
+            let prop_owned = prop.to_string();
+            Tool {
+                name: name.into(),
+                description: description.into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { prop: {"type": json_type} },
+                    "required": [prop],
+                }),
+                function: Arc::new(move |args: serde_json::Value| {
+                    format!("dummy({}={:?})", prop_owned, args.get(&prop_owned))
+                }),
+            }
+        }
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant".into()),
+                n_ctx: 4096,
+                tools: vec![
+                    set_intersection_tool(),
+                    dummy_tool("multiply_strings", "Multiply a string by an integer N times", "pair", "object"),
+                    dummy_tool("sparklify", "Add sparkles to text", "text", "string"),
+                    dummy_tool("reflarbicator", "Boop foob", "reflarb", "integer"),
+                    dummy_tool("add_list_of_vectors", "Add a list of vectors", "list_of_vectors", "array"),
+                    dummy_tool("calculate_volume", "Compute volume of a cube", "dimensions", "object"),
+                ],
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("Failed making worker");
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let f = move |x| {
+            if let llm::WriteOutput::Done(resp) = x {
+                let _ = sender.send(resp);
+            }
+        };
+
+        let ask_result = worker.ask(
+            "Please use the provided tool to find the intersection between the sets {12,5,7,3,4} and {12,9,5,3}".into(),
+            f,
+        );
+
+        match ask_result {
+            Ok(_) => {
+                let resp = receiver.recv_timeout(std::time::Duration::from_secs(120));
+                println!("=== ask returned Ok, response ===");
+                match resp {
+                    Ok(s) => println!("{s}"),
+                    Err(e) => println!("recv error (worker dropped without Done?): {e}"),
+                }
+            }
+            Err(e) => {
+                println!("=== ask returned Err ===");
+                println!("{e:?}");
+            }
+        }
+
+        // Debug: dump chat history to see what the model emitted + how the
+        // engine responded — extract_tool_calls return shape, dispatched
+        // tool result, regen content, etc.
+        println!("=== chat history ===");
+        for (i, m) in worker.extra.messages.iter().enumerate() {
+            println!("[{i}] role={:?}", m);
+        }
     }
 
     #[test]

--- a/nobodywho/core/src/template.rs
+++ b/nobodywho/core/src/template.rs
@@ -90,7 +90,34 @@ impl ChatTemplate {
             ),
             ("bos_token".to_string(), Value::from(self.bos_token.clone())),
             ("eos_token".to_string(), Value::from(self.eos_token.clone())),
-            ("tools".to_string(), Value::from_serialize(&ctx.tools)),
+            // Pre-serialise each tool to its canonical OpenAI JSON shape (insertion
+            // order preserved by `Tool`'s custom Serialize impl using
+            // `serialize_map`) and pass the list as STRINGS. The HF tool-aware
+            // chat templates (LFM2/LFM2.5/Qwen3 etc.) all guard with
+            // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`
+            // — so a string passes through unchanged. This bypasses minijinja's
+            // internal Value→tojson re-serialisation, which otherwise re-sorts
+            // object keys alphabetically (default `serde_json::Map` is `BTreeMap`).
+            // LFM2.5-350M is empirically sensitive to that order: alphabetical
+            // (`{"function":..., "type":"function"}`) makes it hallucinate kwargs
+            // (`parameters=`, `type=`) in the emitted Pythonic tool call.
+            //
+            // NOTE: `ctx.tools` is `Option<Vec<Tool>>`. `Option::iter` yields 0 or 1
+            // element of type `&Vec<Tool>` — so mapping on it would serialise the
+            // ENTIRE list as a single JSON-array string, producing `[[…]]` after the
+            // template's own `[…]` wrap. Flatten via `as_ref().into_iter().flatten()`
+            // so we map per-Tool.
+            (
+                "tools".to_string(),
+                Value::from_serialize(
+                    &ctx.tools
+                        .as_ref()
+                        .into_iter()
+                        .flatten()
+                        .map(|t| serde_json::to_string(t).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
         ];
 
         // Add all template variables

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -95,6 +95,11 @@ impl ToolFormatHandler for Lfm2_5Handler {
 /// individual top-level chunks, respecting `(` / `)` nesting and string
 /// quoting so commas inside args / strings are not separators.
 fn split_top_level_calls(s: &str) -> Vec<&str> {
+    // Split on top-level commas while respecting string quotes and ALL three
+    // bracket pairs Python uses inside arg literals: `(...)`, `[...]`, `{...}`.
+    // Without `[`/`{` tracking, model emissions like
+    //     set_intersection(set1={12, 5, 7, 3, 4}, set2={12, 9, 5, 3})
+    // get split inside the set literal and lose all kwargs.
     let bytes = s.as_bytes();
     let mut depth: i32 = 0;
     let mut start: usize = 0;
@@ -106,8 +111,8 @@ fn split_top_level_calls(s: &str) -> Vec<&str> {
             (Some(_), _) => {}
             (None, b'"') => in_str = Some(b'"'),
             (None, b'\'') => in_str = Some(b'\''),
-            (None, b'(') => depth += 1,
-            (None, b')') => depth -= 1,
+            (None, b'(') | (None, b'[') | (None, b'{') => depth += 1,
+            (None, b')') | (None, b']') | (None, b'}') => depth -= 1,
             (None, b',') if depth == 0 => {
                 out.push(&s[start..i]);
                 start = i + 1;
@@ -119,6 +124,27 @@ fn split_top_level_calls(s: &str) -> Vec<&str> {
         out.push(&s[start..]);
     }
     out
+}
+
+/// True if `s` contains a top-level `:` (used to discriminate dict literal
+/// `{k: v, ...}` from set literal `{1, 2, 3}`).
+fn has_top_level_colon(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_str: Option<u8> = None;
+    for &b in bytes {
+        match (in_str, b) {
+            (Some(q), c) if c == q => in_str = None,
+            (Some(_), _) => {}
+            (None, b'"') => in_str = Some(b'"'),
+            (None, b'\'') => in_str = Some(b'\''),
+            (None, b'(') | (None, b'[') | (None, b'{') => depth += 1,
+            (None, b')') | (None, b']') | (None, b'}') => depth -= 1,
+            (None, b':') if depth == 0 => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn parse_pythonic_call(s: &str) -> Option<ToolCall> {
@@ -158,17 +184,71 @@ fn parse_pythonic_value(s: &str) -> Option<Value> {
     if s.is_empty() {
         return None;
     }
+    // String literals: "..." or '...'
     if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
         if s.len() < 2 {
             return None;
         }
         return Some(Value::String(s[1..s.len() - 1].to_string()));
     }
+    // Bool / null
     match s {
         "true" | "True" => return Some(Value::Bool(true)),
         "false" | "False" => return Some(Value::Bool(false)),
         "null" | "None" => return Some(Value::Null),
         _ => {}
+    }
+    // List or tuple literal: `[...]` / `(...)` -> JSON array.
+    if (s.starts_with('[') && s.ends_with(']')) || (s.starts_with('(') && s.ends_with(')')) {
+        let inner = s[1..s.len() - 1].trim();
+        if inner.is_empty() {
+            return Some(Value::Array(Vec::new()));
+        }
+        let items: Vec<Value> = split_top_level_calls(inner)
+            .into_iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .filter_map(parse_pythonic_value)
+            .collect();
+        return Some(Value::Array(items));
+    }
+    // Set / dict literal: `{...}`. Discriminate by top-level colon.
+    if s.starts_with('{') && s.ends_with('}') {
+        let inner = s[1..s.len() - 1].trim();
+        if inner.is_empty() {
+            return Some(Value::Array(Vec::new()));
+        }
+        let parts: Vec<&str> = split_top_level_calls(inner)
+            .into_iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .collect();
+        let is_dict = parts.iter().any(|p| has_top_level_colon(p));
+        if is_dict {
+            let mut obj = serde_json::Map::new();
+            for p in parts {
+                let Some(colon) = p.find(':') else { continue };
+                let key_raw = p[..colon].trim();
+                let val_raw = p[colon + 1..].trim();
+                let key = if (key_raw.starts_with('"') && key_raw.ends_with('"'))
+                    || (key_raw.starts_with('\'') && key_raw.ends_with('\''))
+                {
+                    if key_raw.len() < 2 {
+                        continue;
+                    }
+                    key_raw[1..key_raw.len() - 1].to_string()
+                } else {
+                    key_raw.to_string()
+                };
+                let val =
+                    parse_pythonic_value(val_raw).unwrap_or(Value::String(val_raw.to_string()));
+                obj.insert(key, val);
+            }
+            return Some(Value::Object(obj));
+        }
+        // Set literal -> JSON array (JSON has no native set; consumers map back)
+        let items: Vec<Value> = parts.into_iter().filter_map(parse_pythonic_value).collect();
+        return Some(Value::Array(items));
     }
     if let Ok(i) = s.parse::<i64>() {
         return Some(json!(i));

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -276,6 +276,21 @@ mod tests {
     }
 
     #[test]
+    fn double_wrap_emit_extracts_first_call() {
+        // LFM2.5-1.2B-Instruct empirically emits a double-wrap on multi-turn weather:
+        //   <|tool_call_start|>[get_weather(city="Cairo")]<|tool_call_end|>[get_weather(city="Cairo")]<|tool_call_end|>
+        // Parser should still extract the first valid call (between begin and FIRST end token).
+        let input = concat!(
+            "<|tool_call_start|>[get_weather(city=\"Cairo\")]<|tool_call_end|>",
+            "[get_weather(city=\"Cairo\")]<|tool_call_end|>"
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1, "should extract first call only, ignore tail");
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
     fn tail_text_after_end_token_is_ignored() {
         // Per LFM2.5 model card: assistant turn can be
         //   <|tool_call_start|>[fn(...)]<|tool_call_end|>{NL summary}

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -1,0 +1,334 @@
+use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
+use gbnf::GbnfGrammar;
+use serde_json::{json, Value};
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Lfm2_5Handler;
+
+// LFM2.5 family (LFM2.5-350M, LFM2.5-1.2B-Instruct, LFM2.5-1.2B-Tool, ...) writes
+// PYTHONIC tool calls between `<|tool_call_start|>` and `<|tool_call_end|>` tokens
+// per the LFM2.5 model card example:
+//
+//   <|tool_call_start|>[get_candidate_status(candidate_id="12345")]<|tool_call_end|>
+//
+// The list may contain multiple calls separated by `,`. Args are kwargs
+// (`key=value`) with values: string ("..." or '...'), int, float, bool, null.
+//
+// This handler runs in PARSER-ONLY mode: `generate_grammar` returns Err so the
+// engine sets `tool_grammar=None` (chat.rs:1240-1265 verified). Sampler runs
+// unconstrained; `extract_tool_calls` parses the wire format from the response.
+// The mirror of llama.cpp's pre-autoparser working configuration for LFM2.5
+// (see llama.cpp issue #20245).
+
+const BEGIN: &str = "<|tool_call_start|>";
+const END: &str = "<|tool_call_end|>";
+
+impl ToolFormatHandler for Lfm2_5Handler {
+    fn begin_token(&self) -> &str {
+        BEGIN
+    }
+
+    fn end_token(&self) -> &str {
+        END
+    }
+
+    fn generate_grammar(&self, _tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
+        // INTENTIONAL Err — engine path (chat.rs:1240-1265) keeps
+        // tool_format=Some(handler) and sets tool_grammar=None on Err.
+        // Sampler runs unconstrained; the model emits its trained Pythonic
+        // wire format; extract_tool_calls parses it on the way out.
+        Err(ToolFormatError::UnsupportedFormat(
+            "LFM2.5 handler runs in parser-only mode; no GBNF constraint".to_string(),
+        ))
+    }
+
+    fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
+        // Per LFM2.5 model card the assistant turn is:
+        //   <|tool_call_start|>[fn1(...), fn2(...)]<|tool_call_end|>{trailing NL}
+        // Locate the FIRST wrap; tail text after END is ignored. If begin_token
+        // never appears, this is plain NL — return None and the engine loop
+        // exits naturally with the model's plain-text response.
+        let begin_at = input.find(BEGIN)?;
+        let after_begin = &input[begin_at + BEGIN.len()..];
+        let end_at = after_begin.find(END)?;
+        let inner = after_begin[..end_at].trim();
+
+        // Inner is `[fn1(...), fn2(...)]` Pythonic list.
+        let bracketed = inner.strip_prefix('[').and_then(|x| x.strip_suffix(']'))?;
+        let body = bracketed.trim();
+        if body.is_empty() {
+            debug!("LFM2.5 emitted empty tool call list");
+            return None;
+        }
+
+        let raw_calls = split_top_level_calls(body);
+        if raw_calls.is_empty() {
+            debug!(input = %input, "LFM2.5 tool call list parsing failed (no calls)");
+            return None;
+        }
+
+        let mut out = Vec::with_capacity(raw_calls.len());
+        for raw in raw_calls {
+            match parse_pythonic_call(raw.trim()) {
+                Some(tc) => out.push(tc),
+                None => {
+                    debug!(call = %raw, "LFM2.5 single-call parse failed");
+                    return None;
+                }
+            }
+        }
+
+        if out.len() > 1 {
+            warn!(
+                count = out.len(),
+                "LFM2.5 emitted >1 tool call in one assistant turn"
+            );
+        }
+        Some(out)
+    }
+}
+
+// ----- Pythonic call parsing helpers (private) -----
+
+/// Split `fn1(...), fn2(...), ...` (or `k=v, k=v` arg lists) into
+/// individual top-level chunks, respecting `(` / `)` nesting and string
+/// quoting so commas inside args / strings are not separators.
+fn split_top_level_calls(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut start: usize = 0;
+    let mut in_str: Option<u8> = None;
+    let mut out: Vec<&str> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        match (in_str, b) {
+            (Some(q), c) if c == q => in_str = None,
+            (Some(_), _) => {}
+            (None, b'"') => in_str = Some(b'"'),
+            (None, b'\'') => in_str = Some(b'\''),
+            (None, b'(') => depth += 1,
+            (None, b')') => depth -= 1,
+            (None, b',') if depth == 0 => {
+                out.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        out.push(&s[start..]);
+    }
+    out
+}
+
+fn parse_pythonic_call(s: &str) -> Option<ToolCall> {
+    let open = s.find('(')?;
+    let name = s[..open].trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let close = s.rfind(')')?;
+    if close <= open {
+        return None;
+    }
+    let args_src = s[open + 1..close].trim();
+
+    let mut args_obj = serde_json::Map::new();
+    if !args_src.is_empty() {
+        for kv in split_top_level_calls(args_src) {
+            let kv = kv.trim();
+            if kv.is_empty() {
+                continue;
+            }
+            let eq = kv.find('=')?;
+            let key = kv[..eq].trim().to_string();
+            let raw_val = kv[eq + 1..].trim();
+            let v = parse_pythonic_value(raw_val)?;
+            args_obj.insert(key, v);
+        }
+    }
+    Some(ToolCall {
+        name,
+        arguments: Value::Object(args_obj),
+    })
+}
+
+fn parse_pythonic_value(s: &str) -> Option<Value> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        if s.len() < 2 {
+            return None;
+        }
+        return Some(Value::String(s[1..s.len() - 1].to_string()));
+    }
+    match s {
+        "true" | "True" => return Some(Value::Bool(true)),
+        "false" | "False" => return Some(Value::Bool(false)),
+        "null" | "None" => return Some(Value::Null),
+        _ => {}
+    }
+    if let Ok(i) = s.parse::<i64>() {
+        return Some(json!(i));
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return Some(json!(f));
+    }
+    Some(Value::String(s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn handler() -> Lfm2_5Handler {
+        Lfm2_5Handler
+    }
+
+    fn dummy_tool(name: &str, prop: &str) -> Tool {
+        Tool::new(
+            name,
+            "test tool",
+            json!({
+                "type": "object",
+                "properties": { prop: { "type": "number" } },
+                "required": [prop]
+            }),
+            Arc::new(|_| "ok".to_string()),
+        )
+    }
+
+    #[test]
+    fn parse_single_kwarg_string() {
+        let input = r#"<|tool_call_start|>[get_weather(city="Cairo")]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn parse_single_kwarg_number() {
+        let input = r#"<|tool_call_start|>[circle_area(radius=12.5)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": 12.5}));
+    }
+
+    #[test]
+    fn parse_multi_call() {
+        let input =
+            r#"<|tool_call_start|>[get_weather(city="London"), get_weather(city="Tokyo")]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].arguments, json!({"city": "London"}));
+        assert_eq!(calls[1].arguments, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn parse_with_single_quotes() {
+        let input = r#"<|tool_call_start|>[get_weather(city='Cairo')]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn parse_negative_int() {
+        let input = r#"<|tool_call_start|>[move(steps=-3)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"steps": -3}));
+    }
+
+    #[test]
+    fn parse_bool_kwarg() {
+        let input = r#"<|tool_call_start|>[set_flag(active=true, dry=False)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"active": true, "dry": false}));
+    }
+
+    #[test]
+    fn no_args() {
+        let input = r#"<|tool_call_start|>[noop()]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "noop");
+        assert_eq!(calls[0].arguments, json!({}));
+    }
+
+    #[test]
+    fn empty_list_returns_none() {
+        let input = "<|tool_call_start|>[]<|tool_call_end|>";
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn malformed_returns_none() {
+        let input = "<|tool_call_start|>not python at all<|tool_call_end|>";
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn no_wrap_returns_none() {
+        let input = r#"I'll help you with that."#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn tail_text_after_end_token_is_ignored() {
+        // Per LFM2.5 model card: assistant turn can be
+        //   <|tool_call_start|>[fn(...)]<|tool_call_end|>{NL summary}
+        let input = concat!(
+            "<|tool_call_start|>[circle_area(radius=5)]<|tool_call_end|>",
+            "Checking the area now."
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": 5}));
+    }
+
+    #[test]
+    fn nl_preamble_before_begin_token_is_ignored() {
+        let input = concat!(
+            "I'll fetch that for you.\n",
+            "<|tool_call_start|>[get_weather(city=\"Cairo\")]<|tool_call_end|>"
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn tokens_match_chat_template() {
+        let h = handler();
+        assert_eq!(h.begin_token(), "<|tool_call_start|>");
+        assert_eq!(h.end_token(), "<|tool_call_end|>");
+    }
+
+    #[test]
+    fn generate_grammar_returns_err_intentionally() {
+        // Plan: parser-only mode. Engine reads Err and sets tool_grammar=None
+        // while keeping tool_format=Some(handler).
+        let r = handler().generate_grammar(&[dummy_tool("circle_area", "radius")]);
+        assert!(r.is_err(), "generate_grammar must return Err for parser-only handler");
+    }
+
+    #[test]
+    fn generate_grammar_returns_err_for_empty_tools() {
+        let r = handler().generate_grammar(&[]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn split_top_level_respects_parens() {
+        let parts = split_top_level_calls("a(1,2), b(3, c(4,5)), d");
+        assert_eq!(parts, vec!["a(1,2)", " b(3, c(4,5))", " d"]);
+    }
+
+    #[test]
+    fn split_top_level_respects_quotes() {
+        let parts = split_top_level_calls(r#"city="Cai,ro", n=1"#);
+        assert_eq!(parts, vec![r#"city="Cai,ro""#, " n=1"]);
+    }
+}

--- a/nobodywho/core/src/tool_calling/llama32.rs
+++ b/nobodywho/core/src/tool_calling/llama32.rs
@@ -1,0 +1,246 @@
+use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
+use gbnf::builder::{nt, seq, t, GrammarBuilder};
+use gbnf::json::json_schema_to_grammar;
+use gbnf::GbnfGrammar;
+use serde_json::json;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Llama32Handler;
+
+const BEGIN: &str = "<|python_tag|>";
+const END: &str = "<|eot_id|>";
+
+#[derive(serde::Deserialize)]
+struct LlamaToolCall {
+    #[serde(alias = "function")]
+    name: String,
+    parameters: serde_json::Value,
+}
+
+impl ToolFormatHandler for Llama32Handler {
+    fn begin_token(&self) -> &str {
+        BEGIN
+    }
+
+    fn end_token(&self) -> &str {
+        END
+    }
+
+    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
+        let tool_call_schemas: serde_json::Value = tools
+            .iter()
+            .map(|tool| {
+                json!(
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": { "const": tool.name },
+                            "parameters": tool.json_schema
+                        },
+                        "required": ["name", "parameters"]
+                    }
+                )
+            })
+            .collect();
+
+        let tool_call_schema = json!({ "oneOf": tool_call_schemas });
+        let json_grammar = json_schema_to_grammar(tool_call_schema, "root")?;
+
+        let grammar = GrammarBuilder::from_existing(json_grammar)
+            .rule(
+                "toolcall",
+                seq(&[t(BEGIN), nt("ws"), nt("root"), nt("ws")]),
+            )
+            .rule("superroot", nt("toolcall"))
+            .root("superroot")
+            .build();
+
+        Ok(grammar)
+    }
+
+    fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
+        let mut s = input.trim();
+        if let Some(rest) = s.strip_prefix(BEGIN) {
+            s = rest.trim_start();
+        }
+        if let Some(prefix) = s.strip_suffix(END) {
+            s = prefix.trim_end();
+        }
+
+        let mut stream = serde_json::Deserializer::from_str(s).into_iter::<LlamaToolCall>();
+        let first = stream.next()?;
+
+        match first {
+            Ok(call) => {
+                if stream.next().is_some() {
+                    warn!(
+                        "Llama-3.x emitted >1 tool call in one assistant turn; \
+                         only the first is dispatched (chat template constraint)"
+                    );
+                }
+                debug!(tool_name = %call.name, "Successfully parsed Llama tool call");
+                Some(vec![ToolCall {
+                    name: call.name,
+                    arguments: call.parameters,
+                }])
+            }
+            Err(e) => {
+                debug!(error = %e, json = s, "Failed to parse Llama tool call JSON");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn handler() -> Llama32Handler {
+        Llama32Handler
+    }
+
+    #[test]
+    fn p1_round4_with_python_tag_name_field() {
+        let input = r#"<|python_tag|>{"name": "circle_area", "parameters": {"radius": "5"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": "5"}));
+    }
+
+    #[test]
+    fn p2_round4_no_prefix_name_field() {
+        let input = r#"{"name": "circle_area", "parameters": {"radius": "12"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": "12"}));
+    }
+
+    #[test]
+    fn p3_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "Cairo"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn p4_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "London"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "London"}));
+    }
+
+    #[test]
+    fn p5_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "Tokyo"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn trailing_eot_is_stripped() {
+        let input = r#"<|python_tag|>{"name":"a","parameters":{}}<|eot_id|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "a");
+    }
+
+    #[test]
+    fn whitespace_between_prefix_and_json_tolerated() {
+        let input = "<|python_tag|>  \n  {\"name\": \"circle_area\", \"parameters\": {\"radius\": \"5\"}}";
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+    }
+
+    #[test]
+    fn plain_assistant_text_with_inline_json_returns_none() {
+        let input = r#"Sure, here is some JSON: {"x": 1}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn json_without_name_or_function_returns_none() {
+        let input = r#"{"x": 1, "parameters": {}}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn json_without_parameters_returns_none() {
+        let input = r#"{"name": "x"}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn truncated_mid_json_returns_none() {
+        let input = r#"{"name": "x", "parameters": {"a""#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn two_blocks_returns_only_first() {
+        let input = r#"{"name":"a","parameters":{}}{"name":"b","parameters":{}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1, "single-call constraint enforced");
+        assert_eq!(calls[0].name, "a");
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(handler().extract_tool_calls("").is_none());
+    }
+
+    #[test]
+    fn tokens_match_chat_template() {
+        let h = handler();
+        assert_eq!(h.begin_token(), "<|python_tag|>");
+        assert_eq!(h.end_token(), "<|eot_id|>");
+    }
+
+    #[test]
+    fn grammar_contains_ws_rule() {
+        let tool = Tool::new(
+            "circle_area",
+            "Compute area of circle",
+            json!({
+                "type": "object",
+                "properties": { "radius": { "type": "number" } },
+                "required": ["radius"]
+            }),
+            std::sync::Arc::new(|_| "78.54".to_string()),
+        );
+        let grammar = handler().generate_grammar(&[tool]).unwrap();
+        let s = grammar.as_str();
+        assert!(s.contains("ws ::="), "expected ws rule in:\n{}", s);
+    }
+
+    #[test]
+    fn grammar_constrains_to_known_tools() {
+        let tool = Tool::new(
+            "circle_area",
+            "Compute area of circle",
+            json!({
+                "type": "object",
+                "properties": { "radius": { "type": "number" } },
+                "required": ["radius"]
+            }),
+            std::sync::Arc::new(|_| "78.54".to_string()),
+        );
+        let grammar = handler().generate_grammar(&[tool]).unwrap();
+        let s = grammar.as_str();
+        assert!(
+            s.contains("circle_area"),
+            "expected tool name as const literal in grammar:\n{}",
+            s
+        );
+        assert!(
+            s.contains("<|python_tag|>"),
+            "expected begin token literal in grammar:\n{}",
+            s
+        );
+    }
+}

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -190,20 +190,51 @@ impl Tool {
 }
 
 // Serialize tools according to https://huggingface.co/blog/unified-tool-use
+//
+// IMPORTANT: emit keys in EXPLICIT INSERTION ORDER (`type` before `function`,
+// inner `name` -> `description` -> `parameters`). The default `serde_json::json!`
+// path materialises a `Value::Object` backed by `BTreeMap`, which re-sorts keys
+// alphabetically. LFM2.5-350M is sensitive to that order — when fed
+// `{"function":{...},"type":"function"}` (alphabetical), it hallucinates extra
+// Pythonic kwargs (`parameters=`, `type=`) in the tool call. Using `serialize_map`
+// directly with nested helpers preserves the canonical OpenAI key order and
+// avoids forcing the `serde_json/preserve_order` cargo feature globally.
 impl Serialize for Tool {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": &self.name,
-                "description": &self.description,
-                "parameters": &self.json_schema,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            description: &'a str,
+            parameters: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(3))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("description", self.description)?;
+                m.serialize_entry("parameters", self.parameters)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            description: &self.description,
+            parameters: &self.json_schema,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -215,6 +246,7 @@ pub struct ToolCall {
 }
 
 // Serialize tools according to https://huggingface.co/blog/unified-tool-use
+// (insertion-order preserved — see Serialize for Tool above for rationale).
 impl Serialize for ToolCall {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -8,9 +8,11 @@
 //! - Gemma4: `<|tool_call>call:name{key:<|"|>val<|"|>}<tool_call|>`
 //! - Ministral3: `[TOOL_CALLS][{"name": "...", "arguments": {...}}]`
 //! - Llama-3.x: `<|python_tag|>{"name"|"function": "...", "parameters": {...}}<|eot_id|>` (prefix optional in extraction; model often omits it)
+//! - LFM2.5: `<|tool_call_start|>[fn1(arg=val), fn2(arg=val)]<|tool_call_end|>` Pythonic call list — handler runs in parser-only mode (no GBNF), mirroring llama.cpp's pre-autoparser working configuration
 
 mod functiongemma;
 mod gemma4;
+mod lfm2_5;
 mod llama32;
 mod ministral3;
 mod qwen3;
@@ -25,6 +27,7 @@ use tracing::debug;
 
 pub use functiongemma::FunctionGemmaHandler;
 pub use gemma4::Gemma4Handler;
+pub use lfm2_5::Lfm2_5Handler;
 pub use llama32::Llama32Handler;
 pub use ministral3::Ministral3Handler;
 pub use qwen3::Qwen3Handler;
@@ -275,6 +278,7 @@ pub enum ToolFormat {
     Gemma4(Gemma4Handler),
     Ministral3(Ministral3Handler),
     Llama32(Llama32Handler),
+    Lfm2_5(Lfm2_5Handler),
 }
 
 impl ToolFormat {
@@ -286,6 +290,7 @@ impl ToolFormat {
             ToolFormat::Gemma4(h) => h,
             ToolFormat::Ministral3(h) => h,
             ToolFormat::Llama32(h) => h,
+            ToolFormat::Lfm2_5(h) => h,
         }
     }
 
@@ -434,6 +439,18 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
             debug!("Detected Llama-3.x format from model name");
             return Ok(ToolFormat::Llama32(Llama32Handler));
         }
+
+        // LFM2.5 by name. `general.name` for LFM2.5-350M is "LFM2.5-350M"
+        // (verified via GGUF strings dump). `general.basename` is "LFM2.5"
+        // by Liquid AI's convention. Architecture metadata is "lfm2" — shared
+        // with LFM2 v1, so name match (not arch match) distinguishes the family.
+        // Other LFM2.5 GGUFs (LFM2.5-1.2B-Instruct, LFM2.5-1.2B-Tool, etc.)
+        // are expected to share this naming convention but should have their
+        // metadata verified before relying on the same handler.
+        if name_lower.contains("lfm2.5") {
+            debug!("Detected LFM2.5 format from model name");
+            return Ok(ToolFormat::Lfm2_5(Lfm2_5Handler));
+        }
     }
 
     Err(ToolFormatError::UnsupportedFormat(
@@ -542,6 +559,7 @@ mod tests {
             ToolFormat::Gemma4(_) => "Gemma4",
             ToolFormat::Ministral3(_) => "Ministral3",
             ToolFormat::Llama32(_) => "Llama32",
+            ToolFormat::Lfm2_5(_) => "Lfm2_5",
         };
         eprintln!("detected handler     = {variant}");
     }
@@ -584,6 +602,7 @@ mod tests {
             ToolFormat::Gemma4(_) => "Gemma4",
             ToolFormat::Ministral3(_) => "Ministral3",
             ToolFormat::Llama32(_) => "Llama32",
+            ToolFormat::Lfm2_5(_) => "Lfm2_5",
         };
         eprintln!("detected handler     = {variant}");
         assert_eq!(

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -7,9 +7,11 @@
 //! - FunctionGemma: `<start_function_call>call:name{param:<escape>val<escape>}<end_function_call>`
 //! - Gemma4: `<|tool_call>call:name{key:<|"|>val<|"|>}<tool_call|>`
 //! - Ministral3: `[TOOL_CALLS][{"name": "...", "arguments": {...}}]`
+//! - Llama-3.x: `<|python_tag|>{"name"|"function": "...", "parameters": {...}}<|eot_id|>` (prefix optional in extraction; model often omits it)
 
 mod functiongemma;
 mod gemma4;
+mod llama32;
 mod ministral3;
 mod qwen3;
 mod qwen35_36;
@@ -23,6 +25,7 @@ use tracing::debug;
 
 pub use functiongemma::FunctionGemmaHandler;
 pub use gemma4::Gemma4Handler;
+pub use llama32::Llama32Handler;
 pub use ministral3::Ministral3Handler;
 pub use qwen3::Qwen3Handler;
 pub use qwen35_36::Qwen35_36Handler;
@@ -271,6 +274,7 @@ pub enum ToolFormat {
     FunctionGemma(FunctionGemmaHandler),
     Gemma4(Gemma4Handler),
     Ministral3(Ministral3Handler),
+    Llama32(Llama32Handler),
 }
 
 impl ToolFormat {
@@ -281,6 +285,7 @@ impl ToolFormat {
             ToolFormat::FunctionGemma(h) => h,
             ToolFormat::Gemma4(h) => h,
             ToolFormat::Ministral3(h) => h,
+            ToolFormat::Llama32(h) => h,
         }
     }
 
@@ -367,6 +372,13 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         return Ok(ToolFormat::Ministral3(Ministral3Handler));
     }
 
+    // Check for Llama-3.x markers. Both signals are unique to Llama-3.1+
+    // tool-use templates; Llama-2 templates have neither.
+    if template_str.contains("Environment: ipython") || template_str.contains("<|python_tag|>") {
+        debug!("Detected Llama-3.x format from template markers");
+        return Ok(ToolFormat::Llama32(Llama32Handler));
+    }
+
     // Fall back to model metadata.
     if let Ok(arch) = model.meta_val_str("general.architecture") {
         debug!(architecture = %arch, "Checking model architecture for format hints");
@@ -378,6 +390,14 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         if arch_lower.starts_with("qwen3") {
             debug!("Detected Qwen3 format from architecture");
             return Ok(ToolFormat::Qwen3(Qwen3Handler));
+        }
+        // Llama-3.x architecture (after Qwen so Qwen-llama derivatives still
+        // match Qwen first). Llama-2 GGUFs have no tool-use template; the
+        // template marker check above already would have rejected them, so
+        // hitting this branch with arch="llama" implies a 3.x family.
+        if arch_lower.starts_with("llama") {
+            debug!("Detected Llama-3.x format from architecture");
+            return Ok(ToolFormat::Llama32(Llama32Handler));
         }
     }
 
@@ -404,6 +424,16 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
             debug!("Detected Qwen3 format from model name");
             return Ok(ToolFormat::Qwen3(Qwen3Handler));
         }
+
+        // Llama-3.x by name. Require the "3" suffix to avoid grabbing
+        // Llama-2 GGUFs which don't speak tool-use.
+        if name_lower.contains("llama-3")
+            || name_lower.contains("llama 3")
+            || name_lower.contains("llama3")
+        {
+            debug!("Detected Llama-3.x format from model name");
+            return Ok(ToolFormat::Llama32(Llama32Handler));
+        }
     }
 
     Err(ToolFormatError::UnsupportedFormat(
@@ -422,6 +452,13 @@ mod tests {
         let format = ToolFormat::Qwen3(Qwen3Handler);
         assert_eq!(format.begin_token(), "<tool_call>");
         assert_eq!(format.end_token(), "</tool_call>");
+    }
+
+    #[test]
+    fn test_llama32_format() {
+        let format = ToolFormat::Llama32(Llama32Handler);
+        assert_eq!(format.begin_token(), "<|python_tag|>");
+        assert_eq!(format.end_token(), "<|eot_id|>");
     }
 
     #[test]
@@ -504,8 +541,55 @@ mod tests {
             ToolFormat::FunctionGemma(_) => "FunctionGemma",
             ToolFormat::Gemma4(_) => "Gemma4",
             ToolFormat::Ministral3(_) => "Ministral3",
+            ToolFormat::Llama32(_) => "Llama32",
         };
         eprintln!("detected handler     = {variant}");
+    }
+
+    #[test]
+    #[ignore = "requires LLAMA32_MODEL env var pointing at a Llama-3.x GGUF"]
+    fn diagnose_llama32_detection() {
+        let path = std::env::var("LLAMA32_MODEL").expect("set LLAMA32_MODEL");
+        let model = crate::llm::get_model(&path, false, None, None).expect("load model");
+
+        let name = model
+            .language_model
+            .meta_val_str("general.name")
+            .unwrap_or_else(|_| "<no general.name>".into());
+        let arch = model
+            .language_model
+            .meta_val_str("general.architecture")
+            .unwrap_or_else(|_| "<no arch>".into());
+        eprintln!("general.name         = {name}");
+        eprintln!("general.architecture = {arch}");
+
+        let default_tmpl: String = model
+            .language_model
+            .chat_template(None)
+            .ok()
+            .and_then(|t| t.to_string().ok())
+            .unwrap_or_default();
+        for marker in ["Environment: ipython", "<|python_tag|>", "<|eot_id|>"] {
+            eprintln!(
+                "default_tmpl contains {marker:>22}: {}",
+                default_tmpl.contains(marker)
+            );
+        }
+
+        let fmt = detect_tool_format(&model.language_model).expect("detect_tool_format failed");
+        let variant = match fmt {
+            ToolFormat::Qwen3(_) => "Qwen3",
+            ToolFormat::Qwen35_36(_) => "Qwen35_36",
+            ToolFormat::FunctionGemma(_) => "FunctionGemma",
+            ToolFormat::Gemma4(_) => "Gemma4",
+            ToolFormat::Ministral3(_) => "Ministral3",
+            ToolFormat::Llama32(_) => "Llama32",
+        };
+        eprintln!("detected handler     = {variant}");
+        assert_eq!(
+            variant, "Llama32",
+            "expected Llama32 handler for {path}, got {variant}"
+        );
     }
 
     #[test]

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -416,6 +416,18 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         return Ok(ToolFormat::Llama32(Llama32Handler));
     }
 
+    // LFM2.5 family — uniquely identifiable by the `keep_past_thinking` jinja
+    // variable in the chat template. LFM2 v1 templates use `<|tool_list_start|>`
+    // wrappers and lack `keep_past_thinking`. We must NOT rely on `general.name`
+    // for the 1.2B variants because their GGUFs ship with `general.name` set
+    // to a git-commit SHA (e.g. "4cd563d5...", "E7Ae5Ebc..."), bypassing the
+    // name-substring fallback below. Template-marker detection covers all
+    // LFM2.5 GGUFs regardless of the metadata-naming bug.
+    if template_str.contains("keep_past_thinking") {
+        debug!("Detected LFM2.5 format from chat template marker (keep_past_thinking)");
+        return Ok(ToolFormat::Lfm2_5(Lfm2_5Handler));
+    }
+
     // Fall back to model metadata.
     if let Ok(arch) = model.meta_val_str("general.architecture") {
         debug!(architecture = %arch, "Checking model architecture for format hints");

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -613,13 +613,18 @@ fn dart_function_type_to_json_schema(
         properties.insert(parameter_name.into(), parameter_type);
     }
 
+    // NOTE: do NOT add `additionalProperties: false` here. LFM2.5-350M (and likely
+    // other small models trained on plain JSON Schema, not OpenAI strict-mode) treats
+    // that field as a literal kwarg name and echoes it back in Pythonic tool calls,
+    // breaking the parser. JSON Schema's default (additional allowed) is fine — no
+    // enforcement happens client-side anyway, and Qwen3/Llama-3.2 tolerated either
+    // form on r5.
     tracing::debug!(
         "\n\n{}\n\n",
         serde_json::json!({
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": false
         })
     );
 
@@ -627,7 +632,6 @@ fn dart_function_type_to_json_schema(
         "type": "object",
         "properties": properties,
         "required": required,
-        "additionalProperties": false
     }))
 }
 
@@ -1055,7 +1059,6 @@ mod tests {
                 }
             },
             "required": ["name", "age", "tags"],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1069,7 +1072,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1084,7 +1086,6 @@ mod tests {
             "type": "object",
             "properties": { "text": { "type": "string" } },
             "required": [ "text" ],
-            "additionalProperties": false,
         });
         assert_eq!(json_schema, expected);
     }
@@ -1099,7 +1100,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }
@@ -1114,7 +1114,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }


### PR DESCRIPTION
## Description

Adds two new model-family tool-calling handlers and three cross-cutting fixes that benefit every existing handler.

**Closes #214** ("[FEATURE] Tool calling GBNF grammar for Llama tool call format"). Supersedes the closed-without-review #326 with a shape-correct handler matching the merged Gemma4 (#464) and Qwen3.5/3.6 (#481) precedent (separate `core/src/tool_calling/<family>.rs` module + GBNF grammar generation + unit tests).

## Type of change

- [x] New feature (Llama-3.x handler + LFM2.5 family handler — non-breaking, additive enum variants)
- [x] Bug fix (3 cross-cutting fixes that affect ALL existing handlers — net-positive correctness)

## What's in the PR (9 atomic commits)

### New family handlers
- `feat(tool_calling): add Llama-3.x format handler` — `core/src/tool_calling/llama32.rs` + 16 unit tests. Format: `<|python_tag|>{"name"|"function": "...", "parameters": {...}}<|eot_id|>` (prefix optional in extraction; model often omits it).
- `feat(tool_calling): wire Llama32 handler into detect_tool_format` — template-marker (`Environment: ipython` / `<|python_tag|>`) + arch + name fallback chain in `mod.rs`.
- `feat(tool_calling): LFM2.5 family handler in parser-only mode` — `core/src/tool_calling/lfm2_5.rs` + 17 unit tests. Format: `<|tool_call_start|>[fn1(arg=val), fn2(arg=val)]<|tool_call_end|>` Pythonic call list. Handler returns `Err` from `generate_grammar` so the engine path keeps `tool_format=Some(handler)` but `tool_grammar=None`; sampler runs unconstrained, parser still extracts on output. Mirrors llama.cpp's pre-autoparser working configuration documented in [llama.cpp #20245](https://github.com/ggml-org/llama.cpp/issues/20245).
- `feat(tool_calling): detect LFM2.5 family by chat-template marker` — adds `template_str.contains(\"keep_past_thinking\")` template-marker check before the metadata fallback. Necessary because LFM2.5-1.2B-Instruct and LFM2.5-1.2B-Thinking GGUFs ship with `general.name` set to a git-commit SHA (e.g. `4cd563d5...`), bypassing the name-substring fallback.
- `feat(tool_calling/lfm2_5): handle Pythonic list/set/dict/tuple literals` — extends parser to recognise `[...]`/`(...)`/`{...}` value shapes that small models emit when the user prompt mirrors Python literal syntax. Adds `has_top_level_colon` helper to discriminate set vs dict literals using a bracket/quote-aware scanner.

### Cross-cutting fixes (apply to ALL handlers)
- `fix(tool_calling): preserve OpenAI key order in Tool serialization` — rewrites `Serialize for Tool` using nested `serialize_map` with explicit `serialize_entry` calls (outer `type` then `function`; inner `name` → `description` → `parameters`). The previous `serde_json::json!({...}).serialize()` path materialised a `Value::Object` backed by `BTreeMap`, which re-sorted keys alphabetically. LFM2.5-350M is empirically sensitive to that order: alphabetical (`{\"function\":..., \"type\":\"function\"}`) makes it hallucinate extra Pythonic kwargs (`parameters=`, `type=`), breaking the parser. Avoids forcing the `serde_json/preserve_order` cargo feature globally.
- `feat(template): pass tools to chat template as pre-serialized JSON strings` — pre-serialise each `Tool` to a JSON STRING via `serde_json::to_string(t)` and pass `Vec<String>` as the `tools` template var. The HF tool-aware chat templates (LFM2/2.5/Qwen3 etc.) all guard with `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}` so a pre-serialised string passes through unchanged. This bypasses minijinja's internal `Value::from_serialize` round-trip through `BTreeMap`.
- `fix(flutter): drop additionalProperties:false from generated tool schemas` — `dart_function_type_to_json_schema` no longer injects `additionalProperties: false` into the JSON schema returned for each Dart tool function. Five `mod tests` expected-schema fixtures updated to drop the same field. Required because small models echo `additionalProperties` as a literal Pythonic kwarg in the emitted tool call (e.g. `[circle_area(additionalProperties={\"radius\": 5}, ...)]`), breaking the parser. The field is OpenAI-strict-mode shorthand that is NOT required by the llama.cpp parser path.

### Engine reliability fix
- `fix(chat): emit terminal Done after tool-call loop epilogue` — adds an unconditional `respond(WriteOutput::Done(response))` at the end of `Worker::ask()`'s chat-loop. Required because `wrap_respond` flips `emitting=false` once the tool-call begin token is observed, suppressing all subsequent forwards including the terminal `Done`. When `extract_tool_calls` returns `None` on a parser-only path (model emitted markers but the parser couldn't recognise the inner Pythonic), the chat-loop exited without ever signalling completion to the consumer; `TokenStream::completed` saw a closed channel with `completed_response = None` and surfaced that as `WorkerCrashed`. `TokenStream::next_token` short-circuits on `completed_response.is_some()`, so multi-iteration flows where iter-N already delivered a Done (Qwen3 etc.) simply ignore this terminal one — no double-process, no regression.

## How Has This Been Tested?

### Host
- `cargo test --release --lib tool_calling`: **66 passed / 0 failed / 2 ignored** (was 53 before this PR; +13 new tests).
- `cargo test --release --lib --workspace`: same 19 fixture-only failures as upstream main (`ModelNotFound` integration tests on `model.gguf` / `embeddings.gguf` / `crossencoder.gguf`); no regressions.
- Existing handler test counts preserved (Qwen3, Gemma4, FunctionGemma, Ministral3, Qwen3.5/3.6 all green).

### Device (Samsung Galaxy S22)
Round r21 bake-off via `bake_off_lfm2_5_family.sh` (5 prompts × 3 sizes), with internet connectivity and screen-on:

| model | p1 (circle r=5) | p2 (circle r=12.5) | p3 (Cairo) | p4 (London) | p5 (Tokyo) | reach | crashes |
|---|---|---|---|---|---|---|---|
| LFM2.5-350M | NUMERIC_OK | NUMERIC_PRESENT | TOOL_OK | TOOL_OK | TOOL_OK | 5/5 | 0 |
| LFM2.5-1.2B-Instruct | NUMERIC_OK | NUMERIC_OK | TOOL_OK | TOOL_OK | TOOL_OK | 5/5 | 0 |
| LFM2.5-1.2B-Thinking | NUMERIC_OK | NUMERIC_OK | DNF (thinking-mode latency >maestro budget) | DNF | DNF | 2/5 reach | 0 |

p2 NUMERIC_PRESENT on 350M is small-model arithmetic on 12.5²×π — pure model limit, not a handler bug.

### Cross-validation
Reference rendered prompt captured from `llama-server --jinja` for LFM2.5-350M; engine's rendered prompt now matches byte-for-byte after the cross-cutting fixes (key order + tools-as-strings).

## Known gaps NOT addressed in this PR

1. **`python_ci.yml` matrix entry deferred for LFM2.5**. Local-Mac validation reveals an upstream `ggml-metal` cleanup assertion (related to issue [ggml-org/llama.cpp#22593](https://github.com/ggml-org/llama.cpp/issues/22593) and PR [#22595](https://github.com/ggml-org/llama.cpp/pull/22595), but the marek-hradil fork has a different organisation around `ggml_metal_buffer_free` that needs a separate fix likely in the Rust Drop chain). On non-Metal Linux CI this should not surface; maintainer welcome to add the matrix entry after CI dry-run. Llama-3.x matrix entry (`Llama32` format) not added pending maintainer preference on which Llama-3.2-1B GGUF to download.
2. **`Cargo.nix` regen pending**. New `tracing-android` deps live on a sibling branch that closes [#440](https://github.com/nobodywho-ooo/nobodywho/issues/440); separate PR forthcoming. This branch keeps `Cargo.lock` and `Cargo.nix` in sync with origin/main.
3. **LFM2.5 model capability on heavy multi-tool fixtures with set/tuple/dict types**. Distil labs benchmark reports 34-63% baseline on 350M for those workloads — pure model capability, no engine fix possible. Not blocked by this PR; tools fire correctly when model decides to use them.

## Checklist:

- [x] My code follows the style guidelines of this project (matched #464 / #481 file shape: new handler module + mod.rs wiring + tests)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (38 new unit tests across llama32.rs and lfm2_5.rs + 5 cross-cutting test fixture updates)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Notes for reviewers

- 9 commits with cleanup history preserved (same cadence as #481's 16 commits and #464's 14 commits).
- Cross-cutting fixes (key order, additionalProperties drop, tools-as-strings) are net-positive for all existing handlers — they were prerequisites for LFM2.5 to parse cleanly but the underlying bugs (BTreeMap key re-sort + minijinja round-trip) affected every family's prompt rendering. Verified Qwen3 + Llama-3.x + Gemma4 + FunctionGemma + Ministral3 still pass their unit tests.