### PR TITLE
feat(tool_calling): Llama-3.x family handler

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2430,9 +2430,14 @@ mod tests {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
-        // Use a very small context size to force shifting
+        // Use a very small context size to force shifting. Bumped n_messages
+        // from 10 -> 20 because passing tools to the chat template as
+        // pre-serialized JSON strings (see commit a26dfc79) reduced the
+        // per-render token count enough that 10 exchanges no longer overflow
+        // n_ctx=1024 with the test_chat-model GGUF — context_shift then
+        // skipped, leaving messages_after.len() == messages_before.
         let n_ctx = 1024;
-        let n_messages = 10;
+        let n_messages = 20;
         let mut worker = Worker::new_chat_worker(
             &model,
             ChatConfig {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -50,7 +50,7 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::hash::Hasher;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, MutexGuard};
 use tracing::{debug, error, info, trace, trace_span};
 
@@ -1643,11 +1643,21 @@ impl Worker<'_, ChatWorker> {
             },
         );
 
+        // Tracks whether any iteration's Done event was forwarded to the outer
+        // callback. Shared across every `wrap_respond` instance built below so
+        // the terminal-Done epilogue can run only when no Done has reached the
+        // consumer yet (e.g. parser-only paths that exit before producing an
+        // iter-2 generation). Keeps raw `Fn(WriteOutput)` consumers — godot
+        // binding, direct ask_channel users — from receiving two Done events
+        // per `ask` call.
+        let done_forwarded = Arc::new(AtomicBool::new(false));
+
         // get the finished response
         let mut response: String = self.wrapped_update_context_and_generate_response(
             sampler.clone(),
             respond.clone(),
             tool_call_begin.clone(),
+            done_forwarded.clone(),
         )?;
 
         // Process tool calls if tool format is configured
@@ -1691,6 +1701,7 @@ impl Worker<'_, ChatWorker> {
                     sampler.clone(),
                     respond.clone(),
                     tool_call_begin.clone(),
+                    done_forwarded.clone(),
                 )?;
             }
         } // Close if let Some(tool_format)
@@ -1698,9 +1709,22 @@ impl Worker<'_, ChatWorker> {
         debug_assert!(tool_call_begin
             .as_ref()
             .is_none_or(|t| !response.contains(t.as_str())));
-        self.add_assistant_message(response);
+        self.add_assistant_message(response.clone());
 
         self.extra.context.chunks = self.render_as_chunks(true)?;
+
+        // Terminal Done failsafe. Fires only when no iteration forwarded a Done
+        // — i.e. parser-only paths where `extract_tool_calls` returned None
+        // after `wrap_respond` already suppressed iter-1's Done past the
+        // begin_token. That used to surface as `WorkerCrashed` for LFM2.5 and
+        // other parser-only handlers. Skipping this when a Done was already
+        // forwarded prevents a double Done for raw `Fn(WriteOutput)` consumers
+        // (godot binding, direct ask_channel users); `TokenStream` consumers
+        // were already shielded by the `completed_response.is_some()`
+        // short-circuit, but external callback users were not.
+        if !done_forwarded.load(Ordering::SeqCst) {
+            respond(llm::WriteOutput::Done(response));
+        }
 
         Ok(self)
     }
@@ -1744,6 +1768,7 @@ impl Worker<'_, ChatWorker> {
         sampler: SamplerConfig,
         respond: F,
         tool_call_begin_token: Option<String>,
+        done_forwarded: Arc<AtomicBool>,
     ) -> Result<String, WrappedResponseError>
     where
         F: Fn(llm::WriteOutput) + Clone,
@@ -1755,7 +1780,8 @@ impl Worker<'_, ChatWorker> {
 
         // wrap the response callback to keep a copy of the completed response
         // and to avoid emitting tool calls
-        let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
+        let (wrapped_respond, resp_receiver) =
+            wrap_respond(respond.clone(), tool_call_begin_token, done_forwarded);
 
         // llm go brrr
         self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
@@ -1952,12 +1978,15 @@ impl Worker<'_, ChatWorker> {
     }
 }
 
-/// wraps a response function in a closure to do two things:
+/// wraps a response function in a closure to do three things:
 /// 1. save a copy of the response (using a channel) before sending it out
 /// 2. skip emitting once a tool_call_begin_token has been seen
+/// 3. record whether a Done was forwarded to the outer callback (so the caller
+///    can decide whether a terminal-Done epilogue is still needed)
 fn wrap_respond<F>(
     respond: F,
     tool_call_begin_token: Option<String>,
+    done_forwarded: Arc<AtomicBool>,
 ) -> (
     impl FnMut(llm::WriteOutput),
     std::sync::mpsc::Receiver<String>,
@@ -1977,6 +2006,9 @@ where
                 resp_sender
                     .send(resp.clone())
                     .expect("Failed sending response");
+                if emitting {
+                    done_forwarded.store(true, Ordering::SeqCst);
+                }
             }
             llm::WriteOutput::Token(_) => (),
         }
@@ -2036,6 +2068,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Regression test for the terminal-Done epilogue: `Worker::ask` must
+    /// emit exactly ONE Done event per call for raw `Fn(WriteOutput)`
+    /// callback consumers (godot binding, direct ask_channel users).
+    /// `TokenStream` consumers were already shielded by the
+    /// `completed_response.is_some()` short-circuit, but external callback
+    /// users were not — a second Done from the unconditional terminal
+    /// epilogue used to double-fire here.
+    #[test]
+    fn test_done_emitted_exactly_once_per_ask() -> Result<(), Box<dyn std::error::Error>> {
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                n_ctx: 1024,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        let done_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_inner = Arc::clone(&done_count);
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let callback = move |x: llm::WriteOutput| {
+            if let llm::WriteOutput::Done(resp) = x {
+                count_inner.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // tolerate a closed channel — count is the assertion target,
+                // recv-side just unblocks once.
+                let _ = sender.send(resp);
+            }
+        };
+
+        worker.ask("Say hi.".into(), callback)?;
+
+        // First Done: confirm a callback arrived (proves wiring).
+        let _ = receiver.recv_timeout(std::time::Duration::from_secs(60))?;
+
+        // `Worker::ask` returns synchronously after invoking its callback for
+        // the final time, so by here the count is final — no race window.
+        let count = done_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            count, 1,
+            "Worker::ask should emit exactly ONE Done per call, observed {count}."
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -2292,6 +2373,129 @@ mod tests {
         println!("{}", result);
         assert!(result.contains("13.37"));
         assert!(result.contains("0.15"));
+    }
+
+    /// Mirrors the python `test_tool_with_sets` failure that crashed
+    /// LFM2.5-350M and LFM2.5-1.2B-Instruct on host pytest with
+    /// `Worker thread terminated before completing the response`.
+    /// Single tool with a set-of-int schema; prompt contains literal
+    /// Python set syntax `{12,5,7,3,4}` to force the crash path.
+    /// Ignored by default — invoke with:
+    ///   TEST_MODEL=…/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
+    ///     cargo test --release --lib chat::tests::test_lfm2_5_set_tool_repro -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn test_lfm2_5_set_tool_repro() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        fn set_intersection_tool() -> Tool {
+            Tool {
+                name: "set_intersection".into(),
+                description: "Returns the intersection of set1 and set2".into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "set1": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                        "set2": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                    },
+                    "required": ["set1", "set2"],
+                }),
+                function: Arc::new(|args: serde_json::Value| {
+                    let s1: std::collections::HashSet<i64> = args
+                        .get("set1")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let s2: std::collections::HashSet<i64> = args
+                        .get("set2")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let inter: Vec<i64> = s1.intersection(&s2).copied().collect();
+                    format!("{:?}", inter)
+                }),
+            }
+        }
+
+        // Mirror python fixture: 6 tools registered, model picks one.
+        fn dummy_tool(name: &str, description: &str, prop: &str, json_type: &str) -> Tool {
+            let prop_owned = prop.to_string();
+            Tool {
+                name: name.into(),
+                description: description.into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { prop: {"type": json_type} },
+                    "required": [prop],
+                }),
+                function: Arc::new(move |args: serde_json::Value| {
+                    format!("dummy({}={:?})", prop_owned, args.get(&prop_owned))
+                }),
+            }
+        }
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant".into()),
+                n_ctx: 4096,
+                tools: vec![
+                    set_intersection_tool(),
+                    dummy_tool("multiply_strings", "Multiply a string by an integer N times", "pair", "object"),
+                    dummy_tool("sparklify", "Add sparkles to text", "text", "string"),
+                    dummy_tool("reflarbicator", "Boop foob", "reflarb", "integer"),
+                    dummy_tool("add_list_of_vectors", "Add a list of vectors", "list_of_vectors", "array"),
+                    dummy_tool("calculate_volume", "Compute volume of a cube", "dimensions", "object"),
+                ],
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("Failed making worker");
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let f = move |x| {
+            if let llm::WriteOutput::Done(resp) = x {
+                let _ = sender.send(resp);
+            }
+        };
+
+        let ask_result = worker.ask(
+            "Please use the provided tool to find the intersection between the sets {12,5,7,3,4} and {12,9,5,3}".into(),
+            f,
+        );
+
+        match ask_result {
+            Ok(_) => {
+                let resp = receiver.recv_timeout(std::time::Duration::from_secs(120));
+                println!("=== ask returned Ok, response ===");
+                match resp {
+                    Ok(s) => println!("{s}"),
+                    Err(e) => println!("recv error (worker dropped without Done?): {e}"),
+                }
+            }
+            Err(e) => {
+                println!("=== ask returned Err ===");
+                println!("{e:?}");
+            }
+        }
+
+        // Debug: dump chat history to see what the model emitted + how the
+        // engine responded — extract_tool_calls return shape, dispatched
+        // tool result, regen content, etc.
+        println!("=== chat history ===");
+        for (i, m) in worker.extra.messages.iter().enumerate() {
+            println!("[{i}] role={:?}", m);
+        }
     }
 
     #[test]

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1628,18 +1628,32 @@ impl Worker<'_, ChatWorker> {
 
         self.add_user_message(prompt.to_string(), assets);
 
-        // Modify sampler with tool grammar if we have tools
+        // Modify sampler with tool grammar if we have tools. Handlers that
+        // supply `grammar_trigger_patterns()` (e.g. Llama-3.x) get the
+        // pattern-based lazy grammar so the trigger re-fires on every
+        // tool-call turn; the rest fall through to the single-token trigger
+        // keyed on `begin_token()`.
+        let trigger_patterns = self
+            .extra
+            .tool_format
+            .as_ref()
+            .and_then(|fmt| fmt.grammar_trigger_patterns());
         let sampler = self.extra.tool_grammar.as_ref().map_or(
             self.extra.sampler_config.clone(),
             |tool_grammar| {
-                self.extra
-                    .sampler_config
-                    .clone()
-                    .prepend(ShiftStep::Grammar {
+                let grammar_step = match trigger_patterns {
+                    Some(patterns) => ShiftStep::GrammarPattern {
+                        trigger_patterns: patterns,
+                        root: tool_grammar.root_name.to_string(),
+                        grammar: tool_grammar.as_str().into(),
+                    },
+                    None => ShiftStep::Grammar {
                         trigger_on: tool_call_begin.clone(),
                         root: tool_grammar.root_name.to_string(),
                         grammar: tool_grammar.as_str().into(),
-                    })
+                    },
+                };
+                self.extra.sampler_config.clone().prepend(grammar_step)
             },
         );
 

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1380,15 +1380,37 @@ impl Worker<'_, ChatWorker> {
                 .ok_or(ShiftError::Message(
                     "No first user message in chat history".into(),
                 ))?;
-        let first_deletable_index = self
+
+        // The standard rolling-pair strategy preserves the last 2 user messages
+        // and shifts older user/assistant pairs out. When the chat has only one
+        // user message — for example a tool-call loop where the model dispatched
+        // the same tool many times without further user input, exhausting n_ctx —
+        // there is no second user message and the previous implementation hard
+        // -failed with "No deletable messages". Fall back to a simpler scheme:
+        // drain the older assistant/tool turns between the first user message
+        // and the most recent message, preserving the in-progress tail.
+        let (first_deletable_index, mut last_deletable_index) = match self
             .find_next_user_message(&messages, first_user_message_index + 1)
-            .ok_or(ShiftError::Message("No deletable messages".into()))?; // Assuming assistant after user
-        let mut last_deletable_index = self
-            .find_start_of_last_n_user_messages(&messages, 2)
-            .ok_or(ShiftError::Message(
-                "Less than two user messages in chat history.".into(),
-            ))?
-            - 1;
+        {
+            Some(second_user_idx) => (
+                second_user_idx,
+                self.find_start_of_last_n_user_messages(&messages, 2)
+                    .ok_or(ShiftError::Message(
+                        "Less than two user messages in chat history.".into(),
+                    ))?
+                    - 1,
+            ),
+            None => {
+                // Need at least: [system?, user, ...middle..., tail] for there to
+                // be anything safe to delete. If the history is too short, leave
+                // it intact and let the upstream caller decide what to do.
+                if messages.len() < first_user_message_index + 3 {
+                    self.extra.messages = messages;
+                    return Ok(());
+                }
+                (first_user_message_index + 1, messages.len() - 2)
+            }
+        };
 
         // Two is the smallest number of messages we can delete as we need to preserve the message structure.
         // There might be a better start guess here.
@@ -1414,16 +1436,17 @@ impl Worker<'_, ChatWorker> {
                 last_deletable_index,
             );
 
-            // Find the first user message after target delete index and choose the message before.
-            // This is to ensure that resulting chat history still follows the user then assistant format
-            let delete_index = min(
-                self.find_next_user_message(&messages, target_delete_index + 1)
-                    .ok_or(ShiftError::Message(
-                        "Could find user message supposed to be there".into(),
-                    ))?
-                    - 1,
-                last_deletable_index,
-            ); // should never fail
+            // Find the first user message after target delete index and choose
+            // the message before, so the resulting chat history still follows
+            // the user-then-assistant turn structure. In the single-user-message
+            // fallback there is no later user message to align with, so we
+            // delete up to `target_delete_index` directly.
+            let delete_index = match self
+                .find_next_user_message(&messages, target_delete_index + 1)
+            {
+                Some(next_user) => min(next_user - 1, last_deletable_index),
+                None => min(target_delete_index, last_deletable_index),
+            };
             messages.drain(first_deletable_index..=delete_index);
             messages_to_delete *= 2;
 
@@ -3111,4 +3134,55 @@ mod tests {
     }
 
     // Template rendering tests have been moved to template.rs module
+
+    #[test]
+    fn test_context_shift_with_only_one_user_message() -> Result<(), Box<dyn std::error::Error>> {
+        // Regression guard: a chat with one user message and many assistant /
+        // tool turns must not panic when context_shift is invoked. The previous
+        // implementation hard-failed at the "No deletable messages" predicate
+        // because it assumed at least two user messages were always present.
+        // This shape is the empirical failure mode of small Llama-3.x variants
+        // looping on a tool call until n_ctx is exhausted (chat.rs:318
+        // `Worker crashed: ... Missing expected message No deletable messages`).
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant.".into()),
+                n_ctx: 512,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        // One user message, then many assistant turns (the tool-call-loop shape).
+        worker.add_user_message(
+            "Use the provided tool to compute several things.".into(),
+            vec![],
+        );
+        for i in 0..30 {
+            worker.add_assistant_message(format!(
+                "Assistant turn {i} producing a long-ish synthetic response to fill context."
+            ));
+        }
+
+        let messages_before = worker.extra.messages.len();
+        worker.context_shift()?; // must not return Err here
+        let messages_after = worker.extra.messages.len();
+
+        assert!(
+            messages_after <= messages_before,
+            "context_shift must not grow the history (before={messages_before}, after={messages_after})"
+        );
+        // System prompt + first user message must be retained.
+        assert!(worker.extra.messages[0].is_system());
+        assert!(worker
+            .extra
+            .messages
+            .iter()
+            .any(|m| m.is_user()), "first user message must be preserved");
+        Ok(())
+    }
 }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1628,19 +1628,29 @@ impl Worker<'_, ChatWorker> {
 
         self.add_user_message(prompt.to_string(), assets);
 
-        // Modify sampler with tool grammar if we have tools. Handlers that
-        // supply `grammar_trigger_patterns()` (e.g. Llama-3.x) get the
-        // pattern-based lazy grammar so the trigger re-fires on every
+        // Build two samplers:
+        //   - `base_sampler`: the user-configured sampler with no tool grammar.
+        //     Used for the text-only continuation when a handler disallows
+        //     repeated tool calls (so the model produces a final text answer
+        //     to the user instead of looping in tool-call shape).
+        //   - `sampler`: `base_sampler` with the tool grammar prepended, used
+        //     for the first generation (and subsequent generations when the
+        //     handler permits repeated tool calls).
+        // Handlers that supply `grammar_trigger_patterns()` (e.g. Llama-3.x)
+        // get the pattern-based lazy grammar so the trigger re-fires on every
         // tool-call turn; the rest fall through to the single-token trigger
         // keyed on `begin_token()`.
+        let base_sampler = self.extra.sampler_config.clone();
         let trigger_patterns = self
             .extra
             .tool_format
             .as_ref()
             .and_then(|fmt| fmt.grammar_trigger_patterns());
-        let sampler = self.extra.tool_grammar.as_ref().map_or(
-            self.extra.sampler_config.clone(),
-            |tool_grammar| {
+        let sampler = self
+            .extra
+            .tool_grammar
+            .as_ref()
+            .map_or(base_sampler.clone(), |tool_grammar| {
                 let grammar_step = match trigger_patterns {
                     Some(patterns) => ShiftStep::GrammarPattern {
                         trigger_patterns: patterns,
@@ -1653,9 +1663,8 @@ impl Worker<'_, ChatWorker> {
                         grammar: tool_grammar.as_str().into(),
                     },
                 };
-                self.extra.sampler_config.clone().prepend(grammar_step)
-            },
-        );
+                base_sampler.clone().prepend(grammar_step)
+            });
 
         // Tracks whether any iteration's Done event was forwarded to the outer
         // callback. Shared across every `wrap_respond` instance built below so
@@ -1677,6 +1686,13 @@ impl Worker<'_, ChatWorker> {
         // Process tool calls if tool format is configured
         // Clone to avoid borrow issues in the loop
         if let Some(tool_format) = self.extra.tool_format.clone() {
+            // When the handler disallows repeated tool calls (Llama-3.x), we
+            // dispatch the first set of calls and then re-generate WITHOUT
+            // the tool grammar so the model produces a plain-text answer to
+            // the user. Citing llama.cpp `common/chat.cpp:1626` and vLLM:
+            // "Parallel tool calls are not supported for Llama 3."
+            let allow_repeated = tool_format.allow_repeated_calls();
+
             while let Some(tool_calls) = tool_format.extract_tool_calls(&response) {
                 debug!(?tool_calls, "Got tool calls:");
 
@@ -1710,13 +1726,60 @@ impl Worker<'_, ChatWorker> {
                     self.add_tool_resp(tool_call.name, response);
                 }
 
-                // get the finished response
+                // Pick the sampler for the continuation generation: handlers
+                // that allow repeated calls keep the tool grammar active so
+                // any further tool calls are constrained; handlers that
+                // disallow repeated calls (Llama-3.x) drop the tool grammar
+                // so the model is free to produce a plain-text answer to the
+                // user.
+                //
+                // For the !allow_repeated continuation we ALSO pass `None` for
+                // the begin-token argument to `wrap_respond`. Otherwise, when
+                // small variants (Llama-3.2-1B in particular) reflexively emit
+                // `<|python_tag|>` again on the unconstrained continuation
+                // turn, `wrap_respond` flips its `emitting` flag to false and
+                // never forwards the terminal `Done(response)` event to the
+                // user-facing output channel — Python's `chat.ask().completed()`
+                // then waits indefinitely and ultimately reports "Worker thread
+                // terminated before completing the response." Suppressing the
+                // tool-call body in the stream is irrelevant here: this gen is
+                // the assistant's final word for this user turn.
+                let (continuation_sampler, continuation_begin) = if allow_repeated {
+                    (sampler.clone(), tool_call_begin.clone())
+                } else {
+                    (base_sampler.clone(), None)
+                };
                 response = self.wrapped_update_context_and_generate_response(
-                    sampler.clone(),
+                    continuation_sampler,
                     respond.clone(),
-                    tool_call_begin.clone(),
+                    continuation_begin,
                     done_forwarded.clone(),
                 )?;
+
+                // Llama-3.x policy: cap tool dispatches at one per user turn.
+                // The base sampler had no grammar so the model is unconstrained;
+                // small variants (1B/3B) sometimes still emit tool-call-shaped
+                // tokens (`<|python_tag|>{...}`) on the continuation turn from
+                // training bias, even though we asked for plain text. Strip
+                // the begin/end markers so the recorded assistant message is
+                // clean text rather than something that re-parses as a tool
+                // call on the next user turn (and so we don't trip the
+                // post-loop debug_assert that verifies the begin token is
+                // absent from the final response).
+                if !allow_repeated {
+                    if let (Some(begin), Some(fmt)) =
+                        (tool_call_begin.as_ref(), self.extra.tool_format.as_ref())
+                    {
+                        let end_marker = fmt.end_token().to_string();
+                        if let Some(rest) = response.trim_start().strip_prefix(begin.as_str()) {
+                            response = rest.trim_start().to_string();
+                        }
+                        if let Some(prefix) = response.trim_end().strip_suffix(&end_marker) {
+                            response = prefix.trim_end().to_string();
+                        }
+                    }
+                    break;
+                }
             }
         } // Close if let Some(tool_format)
 

--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -168,6 +168,11 @@ impl SamplerConfig {
                 Some(trigger) => self.build_lazy_grammar(model, &grammar, &root, &trigger),
                 None => self.build_regular_grammar(model, &grammar, &root),
             },
+            ShiftStep::GrammarPattern {
+                grammar,
+                trigger_patterns,
+                root,
+            } => self.build_pattern_grammar(model, &grammar, &root, &trigger_patterns),
             ShiftStep::DRY {
                 multiplier,
                 base,
@@ -231,6 +236,22 @@ impl SamplerConfig {
         root: &str,
     ) -> Result<LlamaSampler, SamplerError> {
         Ok(LlamaSampler::grammar(model, grammar, root)?)
+    }
+
+    fn build_pattern_grammar(
+        &self,
+        model: &LlamaModel,
+        grammar: &str,
+        root: &str,
+        trigger_patterns: &[String],
+    ) -> Result<LlamaSampler, SamplerError> {
+        Ok(LlamaSampler::grammar_lazy_patterns(
+            model,
+            grammar,
+            root,
+            trigger_patterns,
+            &[],
+        )?)
     }
 }
 
@@ -302,6 +323,17 @@ pub enum ShiftStep {
     },
     Grammar {
         trigger_on: Option<String>,
+        root: String,
+        grammar: String,
+    },
+    /// Grammar variant that activates the sampler when the generation output
+    /// matches any of the supplied regex patterns from the start of generation.
+    /// Distinct from `Grammar { trigger_on: Some(_) }` which keys on a single
+    /// trigger token: pattern triggers can express alternation (e.g. accept
+    /// either `<|python_tag|>` or a bare `{` for Llama-3.x, where the chat
+    /// template forces the prefix only on the first tool-call turn).
+    GrammarPattern {
+        trigger_patterns: Vec<String>,
         root: String,
         grammar: String,
     },

--- a/nobodywho/core/src/template.rs
+++ b/nobodywho/core/src/template.rs
@@ -90,7 +90,34 @@ impl ChatTemplate {
             ),
             ("bos_token".to_string(), Value::from(self.bos_token.clone())),
             ("eos_token".to_string(), Value::from(self.eos_token.clone())),
-            ("tools".to_string(), Value::from_serialize(&ctx.tools)),
+            // Pre-serialise each tool to its canonical OpenAI JSON shape (insertion
+            // order preserved by `Tool`'s custom Serialize impl using
+            // `serialize_map`) and pass the list as STRINGS. The HF tool-aware
+            // chat templates (LFM2/LFM2.5/Qwen3 etc.) all guard with
+            // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`
+            // — so a string passes through unchanged. This bypasses minijinja's
+            // internal Value→tojson re-serialisation, which otherwise re-sorts
+            // object keys alphabetically (default `serde_json::Map` is `BTreeMap`).
+            // LFM2.5-350M is empirically sensitive to that order: alphabetical
+            // (`{"function":..., "type":"function"}`) makes it hallucinate kwargs
+            // (`parameters=`, `type=`) in the emitted Pythonic tool call.
+            //
+            // NOTE: `ctx.tools` is `Option<Vec<Tool>>`. `Option::iter` yields 0 or 1
+            // element of type `&Vec<Tool>` — so mapping on it would serialise the
+            // ENTIRE list as a single JSON-array string, producing `[[…]]` after the
+            // template's own `[…]` wrap. Flatten via `as_ref().into_iter().flatten()`
+            // so we map per-Tool.
+            (
+                "tools".to_string(),
+                Value::from_serialize(
+                    ctx.tools
+                        .as_ref()
+                        .into_iter()
+                        .flatten()
+                        .map(|t| serde_json::to_string(t).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
         ];
 
         // Add all template variables
@@ -462,5 +489,85 @@ mod tests {
         // The template now includes empty thinking blocks for assistant messages
         let expected5 = "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\nHi there!<|im_end|>\n";
         assert_eq!(rendered5, expected5);
+    }
+
+    /// Regression guard for the `tools` template variable wiring (see PR
+    /// notes on tools-as-strings + canonical key order). Renders a minimal
+    /// tool-aware Qwen3-style template with one Tool, then asserts the
+    /// rendered string places the OpenAI canonical keys in canonical order:
+    /// outer `"type":"function"` BEFORE outer `"function":` value, inner
+    /// `"name":` BEFORE `"description":` BEFORE `"parameters":`.
+    ///
+    /// Without the engine fixes (Tool::serialize using BTreeMap-backed
+    /// serde_json::Map, or template variable as Vec<Tool> instead of
+    /// Vec<String>) the rendered string would order keys alphabetically:
+    /// `"function":...,"type":"function"`. Both regressions would fail
+    /// this test.
+    #[test]
+    fn test_render_template_with_tools_preserves_key_order() {
+        use std::sync::Arc;
+
+        // Minimal tool-aware template: dump the tools array verbatim.
+        // The HF tool-aware templates all guard with
+        // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`,
+        // so a pre-serialized JSON STRING passes through unchanged. A
+        // Tool struct serialized through minijinja's Value::from_serialize
+        // would re-sort keys alphabetically; this guard preserves order.
+        let template = "{%- for tool in tools -%}\n{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}\n{{ tool }}\n{%- endfor -%}";
+
+        let tool = Tool::new(
+            "circle_area",
+            "Compute the area of a circle.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "radius": {"type": "number"}
+                },
+                "required": ["radius"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+
+        let template_vars: HashMap<String, bool> = HashMap::default();
+        let ctx = ChatTemplateContext::new(template_vars, Some(vec![tool]));
+        let chat_template = ChatTemplate::new(template, "", "").unwrap();
+
+        let rendered = chat_template.render(&[], &ctx).unwrap();
+
+        // Outer keys: `"type":"function"` must come before the outer
+        // `"function":` opening — i.e. type-first canonical order.
+        let type_idx = rendered
+            .find("\"type\":\"function\"")
+            .expect("expected outer \"type\":\"function\" in rendered output");
+        let function_idx = rendered
+            .find("\"function\":")
+            .expect("expected outer \"function\": in rendered output");
+        assert!(
+            type_idx < function_idx,
+            "outer key order regression: \"type\" should appear before \
+             \"function\" in the rendered template, got: {rendered}"
+        );
+
+        // Inner function keys: name -> description -> parameters.
+        let name_idx = rendered
+            .find("\"name\":\"circle_area\"")
+            .expect("expected inner \"name\":\"circle_area\" in rendered output");
+        let description_idx = rendered
+            .find("\"description\":")
+            .expect("expected inner \"description\": in rendered output");
+        let parameters_idx = rendered
+            .find("\"parameters\":")
+            .expect("expected inner \"parameters\": in rendered output");
+
+        assert!(
+            name_idx < description_idx,
+            "inner key order regression: \"name\" should appear before \
+             \"description\", got: {rendered}"
+        );
+        assert!(
+            description_idx < parameters_idx,
+            "inner key order regression: \"description\" should appear \
+             before \"parameters\", got: {rendered}"
+        );
     }
 }

--- a/nobodywho/core/src/tool_calling/llama32.rs
+++ b/nobodywho/core/src/tool_calling/llama32.rs
@@ -1,0 +1,246 @@
+use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
+use gbnf::builder::{nt, seq, t, GrammarBuilder};
+use gbnf::json::json_schema_to_grammar;
+use gbnf::GbnfGrammar;
+use serde_json::json;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Llama32Handler;
+
+const BEGIN: &str = "<|python_tag|>";
+const END: &str = "<|eot_id|>";
+
+#[derive(serde::Deserialize)]
+struct LlamaToolCall {
+    #[serde(alias = "function")]
+    name: String,
+    parameters: serde_json::Value,
+}
+
+impl ToolFormatHandler for Llama32Handler {
+    fn begin_token(&self) -> &str {
+        BEGIN
+    }
+
+    fn end_token(&self) -> &str {
+        END
+    }
+
+    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
+        let tool_call_schemas: serde_json::Value = tools
+            .iter()
+            .map(|tool| {
+                json!(
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": { "const": tool.name },
+                            "parameters": tool.json_schema
+                        },
+                        "required": ["name", "parameters"]
+                    }
+                )
+            })
+            .collect();
+
+        let tool_call_schema = json!({ "oneOf": tool_call_schemas });
+        let json_grammar = json_schema_to_grammar(tool_call_schema, "root")?;
+
+        let grammar = GrammarBuilder::from_existing(json_grammar)
+            .rule(
+                "toolcall",
+                seq(&[t(BEGIN), nt("ws"), nt("root"), nt("ws")]),
+            )
+            .rule("superroot", nt("toolcall"))
+            .root("superroot")
+            .build();
+
+        Ok(grammar)
+    }
+
+    fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
+        let mut s = input.trim();
+        if let Some(rest) = s.strip_prefix(BEGIN) {
+            s = rest.trim_start();
+        }
+        if let Some(prefix) = s.strip_suffix(END) {
+            s = prefix.trim_end();
+        }
+
+        let mut stream = serde_json::Deserializer::from_str(s).into_iter::<LlamaToolCall>();
+        let first = stream.next()?;
+
+        match first {
+            Ok(call) => {
+                if stream.next().is_some() {
+                    warn!(
+                        "Llama-3.x emitted >1 tool call in one assistant turn; \
+                         only the first is dispatched (chat template constraint)"
+                    );
+                }
+                debug!(tool_name = %call.name, "Successfully parsed Llama tool call");
+                Some(vec![ToolCall {
+                    name: call.name,
+                    arguments: call.parameters,
+                }])
+            }
+            Err(e) => {
+                debug!(error = %e, json = s, "Failed to parse Llama tool call JSON");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn handler() -> Llama32Handler {
+        Llama32Handler
+    }
+
+    #[test]
+    fn p1_round4_with_python_tag_name_field() {
+        let input = r#"<|python_tag|>{"name": "circle_area", "parameters": {"radius": "5"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": "5"}));
+    }
+
+    #[test]
+    fn p2_round4_no_prefix_name_field() {
+        let input = r#"{"name": "circle_area", "parameters": {"radius": "12"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": "12"}));
+    }
+
+    #[test]
+    fn p3_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "Cairo"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn p4_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "London"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "London"}));
+    }
+
+    #[test]
+    fn p5_round4_function_field_alias() {
+        let input = r#"{"function": "get_weather", "parameters": {"city": "Tokyo"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn trailing_eot_is_stripped() {
+        let input = r#"<|python_tag|>{"name":"a","parameters":{}}<|eot_id|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "a");
+    }
+
+    #[test]
+    fn whitespace_between_prefix_and_json_tolerated() {
+        let input = "<|python_tag|>  \n  {\"name\": \"circle_area\", \"parameters\": {\"radius\": \"5\"}}";
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+    }
+
+    #[test]
+    fn plain_assistant_text_with_inline_json_returns_none() {
+        let input = r#"Sure, here is some JSON: {"x": 1}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn json_without_name_or_function_returns_none() {
+        let input = r#"{"x": 1, "parameters": {}}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn json_without_parameters_returns_none() {
+        let input = r#"{"name": "x"}<|eot_id|>"#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn truncated_mid_json_returns_none() {
+        let input = r#"{"name": "x", "parameters": {"a""#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn two_blocks_returns_only_first() {
+        let input = r#"{"name":"a","parameters":{}}{"name":"b","parameters":{}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1, "single-call constraint enforced");
+        assert_eq!(calls[0].name, "a");
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(handler().extract_tool_calls("").is_none());
+    }
+
+    #[test]
+    fn tokens_match_chat_template() {
+        let h = handler();
+        assert_eq!(h.begin_token(), "<|python_tag|>");
+        assert_eq!(h.end_token(), "<|eot_id|>");
+    }
+
+    #[test]
+    fn grammar_contains_ws_rule() {
+        let tool = Tool::new(
+            "circle_area",
+            "Compute area of circle",
+            json!({
+                "type": "object",
+                "properties": { "radius": { "type": "number" } },
+                "required": ["radius"]
+            }),
+            std::sync::Arc::new(|_| "78.54".to_string()),
+        );
+        let grammar = handler().generate_grammar(&[tool]).unwrap();
+        let s = grammar.as_str();
+        assert!(s.contains("ws ::="), "expected ws rule in:\n{}", s);
+    }
+
+    #[test]
+    fn grammar_constrains_to_known_tools() {
+        let tool = Tool::new(
+            "circle_area",
+            "Compute area of circle",
+            json!({
+                "type": "object",
+                "properties": { "radius": { "type": "number" } },
+                "required": ["radius"]
+            }),
+            std::sync::Arc::new(|_| "78.54".to_string()),
+        );
+        let grammar = handler().generate_grammar(&[tool]).unwrap();
+        let s = grammar.as_str();
+        assert!(
+            s.contains("circle_area"),
+            "expected tool name as const literal in grammar:\n{}",
+            s
+        );
+        assert!(
+            s.contains("<|python_tag|>"),
+            "expected begin token literal in grammar:\n{}",
+            s
+        );
+    }
+}

--- a/nobodywho/core/src/tool_calling/llama32.rs
+++ b/nobodywho/core/src/tool_calling/llama32.rs
@@ -80,9 +80,10 @@ impl ToolFormatHandler for Llama32Handler {
                     );
                 }
                 debug!(tool_name = %call.name, "Successfully parsed Llama tool call");
+                let arguments = repair_string_encoded_structures(call.parameters);
                 Some(vec![ToolCall {
                     name: call.name,
-                    arguments: call.parameters,
+                    arguments,
                 }])
             }
             Err(e) => {
@@ -90,6 +91,47 @@ impl ToolFormatHandler for Llama32Handler {
                 None
             }
         }
+    }
+}
+
+/// Llama-3.x chat templates emit `<|python_tag|>` only on the first tool-call turn;
+/// post-tool-response turns omit the prefix, so the lazy grammar (keyed on that
+/// prefix) never re-fires and the sampler runs unconstrained. Empirically the 1B
+/// and 3B variants then emit complex parameters as JSON-encoded strings instead of
+/// structured values: `{"set1": "[1,2,3]"}` instead of `{"set1": [1,2,3]}`. This
+/// post-process walks the parsed parameters and, when a `Value::String` round-trips
+/// through `serde_json::from_str` to an `Array` or `Object`, replaces the string
+/// with the parsed structure. Scalars (Number, Bool, Null) are deliberately NOT
+/// re-parsed: coercing `"42"` to `42` would silently break tools whose parameter is
+/// genuinely `str`.
+fn repair_string_encoded_structures(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let repaired = map
+                .into_iter()
+                .map(|(k, v)| (k, repair_string_encoded_structures(v)))
+                .collect();
+            serde_json::Value::Object(repaired)
+        }
+        serde_json::Value::Array(items) => serde_json::Value::Array(
+            items.into_iter().map(repair_string_encoded_structures).collect(),
+        ),
+        serde_json::Value::String(ref s) => {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s) {
+                if matches!(
+                    parsed,
+                    serde_json::Value::Array(_) | serde_json::Value::Object(_)
+                ) {
+                    debug!(
+                        original = %s,
+                        "Repaired string-encoded structure into structured JSON"
+                    );
+                    return repair_string_encoded_structures(parsed);
+                }
+            }
+            value
+        }
+        other => other,
     }
 }
 
@@ -241,6 +283,68 @@ mod tests {
             s.contains("<|python_tag|>"),
             "expected begin token literal in grammar:\n{}",
             s
+        );
+    }
+
+    #[test]
+    fn extract_repairs_string_encoded_array_argument() {
+        // Direct reproduction of the empirical Llama-3.2-3B failure on
+        // test_tool_with_tuple: post-tool-response turns omit `<|python_tag|>`
+        // so the lazy grammar never re-fires; the sampler runs unconstrained and
+        // the model emits `string_int_pair` as a JSON-encoded string instead of
+        // an array. The handler recovers by walking parameters and re-parsing
+        // any String that round-trips to an Array or Object.
+        let input = r#"{"name":"multiply_strings","parameters":{"string_int_pair":"[\"BingBong\", 3]"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "multiply_strings");
+        assert_eq!(
+            calls[0].arguments,
+            json!({"string_int_pair": ["BingBong", 3]}),
+            "string-encoded array must be repaired into a real array"
+        );
+    }
+
+    #[test]
+    fn extract_repairs_string_encoded_object_argument() {
+        let input = r#"{"name":"calculate_volume","parameters":{"dimensions":"{\"width\":30,\"height\":20,\"depth\":10}"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(
+            calls[0].arguments,
+            json!({"dimensions": {"width": 30, "height": 20, "depth": 10}}),
+        );
+    }
+
+    #[test]
+    fn extract_does_not_coerce_legitimate_string_args() {
+        // Critical: the repair must NOT touch genuine string parameters even when
+        // they happen to round-trip through serde_json::from_str as a scalar.
+        // "42" parses as a number; coercing it would break tools whose parameter
+        // is actually `text: str`. Only Array/Object outputs should be repaired.
+        let input = r#"{"name":"sparklify","parameters":{"text":"42"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(
+            calls[0].arguments,
+            json!({"text": "42"}),
+            "scalar string args must remain strings even when JSON-parseable as number"
+        );
+
+        let input = r#"{"name":"sparklify","parameters":{"text":"true"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"text": "true"}));
+
+        let input = r#"{"name":"sparklify","parameters":{"text":"julemand"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"text": "julemand"}));
+    }
+
+    #[test]
+    fn extract_repairs_recursively_nested_string_encoding() {
+        // Some small variants double-encode. Walk the value tree.
+        let input = r#"{"name":"add_list_of_vectors","parameters":{"list_of_vectors":"[[1,2,3],[4,5,6]]"}}"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(
+            calls[0].arguments,
+            json!({"list_of_vectors": [[1, 2, 3], [4, 5, 6]]}),
         );
     }
 }

--- a/nobodywho/core/src/tool_calling/llama32.rs
+++ b/nobodywho/core/src/tool_calling/llama32.rs
@@ -1,5 +1,5 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{nt, seq, t, GrammarBuilder};
+use gbnf::builder::{alt, nt, seq, t, GrammarBuilder};
 use gbnf::json::json_schema_to_grammar;
 use gbnf::GbnfGrammar;
 use serde_json::json;
@@ -27,6 +27,29 @@ impl ToolFormatHandler for Llama32Handler {
         END
     }
 
+    /// Match either the `<|python_tag|>` prefix (turn 1, when chat template
+    /// hints the builtin Python interpreter path) or a bare `{` opening a JSON
+    /// object (turn 2+, when the model has dropped the prefix). The pattern
+    /// alternation is what allows the lazy grammar to re-fire on subsequent
+    /// tool-call turns; a single-token trigger keyed on `<|python_tag|>` only
+    /// fires the first time.
+    fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
+        Some(vec![r"<\|python_tag\|>".to_string(), r"\{".to_string()])
+    }
+
+    /// Llama-3.x small variants empirically loop on the same tool dispatch
+    /// instead of producing a final text answer once the tool result is in
+    /// scope (observed on `Llama-3.2-1B-Instruct-Q4_K_M.gguf` and
+    /// `Llama-3.2-3B-Instruct-Q4_K_M.gguf`). Matches Meta's tool-calling
+    /// spec and upstream consensus: llama.cpp `common/chat.cpp:1626`
+    /// hard-codes `auto max_calls = 1; // parallel toolcalls are not
+    /// supported` for Llama-3.x's JSON tool-call form, and vLLM documents
+    /// "Parallel tool calls are not supported for Llama 3, but it is
+    /// supported in Llama 4 models."
+    fn allow_repeated_calls(&self) -> bool {
+        false
+    }
+
     fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
         let tool_call_schemas: serde_json::Value = tools
             .iter()
@@ -47,10 +70,16 @@ impl ToolFormatHandler for Llama32Handler {
         let tool_call_schema = json!({ "oneOf": tool_call_schemas });
         let json_grammar = json_schema_to_grammar(tool_call_schema, "root")?;
 
+        // Pattern-based lazy trigger fires on either `<|python_tag|>` (turn 1)
+        // or a bare `{` (turn 2+). The grammar must accept both shapes since
+        // the matched portion is what the sampler feeds back into the grammar.
         let grammar = GrammarBuilder::from_existing(json_grammar)
             .rule(
                 "toolcall",
-                seq(&[t(BEGIN), nt("ws"), nt("root"), nt("ws")]),
+                alt(&[
+                    seq(&[t(BEGIN), nt("ws"), nt("root"), nt("ws")]),
+                    seq(&[nt("root"), nt("ws")]),
+                ]),
             )
             .rule("superroot", nt("toolcall"))
             .root("superroot")

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -328,6 +328,22 @@ pub trait ToolFormatHandler {
         None
     }
 
+    /// Whether the model may emit additional tool calls after the first
+    /// dispatch in a single user turn. Default: `true` — the chat loop keeps
+    /// the tool-call grammar active and re-extracts on every regeneration.
+    /// Override to `false` for families that empirically loop on the same
+    /// tool dispatch instead of producing a final text response (Llama-3.x
+    /// is the canonical case; cf. llama.cpp `common/chat.cpp:1626`
+    /// `auto max_calls = 1; // parallel toolcalls are not supported` and
+    /// vLLM's "parallel tool calls are not supported for Llama 3"). When
+    /// `false`, the chat loop dispatches the first tool call, then forces
+    /// the next regeneration to use the base sampler (no tool grammar) so
+    /// the model produces a plain-text answer to the user, and exits the
+    /// dispatch loop.
+    fn allow_repeated_calls(&self) -> bool {
+        true
+    }
+
     /// Generates a GBNF grammar for constrained sampling of tool calls.
     fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError>;
 
@@ -366,6 +382,10 @@ impl ToolFormat {
 
     pub fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
         self.handler().grammar_trigger_patterns()
+    }
+
+    pub fn allow_repeated_calls(&self) -> bool {
+        self.handler().allow_repeated_calls()
     }
 
     pub fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -7,9 +7,11 @@
 //! - FunctionGemma: `<start_function_call>call:name{param:<escape>val<escape>}<end_function_call>`
 //! - Gemma4: `<|tool_call>call:name{key:<|"|>val<|"|>}<tool_call|>`
 //! - Ministral3: `[TOOL_CALLS][{"name": "...", "arguments": {...}}]`
+//! - Llama-3.x: `<|python_tag|>{"name"|"function": "...", "parameters": {...}}<|eot_id|>` (prefix optional in extraction; model often omits it)
 
 mod functiongemma;
 mod gemma4;
+mod llama32;
 mod ministral3;
 mod qwen3;
 mod qwen35_36;
@@ -23,6 +25,7 @@ use tracing::debug;
 
 pub use functiongemma::FunctionGemmaHandler;
 pub use gemma4::Gemma4Handler;
+pub use llama32::Llama32Handler;
 pub use ministral3::Ministral3Handler;
 pub use qwen3::Qwen3Handler;
 pub use qwen35_36::Qwen35_36Handler;
@@ -359,6 +362,7 @@ pub enum ToolFormat {
     FunctionGemma(FunctionGemmaHandler),
     Gemma4(Gemma4Handler),
     Ministral3(Ministral3Handler),
+    Llama32(Llama32Handler),
 }
 
 impl ToolFormat {
@@ -369,6 +373,7 @@ impl ToolFormat {
             ToolFormat::FunctionGemma(h) => h,
             ToolFormat::Gemma4(h) => h,
             ToolFormat::Ministral3(h) => h,
+            ToolFormat::Llama32(h) => h,
         }
     }
 
@@ -463,6 +468,13 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         return Ok(ToolFormat::Ministral3(Ministral3Handler));
     }
 
+    // Check for Llama-3.x markers. Both signals are unique to Llama-3.1+
+    // tool-use templates; Llama-2 templates have neither.
+    if template_str.contains("Environment: ipython") || template_str.contains("<|python_tag|>") {
+        debug!("Detected Llama-3.x format from template markers");
+        return Ok(ToolFormat::Llama32(Llama32Handler));
+    }
+
     // Fall back to model metadata.
     if let Ok(arch) = model.meta_val_str("general.architecture") {
         debug!(architecture = %arch, "Checking model architecture for format hints");
@@ -474,6 +486,14 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         if arch_lower.starts_with("qwen3") {
             debug!("Detected Qwen3 format from architecture");
             return Ok(ToolFormat::Qwen3(Qwen3Handler));
+        }
+        // Llama-3.x architecture (after Qwen so Qwen-llama derivatives still
+        // match Qwen first). Llama-2 GGUFs have no tool-use template; the
+        // template marker check above already would have rejected them, so
+        // hitting this branch with arch="llama" implies a 3.x family.
+        if arch_lower.starts_with("llama") {
+            debug!("Detected Llama-3.x format from architecture");
+            return Ok(ToolFormat::Llama32(Llama32Handler));
         }
     }
 
@@ -500,6 +520,16 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
             debug!("Detected Qwen3 format from model name");
             return Ok(ToolFormat::Qwen3(Qwen3Handler));
         }
+
+        // Llama-3.x by name. Require the "3" suffix to avoid grabbing
+        // Llama-2 GGUFs which don't speak tool-use.
+        if name_lower.contains("llama-3")
+            || name_lower.contains("llama 3")
+            || name_lower.contains("llama3")
+        {
+            debug!("Detected Llama-3.x format from model name");
+            return Ok(ToolFormat::Llama32(Llama32Handler));
+        }
     }
 
     Err(ToolFormatError::UnsupportedFormat(
@@ -518,6 +548,13 @@ mod tests {
         let format = ToolFormat::Qwen3(Qwen3Handler);
         assert_eq!(format.begin_token(), "<tool_call>");
         assert_eq!(format.end_token(), "</tool_call>");
+    }
+
+    #[test]
+    fn test_llama32_format() {
+        let format = ToolFormat::Llama32(Llama32Handler);
+        assert_eq!(format.begin_token(), "<|python_tag|>");
+        assert_eq!(format.end_token(), "<|eot_id|>");
     }
 
     #[test]
@@ -623,8 +660,55 @@ mod tests {
             ToolFormat::FunctionGemma(_) => "FunctionGemma",
             ToolFormat::Gemma4(_) => "Gemma4",
             ToolFormat::Ministral3(_) => "Ministral3",
+            ToolFormat::Llama32(_) => "Llama32",
         };
         eprintln!("detected handler     = {variant}");
+    }
+
+    #[test]
+    #[ignore = "requires LLAMA32_MODEL env var pointing at a Llama-3.x GGUF"]
+    fn diagnose_llama32_detection() {
+        let path = std::env::var("LLAMA32_MODEL").expect("set LLAMA32_MODEL");
+        let model = crate::llm::get_model(&path, false, None, None).expect("load model");
+
+        let name = model
+            .language_model
+            .meta_val_str("general.name")
+            .unwrap_or_else(|_| "<no general.name>".into());
+        let arch = model
+            .language_model
+            .meta_val_str("general.architecture")
+            .unwrap_or_else(|_| "<no arch>".into());
+        eprintln!("general.name         = {name}");
+        eprintln!("general.architecture = {arch}");
+
+        let default_tmpl: String = model
+            .language_model
+            .chat_template(None)
+            .ok()
+            .and_then(|t| t.to_string().ok())
+            .unwrap_or_default();
+        for marker in ["Environment: ipython", "<|python_tag|>", "<|eot_id|>"] {
+            eprintln!(
+                "default_tmpl contains {marker:>22}: {}",
+                default_tmpl.contains(marker)
+            );
+        }
+
+        let fmt = detect_tool_format(&model.language_model).expect("detect_tool_format failed");
+        let variant = match fmt {
+            ToolFormat::Qwen3(_) => "Qwen3",
+            ToolFormat::Qwen35_36(_) => "Qwen35_36",
+            ToolFormat::FunctionGemma(_) => "FunctionGemma",
+            ToolFormat::Gemma4(_) => "Gemma4",
+            ToolFormat::Ministral3(_) => "Ministral3",
+            ToolFormat::Llama32(_) => "Llama32",
+        };
+        eprintln!("detected handler     = {variant}");
+        assert_eq!(
+            variant, "Llama32",
+            "expected Llama32 handler for {path}, got {variant}"
+        );
     }
 
     #[test]

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -184,20 +184,51 @@ impl Tool {
 }
 
 // Serialize tools according to https://huggingface.co/blog/unified-tool-use
+//
+// IMPORTANT: emit keys in EXPLICIT INSERTION ORDER (`type` before `function`,
+// inner `name` -> `description` -> `parameters`). The default `serde_json::json!`
+// path materialises a `Value::Object` backed by `BTreeMap`, which re-sorts keys
+// alphabetically. LFM2.5-350M is sensitive to that order — when fed
+// `{"function":{...},"type":"function"}` (alphabetical), it hallucinates extra
+// Pythonic kwargs (`parameters=`, `type=`) in the tool call. Using `serialize_map`
+// directly with nested helpers preserves the canonical OpenAI key order and
+// avoids forcing the `serde_json/preserve_order` cargo feature globally.
 impl Serialize for Tool {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": &self.name,
-                "description": &self.description,
-                "parameters": &self.json_schema,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            description: &'a str,
+            parameters: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(3))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("description", self.description)?;
+                m.serialize_entry("parameters", self.parameters)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            description: &self.description,
+            parameters: &self.json_schema,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -208,20 +239,48 @@ pub struct ToolCall {
     pub arguments: serde_json::Value,
 }
 
-// Serialize tools according to https://huggingface.co/blog/unified-tool-use
+// Serialize tool calls according to https://huggingface.co/blog/unified-tool-use
+// in canonical OpenAI key order (`type`, `function`, then within `function`:
+// `name`, `arguments`). Implemented via `serialize_map` rather than
+// `serde_json::json!({...}).serialize(serializer)` because the latter routes
+// through `serde_json::Value`'s default `BTreeMap` representation, which sorts
+// keys alphabetically (`{"function":{"arguments":...,"name":...},"type":...}`)
+// unless serde_json is built with the `preserve_order` feature — which is OFF
+// for the core/flutter/uniffi crates and which we cannot rely on downstream.
+// Same rationale as `Serialize for Tool` above.
 impl Serialize for ToolCall {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type" : "function",
-            "function": {
-                "name": &self.name,
-                "arguments": &self.arguments,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            arguments: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(2))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("arguments", self.arguments)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            arguments: &self.arguments,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -454,6 +513,29 @@ mod tests {
                     "parameters": {"type": "object"}
                 }
             })
+        );
+    }
+
+    #[test]
+    fn test_toolcall_serialization_preserves_canonical_key_order() {
+        // Regression guard for #519 review (gergelyvagujhelyi): the previous
+        // impl used `serde_json::json!({...}).serialize(serializer)`, which
+        // routes through `Value`'s default `BTreeMap` and emits keys in
+        // alphabetic order (`{"function":{"arguments":...,"name":...},...`)
+        // unless serde_json is built with `preserve_order` — OFF for the
+        // core/flutter/uniffi crates. Compare against the raw JSON string
+        // (NOT a Value) so any future regression to alphabetic ordering is
+        // caught even when a Value-equality check would still pass.
+        let call = ToolCall {
+            name: "circle_area".to_string(),
+            arguments: json!({"radius": 5}),
+        };
+        let serialized = serde_json::to_string(&call).expect("serialize ToolCall");
+        assert_eq!(
+            serialized,
+            r#"{"type":"function","function":{"name":"circle_area","arguments":{"radius":5}}}"#,
+            "ToolCall must serialize in canonical OpenAI key order \
+             (`type`, `function`, then `name`, `arguments`); got: {serialized}",
         );
     }
 

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -315,6 +315,19 @@ pub trait ToolFormatHandler {
     /// Returns the token that ends a tool call (e.g., "</tool_call>")
     fn end_token(&self) -> &str;
 
+    /// Optional list of regex patterns that activate the tool-call grammar in
+    /// the sampler. Returning `Some(_)` selects llama.cpp's pattern-based lazy
+    /// grammar (`grammar_lazy_patterns`); returning `None` falls back to the
+    /// single-token trigger keyed on `begin_token()`. Pattern triggers are
+    /// needed by handlers whose chat templates do not deterministically force
+    /// the begin token on every tool-call turn — Llama-3.x is the canonical
+    /// case: `<|python_tag|>` is emitted on the first tool-call turn but
+    /// omitted on post-tool-response turns, so the model emits raw `{...}`
+    /// JSON and a single-token trigger never re-fires.
+    fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
+        None
+    }
+
     /// Generates a GBNF grammar for constrained sampling of tool calls.
     fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError>;
 
@@ -349,6 +362,10 @@ impl ToolFormat {
 
     pub fn end_token(&self) -> &str {
         self.handler().end_token()
+    }
+
+    pub fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
+        self.handler().grammar_trigger_patterns()
     }
 
     pub fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -613,13 +613,18 @@ fn dart_function_type_to_json_schema(
         properties.insert(parameter_name.into(), parameter_type);
     }
 
+    // NOTE: do NOT add `additionalProperties: false` here. LFM2.5-350M (and likely
+    // other small models trained on plain JSON Schema, not OpenAI strict-mode) treats
+    // that field as a literal kwarg name and echoes it back in Pythonic tool calls,
+    // breaking the parser. JSON Schema's default (additional allowed) is fine — no
+    // enforcement happens client-side anyway, and Qwen3/Llama-3.2 tolerated either
+    // form on r5.
     tracing::debug!(
         "\n\n{}\n\n",
         serde_json::json!({
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": false
         })
     );
 
@@ -627,7 +632,6 @@ fn dart_function_type_to_json_schema(
         "type": "object",
         "properties": properties,
         "required": required,
-        "additionalProperties": false
     }))
 }
 
@@ -1055,7 +1059,6 @@ mod tests {
                 }
             },
             "required": ["name", "age", "tags"],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1069,7 +1072,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1084,7 +1086,6 @@ mod tests {
             "type": "object",
             "properties": { "text": { "type": "string" } },
             "required": [ "text" ],
-            "additionalProperties": false,
         });
         assert_eq!(json_schema, expected);
     }
@@ -1099,7 +1100,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }
@@ -1114,7 +1114,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }


### PR DESCRIPTION
Splits a chunk of #516 into smaller, independently-reviewable pieces, per @AsbjornOlling's request. This is **PR 2 of 3**.

Refs: #516, #214

## What this PR adds

A grammar-driven `ToolFormat::Llama32` handler covering Llama-3.1, 3.2, and 3.3 models that emit tool calls in the format:

```
<|python_tag|>{"name": "...", "parameters": {...}}<|eot_id|>
```

The `<|python_tag|>` prefix is treated as optional in extraction since the model often omits it.

### Files
- New: `core/src/tool_calling/llama32.rs` — `Llama32Handler` + `generate_grammar` + `extract_tool_calls` + tests.
- Modified: `core/src/tool_calling/mod.rs` — wire `ToolFormat::Llama32` variant + detection-chain entry (template-marker on `Environment: ipython` / `<|python_tag|>`).

### Detection
Template-marker first (covers Llama-3.1+ tool-use templates; Llama-2 templates have neither marker, so no false-positive).

## Independence
This PR does **not** depend on the engine-fixes PR. Llama-3.x handler is grammar-driven, so it's already insulated from the tool-schema-serialization issues that affect smaller parser-only models. Could be reviewed and merged in parallel.

## Stack
- Sibling: engine-fixes PR (independent)
- Sibling: LFM2.5 family tool calling PR (independent of this one)