### PR TITLE
fix: engine fixes for tool-calling key order + template rendering

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2430,9 +2430,14 @@ mod tests {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
-        // Use a very small context size to force shifting
+        // Use a very small context size to force shifting. Bumped n_messages
+        // from 10 -> 20 because passing tools to the chat template as
+        // pre-serialized JSON strings (see commit a26dfc79) reduced the
+        // per-render token count enough that 10 exchanges no longer overflow
+        // n_ctx=1024 with the test_chat-model GGUF — context_shift then
+        // skipped, leaving messages_after.len() == messages_before.
         let n_ctx = 1024;
-        let n_messages = 10;
+        let n_messages = 20;
         let mut worker = Worker::new_chat_worker(
             &model,
             ChatConfig {

--- a/nobodywho/core/src/template.rs
+++ b/nobodywho/core/src/template.rs
@@ -90,7 +90,34 @@ impl ChatTemplate {
             ),
             ("bos_token".to_string(), Value::from(self.bos_token.clone())),
             ("eos_token".to_string(), Value::from(self.eos_token.clone())),
-            ("tools".to_string(), Value::from_serialize(&ctx.tools)),
+            // Pre-serialise each tool to its canonical OpenAI JSON shape (insertion
+            // order preserved by `Tool`'s custom Serialize impl using
+            // `serialize_map`) and pass the list as STRINGS. The HF tool-aware
+            // chat templates (LFM2/LFM2.5/Qwen3 etc.) all guard with
+            // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`
+            // — so a string passes through unchanged. This bypasses minijinja's
+            // internal Value→tojson re-serialisation, which otherwise re-sorts
+            // object keys alphabetically (default `serde_json::Map` is `BTreeMap`).
+            // LFM2.5-350M is empirically sensitive to that order: alphabetical
+            // (`{"function":..., "type":"function"}`) makes it hallucinate kwargs
+            // (`parameters=`, `type=`) in the emitted Pythonic tool call.
+            //
+            // NOTE: `ctx.tools` is `Option<Vec<Tool>>`. `Option::iter` yields 0 or 1
+            // element of type `&Vec<Tool>` — so mapping on it would serialise the
+            // ENTIRE list as a single JSON-array string, producing `[[…]]` after the
+            // template's own `[…]` wrap. Flatten via `as_ref().into_iter().flatten()`
+            // so we map per-Tool.
+            (
+                "tools".to_string(),
+                Value::from_serialize(
+                    ctx.tools
+                        .as_ref()
+                        .into_iter()
+                        .flatten()
+                        .map(|t| serde_json::to_string(t).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
         ];
 
         // Add all template variables
@@ -462,5 +489,85 @@ mod tests {
         // The template now includes empty thinking blocks for assistant messages
         let expected5 = "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\nHi there!<|im_end|>\n";
         assert_eq!(rendered5, expected5);
+    }
+
+    /// Regression guard for the `tools` template variable wiring (see PR
+    /// notes on tools-as-strings + canonical key order). Renders a minimal
+    /// tool-aware Qwen3-style template with one Tool, then asserts the
+    /// rendered string places the OpenAI canonical keys in canonical order:
+    /// outer `"type":"function"` BEFORE outer `"function":` value, inner
+    /// `"name":` BEFORE `"description":` BEFORE `"parameters":`.
+    ///
+    /// Without the engine fixes (Tool::serialize using BTreeMap-backed
+    /// serde_json::Map, or template variable as Vec<Tool> instead of
+    /// Vec<String>) the rendered string would order keys alphabetically:
+    /// `"function":...,"type":"function"`. Both regressions would fail
+    /// this test.
+    #[test]
+    fn test_render_template_with_tools_preserves_key_order() {
+        use std::sync::Arc;
+
+        // Minimal tool-aware template: dump the tools array verbatim.
+        // The HF tool-aware templates all guard with
+        // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`,
+        // so a pre-serialized JSON STRING passes through unchanged. A
+        // Tool struct serialized through minijinja's Value::from_serialize
+        // would re-sort keys alphabetically; this guard preserves order.
+        let template = "{%- for tool in tools -%}\n{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}\n{{ tool }}\n{%- endfor -%}";
+
+        let tool = Tool::new(
+            "circle_area",
+            "Compute the area of a circle.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "radius": {"type": "number"}
+                },
+                "required": ["radius"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+
+        let template_vars: HashMap<String, bool> = HashMap::default();
+        let ctx = ChatTemplateContext::new(template_vars, Some(vec![tool]));
+        let chat_template = ChatTemplate::new(template, "", "").unwrap();
+
+        let rendered = chat_template.render(&[], &ctx).unwrap();
+
+        // Outer keys: `"type":"function"` must come before the outer
+        // `"function":` opening — i.e. type-first canonical order.
+        let type_idx = rendered
+            .find("\"type\":\"function\"")
+            .expect("expected outer \"type\":\"function\" in rendered output");
+        let function_idx = rendered
+            .find("\"function\":")
+            .expect("expected outer \"function\": in rendered output");
+        assert!(
+            type_idx < function_idx,
+            "outer key order regression: \"type\" should appear before \
+             \"function\" in the rendered template, got: {rendered}"
+        );
+
+        // Inner function keys: name -> description -> parameters.
+        let name_idx = rendered
+            .find("\"name\":\"circle_area\"")
+            .expect("expected inner \"name\":\"circle_area\" in rendered output");
+        let description_idx = rendered
+            .find("\"description\":")
+            .expect("expected inner \"description\": in rendered output");
+        let parameters_idx = rendered
+            .find("\"parameters\":")
+            .expect("expected inner \"parameters\": in rendered output");
+
+        assert!(
+            name_idx < description_idx,
+            "inner key order regression: \"name\" should appear before \
+             \"description\", got: {rendered}"
+        );
+        assert!(
+            description_idx < parameters_idx,
+            "inner key order regression: \"description\" should appear \
+             before \"parameters\", got: {rendered}"
+        );
     }
 }

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -184,20 +184,51 @@ impl Tool {
 }
 
 // Serialize tools according to https://huggingface.co/blog/unified-tool-use
+//
+// IMPORTANT: emit keys in EXPLICIT INSERTION ORDER (`type` before `function`,
+// inner `name` -> `description` -> `parameters`). The default `serde_json::json!`
+// path materialises a `Value::Object` backed by `BTreeMap`, which re-sorts keys
+// alphabetically. LFM2.5-350M is sensitive to that order — when fed
+// `{"function":{...},"type":"function"}` (alphabetical), it hallucinates extra
+// Pythonic kwargs (`parameters=`, `type=`) in the tool call. Using `serialize_map`
+// directly with nested helpers preserves the canonical OpenAI key order and
+// avoids forcing the `serde_json/preserve_order` cargo feature globally.
 impl Serialize for Tool {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": &self.name,
-                "description": &self.description,
-                "parameters": &self.json_schema,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            description: &'a str,
+            parameters: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(3))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("description", self.description)?;
+                m.serialize_entry("parameters", self.parameters)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            description: &self.description,
+            parameters: &self.json_schema,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -208,20 +239,48 @@ pub struct ToolCall {
     pub arguments: serde_json::Value,
 }
 
-// Serialize tools according to https://huggingface.co/blog/unified-tool-use
+// Serialize tool calls according to https://huggingface.co/blog/unified-tool-use
+// in canonical OpenAI key order (`type`, `function`, then within `function`:
+// `name`, `arguments`). Implemented via `serialize_map` rather than
+// `serde_json::json!({...}).serialize(serializer)` because the latter routes
+// through `serde_json::Value`'s default `BTreeMap` representation, which sorts
+// keys alphabetically (`{"function":{"arguments":...,"name":...},"type":...}`)
+// unless serde_json is built with the `preserve_order` feature — which is OFF
+// for the core/flutter/uniffi crates and which we cannot rely on downstream.
+// Same rationale as `Serialize for Tool` above.
 impl Serialize for ToolCall {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type" : "function",
-            "function": {
-                "name": &self.name,
-                "arguments": &self.arguments,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            arguments: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(2))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("arguments", self.arguments)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            arguments: &self.arguments,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -454,6 +513,29 @@ mod tests {
                     "parameters": {"type": "object"}
                 }
             })
+        );
+    }
+
+    #[test]
+    fn test_toolcall_serialization_preserves_canonical_key_order() {
+        // Regression guard for #519 review (gergelyvagujhelyi): the previous
+        // impl used `serde_json::json!({...}).serialize(serializer)`, which
+        // routes through `Value`'s default `BTreeMap` and emits keys in
+        // alphabetic order (`{"function":{"arguments":...,"name":...},...`)
+        // unless serde_json is built with `preserve_order` — OFF for the
+        // core/flutter/uniffi crates. Compare against the raw JSON string
+        // (NOT a Value) so any future regression to alphabetic ordering is
+        // caught even when a Value-equality check would still pass.
+        let call = ToolCall {
+            name: "circle_area".to_string(),
+            arguments: json!({"radius": 5}),
+        };
+        let serialized = serde_json::to_string(&call).expect("serialize ToolCall");
+        assert_eq!(
+            serialized,
+            r#"{"type":"function","function":{"name":"circle_area","arguments":{"radius":5}}}"#,
+            "ToolCall must serialize in canonical OpenAI key order \
+             (`type`, `function`, then `name`, `arguments`); got: {serialized}",
         );
     }
 

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -613,13 +613,18 @@ fn dart_function_type_to_json_schema(
         properties.insert(parameter_name.into(), parameter_type);
     }
 
+    // NOTE: do NOT add `additionalProperties: false` here. LFM2.5-350M (and likely
+    // other small models trained on plain JSON Schema, not OpenAI strict-mode) treats
+    // that field as a literal kwarg name and echoes it back in Pythonic tool calls,
+    // breaking the parser. JSON Schema's default (additional allowed) is fine — no
+    // enforcement happens client-side anyway, and Qwen3/Llama-3.2 tolerated either
+    // form on r5.
     tracing::debug!(
         "\n\n{}\n\n",
         serde_json::json!({
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": false
         })
     );
 
@@ -627,7 +632,6 @@ fn dart_function_type_to_json_schema(
         "type": "object",
         "properties": properties,
         "required": required,
-        "additionalProperties": false
     }))
 }
 
@@ -1055,7 +1059,6 @@ mod tests {
                 }
             },
             "required": ["name", "age", "tags"],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1069,7 +1072,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1084,7 +1086,6 @@ mod tests {
             "type": "object",
             "properties": { "text": { "type": "string" } },
             "required": [ "text" ],
-            "additionalProperties": false,
         });
         assert_eq!(json_schema, expected);
     }
@@ -1099,7 +1100,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }
@@ -1114,7 +1114,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }


### PR DESCRIPTION
Splits a chunk of #516 into smaller, independently-reviewable pieces, per @AsbjornOlling's request. This is **PR 1 of 3**.

Refs: #516, #214

## What this PR fixes

Three load-bearing tool-calling correctness fixes that benefit **all** model families (Qwen3, Llama-3.x, LFM2.5, etc.) plus a test tuning for the new tokenization. No new family handlers — those land in the follow-up PRs.

### 1. `Serialize for Tool` — preserve OpenAI canonical key order

`serde_json::json!({...})` materialises a `serde_json::Map` backed by `BTreeMap` by default, which re-sorts keys alphabetically. That made tool schemas serialize as `{"function":..., "type":"function"}` instead of the canonical `{"type":"function", "function":...}`.

Replaced with explicit `serializer.serialize_map` + `serialize_entry` calls in canonical order:
- Outer: `type` → `function`
- Inner: `name` → `description` → `parameters`

Empirically, smaller models (LFM2.5-350M in particular) are order-sensitive — alphabetical key order makes them hallucinate Pythonic kwargs in tool calls.

### 2. Pass tools to chat template as pre-serialized JSON strings

Even with a correctly ordered `Tool`, minijinja's `Value::from_serialize` round-trips through `serde_json::Value` (BTreeMap) and re-sorts keys.

Pre-serializing each `Tool` to a JSON `String` and passing `Vec<String>` as the `tools` template variable bypasses minijinja's serializer. The HF tool-aware chat templates (LFM2/2.5, Qwen3) all guard with `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`, so a string passes through unchanged.

Pitfall avoided: `Option::iter()` yields the entire `Vec` (not per-Tool), producing one giant array-string. Used `.as_ref().into_iter().flatten()` to map per-Tool.

### 3. Drop `additionalProperties: false` from generated tool schemas

`flutter/rust/src/lib.rs::dart_function_type_to_json_schema` was injecting `additionalProperties: false` into the generated schema. Small models like LFM2.5-350M echoed that field name as a Pythonic kwarg in tool emits.

This is JSON Schema strict-mode shorthand from OpenAI's API spec — not required by the llama.cpp parser path. Five `#[test]` expected schemas updated accordingly.

### 4. Test tuning: bump `n_messages` in `test_context_shift_with_tool_calls`

The pre-serialized JSON tool strings (point 2) reduced per-render token count enough that 10 messages no longer overflowed `n_ctx=1024` with the standard test model. `context_shift` then skipped, breaking the `assert!(messages_after.len() < messages_before)` check.

Bumped to 20 to restore the overflow condition without changing test intent.

## Stack

- This PR: engine fixes (you are here)
- Next: `feat: Llama-3.x family handler` — independent of this PR
- Next: `feat: LFM2.5 family tool calling (parser-only)` — depends on this PR