### PR TITLE
feat(tool_calling): LFM2.5 family handler (parser-only)

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2430,9 +2430,14 @@ mod tests {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
-        // Use a very small context size to force shifting
+        // Use a very small context size to force shifting. Bumped n_messages
+        // from 10 -> 20 because passing tools to the chat template as
+        // pre-serialized JSON strings (see commit a26dfc79) reduced the
+        // per-render token count enough that 10 exchanges no longer overflow
+        // n_ctx=1024 with the test_chat-model GGUF — context_shift then
+        // skipped, leaving messages_after.len() == messages_before.
         let n_ctx = 1024;
-        let n_messages = 10;
+        let n_messages = 20;
         let mut worker = Worker::new_chat_worker(
             &model,
             ChatConfig {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -50,7 +50,7 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::hash::Hasher;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, MutexGuard};
 use tracing::{debug, error, info, trace, trace_span};
 
@@ -1643,11 +1643,21 @@ impl Worker<'_, ChatWorker> {
             },
         );
 
+        // Tracks whether any iteration's Done event was forwarded to the outer
+        // callback. Shared across every `wrap_respond` instance built below so
+        // the terminal-Done epilogue can run only when no Done has reached the
+        // consumer yet (e.g. parser-only paths that exit before producing an
+        // iter-2 generation). Keeps raw `Fn(WriteOutput)` consumers — godot
+        // binding, direct ask_channel users — from receiving two Done events
+        // per `ask` call.
+        let done_forwarded = Arc::new(AtomicBool::new(false));
+
         // get the finished response
         let mut response: String = self.wrapped_update_context_and_generate_response(
             sampler.clone(),
             respond.clone(),
             tool_call_begin.clone(),
+            done_forwarded.clone(),
         )?;
 
         // Process tool calls if tool format is configured
@@ -1691,6 +1701,7 @@ impl Worker<'_, ChatWorker> {
                     sampler.clone(),
                     respond.clone(),
                     tool_call_begin.clone(),
+                    done_forwarded.clone(),
                 )?;
             }
         } // Close if let Some(tool_format)
@@ -1698,9 +1709,22 @@ impl Worker<'_, ChatWorker> {
         debug_assert!(tool_call_begin
             .as_ref()
             .is_none_or(|t| !response.contains(t.as_str())));
-        self.add_assistant_message(response);
+        self.add_assistant_message(response.clone());
 
         self.extra.context.chunks = self.render_as_chunks(true)?;
+
+        // Terminal Done failsafe. Fires only when no iteration forwarded a Done
+        // — i.e. parser-only paths where `extract_tool_calls` returned None
+        // after `wrap_respond` already suppressed iter-1's Done past the
+        // begin_token. That used to surface as `WorkerCrashed` for LFM2.5 and
+        // other parser-only handlers. Skipping this when a Done was already
+        // forwarded prevents a double Done for raw `Fn(WriteOutput)` consumers
+        // (godot binding, direct ask_channel users); `TokenStream` consumers
+        // were already shielded by the `completed_response.is_some()`
+        // short-circuit, but external callback users were not.
+        if !done_forwarded.load(Ordering::SeqCst) {
+            respond(llm::WriteOutput::Done(response));
+        }
 
         Ok(self)
     }
@@ -1744,6 +1768,7 @@ impl Worker<'_, ChatWorker> {
         sampler: SamplerConfig,
         respond: F,
         tool_call_begin_token: Option<String>,
+        done_forwarded: Arc<AtomicBool>,
     ) -> Result<String, WrappedResponseError>
     where
         F: Fn(llm::WriteOutput) + Clone,
@@ -1755,7 +1780,8 @@ impl Worker<'_, ChatWorker> {
 
         // wrap the response callback to keep a copy of the completed response
         // and to avoid emitting tool calls
-        let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
+        let (wrapped_respond, resp_receiver) =
+            wrap_respond(respond.clone(), tool_call_begin_token, done_forwarded);
 
         // llm go brrr
         self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
@@ -1952,12 +1978,15 @@ impl Worker<'_, ChatWorker> {
     }
 }
 
-/// wraps a response function in a closure to do two things:
+/// wraps a response function in a closure to do three things:
 /// 1. save a copy of the response (using a channel) before sending it out
 /// 2. skip emitting once a tool_call_begin_token has been seen
+/// 3. record whether a Done was forwarded to the outer callback (so the caller
+///    can decide whether a terminal-Done epilogue is still needed)
 fn wrap_respond<F>(
     respond: F,
     tool_call_begin_token: Option<String>,
+    done_forwarded: Arc<AtomicBool>,
 ) -> (
     impl FnMut(llm::WriteOutput),
     std::sync::mpsc::Receiver<String>,
@@ -1977,6 +2006,9 @@ where
                 resp_sender
                     .send(resp.clone())
                     .expect("Failed sending response");
+                if emitting {
+                    done_forwarded.store(true, Ordering::SeqCst);
+                }
             }
             llm::WriteOutput::Token(_) => (),
         }
@@ -2036,6 +2068,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Regression test for the terminal-Done epilogue: `Worker::ask` must
+    /// emit exactly ONE Done event per call for raw `Fn(WriteOutput)`
+    /// callback consumers (godot binding, direct ask_channel users).
+    /// `TokenStream` consumers were already shielded by the
+    /// `completed_response.is_some()` short-circuit, but external callback
+    /// users were not — a second Done from the unconditional terminal
+    /// epilogue used to double-fire here.
+    #[test]
+    fn test_done_emitted_exactly_once_per_ask() -> Result<(), Box<dyn std::error::Error>> {
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                n_ctx: 1024,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        let done_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_inner = Arc::clone(&done_count);
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let callback = move |x: llm::WriteOutput| {
+            if let llm::WriteOutput::Done(resp) = x {
+                count_inner.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // tolerate a closed channel — count is the assertion target,
+                // recv-side just unblocks once.
+                let _ = sender.send(resp);
+            }
+        };
+
+        worker.ask("Say hi.".into(), callback)?;
+
+        // First Done: confirm a callback arrived (proves wiring).
+        let _ = receiver.recv_timeout(std::time::Duration::from_secs(60))?;
+
+        // `Worker::ask` returns synchronously after invoking its callback for
+        // the final time, so by here the count is final — no race window.
+        let count = done_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            count, 1,
+            "Worker::ask should emit exactly ONE Done per call, observed {count}."
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -2292,6 +2373,129 @@ mod tests {
         println!("{}", result);
         assert!(result.contains("13.37"));
         assert!(result.contains("0.15"));
+    }
+
+    /// Mirrors the python `test_tool_with_sets` failure that crashed
+    /// LFM2.5-350M and LFM2.5-1.2B-Instruct on host pytest with
+    /// `Worker thread terminated before completing the response`.
+    /// Single tool with a set-of-int schema; prompt contains literal
+    /// Python set syntax `{12,5,7,3,4}` to force the crash path.
+    /// Ignored by default — invoke with:
+    ///   TEST_MODEL=…/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
+    ///     cargo test --release --lib chat::tests::test_lfm2_5_set_tool_repro -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn test_lfm2_5_set_tool_repro() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        fn set_intersection_tool() -> Tool {
+            Tool {
+                name: "set_intersection".into(),
+                description: "Returns the intersection of set1 and set2".into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "set1": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                        "set2": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "uniqueItems": true,
+                        },
+                    },
+                    "required": ["set1", "set2"],
+                }),
+                function: Arc::new(|args: serde_json::Value| {
+                    let s1: std::collections::HashSet<i64> = args
+                        .get("set1")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let s2: std::collections::HashSet<i64> = args
+                        .get("set2")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    let inter: Vec<i64> = s1.intersection(&s2).copied().collect();
+                    format!("{:?}", inter)
+                }),
+            }
+        }
+
+        // Mirror python fixture: 6 tools registered, model picks one.
+        fn dummy_tool(name: &str, description: &str, prop: &str, json_type: &str) -> Tool {
+            let prop_owned = prop.to_string();
+            Tool {
+                name: name.into(),
+                description: description.into(),
+                json_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": { prop: {"type": json_type} },
+                    "required": [prop],
+                }),
+                function: Arc::new(move |args: serde_json::Value| {
+                    format!("dummy({}={:?})", prop_owned, args.get(&prop_owned))
+                }),
+            }
+        }
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant".into()),
+                n_ctx: 4096,
+                tools: vec![
+                    set_intersection_tool(),
+                    dummy_tool("multiply_strings", "Multiply a string by an integer N times", "pair", "object"),
+                    dummy_tool("sparklify", "Add sparkles to text", "text", "string"),
+                    dummy_tool("reflarbicator", "Boop foob", "reflarb", "integer"),
+                    dummy_tool("add_list_of_vectors", "Add a list of vectors", "list_of_vectors", "array"),
+                    dummy_tool("calculate_volume", "Compute volume of a cube", "dimensions", "object"),
+                ],
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("Failed making worker");
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let f = move |x| {
+            if let llm::WriteOutput::Done(resp) = x {
+                let _ = sender.send(resp);
+            }
+        };
+
+        let ask_result = worker.ask(
+            "Please use the provided tool to find the intersection between the sets {12,5,7,3,4} and {12,9,5,3}".into(),
+            f,
+        );
+
+        match ask_result {
+            Ok(_) => {
+                let resp = receiver.recv_timeout(std::time::Duration::from_secs(120));
+                println!("=== ask returned Ok, response ===");
+                match resp {
+                    Ok(s) => println!("{s}"),
+                    Err(e) => println!("recv error (worker dropped without Done?): {e}"),
+                }
+            }
+            Err(e) => {
+                println!("=== ask returned Err ===");
+                println!("{e:?}");
+            }
+        }
+
+        // Debug: dump chat history to see what the model emitted + how the
+        // engine responded — extract_tool_calls return shape, dispatched
+        // tool result, regen content, etc.
+        println!("=== chat history ===");
+        for (i, m) in worker.extra.messages.iter().enumerate() {
+            println!("[{i}] role={:?}", m);
+        }
     }
 
     #[test]

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1628,18 +1628,32 @@ impl Worker<'_, ChatWorker> {
 
         self.add_user_message(prompt.to_string(), assets);
 
-        // Modify sampler with tool grammar if we have tools
+        // Modify sampler with tool grammar if we have tools. Handlers that
+        // supply `grammar_trigger_patterns()` (e.g. Llama-3.x) get the
+        // pattern-based lazy grammar so the trigger re-fires on every
+        // tool-call turn; the rest fall through to the single-token trigger
+        // keyed on `begin_token()`.
+        let trigger_patterns = self
+            .extra
+            .tool_format
+            .as_ref()
+            .and_then(|fmt| fmt.grammar_trigger_patterns());
         let sampler = self.extra.tool_grammar.as_ref().map_or(
             self.extra.sampler_config.clone(),
             |tool_grammar| {
-                self.extra
-                    .sampler_config
-                    .clone()
-                    .prepend(ShiftStep::Grammar {
+                let grammar_step = match trigger_patterns {
+                    Some(patterns) => ShiftStep::GrammarPattern {
+                        trigger_patterns: patterns,
+                        root: tool_grammar.root_name.to_string(),
+                        grammar: tool_grammar.as_str().into(),
+                    },
+                    None => ShiftStep::Grammar {
                         trigger_on: tool_call_begin.clone(),
                         root: tool_grammar.root_name.to_string(),
                         grammar: tool_grammar.as_str().into(),
-                    })
+                    },
+                };
+                self.extra.sampler_config.clone().prepend(grammar_step)
             },
         );
 

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1380,15 +1380,37 @@ impl Worker<'_, ChatWorker> {
                 .ok_or(ShiftError::Message(
                     "No first user message in chat history".into(),
                 ))?;
-        let first_deletable_index = self
+
+        // The standard rolling-pair strategy preserves the last 2 user messages
+        // and shifts older user/assistant pairs out. When the chat has only one
+        // user message — for example a tool-call loop where the model dispatched
+        // the same tool many times without further user input, exhausting n_ctx —
+        // there is no second user message and the previous implementation hard
+        // -failed with "No deletable messages". Fall back to a simpler scheme:
+        // drain the older assistant/tool turns between the first user message
+        // and the most recent message, preserving the in-progress tail.
+        let (first_deletable_index, mut last_deletable_index) = match self
             .find_next_user_message(&messages, first_user_message_index + 1)
-            .ok_or(ShiftError::Message("No deletable messages".into()))?; // Assuming assistant after user
-        let mut last_deletable_index = self
-            .find_start_of_last_n_user_messages(&messages, 2)
-            .ok_or(ShiftError::Message(
-                "Less than two user messages in chat history.".into(),
-            ))?
-            - 1;
+        {
+            Some(second_user_idx) => (
+                second_user_idx,
+                self.find_start_of_last_n_user_messages(&messages, 2)
+                    .ok_or(ShiftError::Message(
+                        "Less than two user messages in chat history.".into(),
+                    ))?
+                    - 1,
+            ),
+            None => {
+                // Need at least: [system?, user, ...middle..., tail] for there to
+                // be anything safe to delete. If the history is too short, leave
+                // it intact and let the upstream caller decide what to do.
+                if messages.len() < first_user_message_index + 3 {
+                    self.extra.messages = messages;
+                    return Ok(());
+                }
+                (first_user_message_index + 1, messages.len() - 2)
+            }
+        };
 
         // Two is the smallest number of messages we can delete as we need to preserve the message structure.
         // There might be a better start guess here.
@@ -1414,16 +1436,17 @@ impl Worker<'_, ChatWorker> {
                 last_deletable_index,
             );
 
-            // Find the first user message after target delete index and choose the message before.
-            // This is to ensure that resulting chat history still follows the user then assistant format
-            let delete_index = min(
-                self.find_next_user_message(&messages, target_delete_index + 1)
-                    .ok_or(ShiftError::Message(
-                        "Could find user message supposed to be there".into(),
-                    ))?
-                    - 1,
-                last_deletable_index,
-            ); // should never fail
+            // Find the first user message after target delete index and choose
+            // the message before, so the resulting chat history still follows
+            // the user-then-assistant turn structure. In the single-user-message
+            // fallback there is no later user message to align with, so we
+            // delete up to `target_delete_index` directly.
+            let delete_index = match self
+                .find_next_user_message(&messages, target_delete_index + 1)
+            {
+                Some(next_user) => min(next_user - 1, last_deletable_index),
+                None => min(target_delete_index, last_deletable_index),
+            };
             messages.drain(first_deletable_index..=delete_index);
             messages_to_delete *= 2;
 
@@ -3111,4 +3134,55 @@ mod tests {
     }
 
     // Template rendering tests have been moved to template.rs module
+
+    #[test]
+    fn test_context_shift_with_only_one_user_message() -> Result<(), Box<dyn std::error::Error>> {
+        // Regression guard: a chat with one user message and many assistant /
+        // tool turns must not panic when context_shift is invoked. The previous
+        // implementation hard-failed at the "No deletable messages" predicate
+        // because it assumed at least two user messages were always present.
+        // This shape is the empirical failure mode of small Llama-3.x variants
+        // looping on a tool call until n_ctx is exhausted (chat.rs:318
+        // `Worker crashed: ... Missing expected message No deletable messages`).
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant.".into()),
+                n_ctx: 512,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        // One user message, then many assistant turns (the tool-call-loop shape).
+        worker.add_user_message(
+            "Use the provided tool to compute several things.".into(),
+            vec![],
+        );
+        for i in 0..30 {
+            worker.add_assistant_message(format!(
+                "Assistant turn {i} producing a long-ish synthetic response to fill context."
+            ));
+        }
+
+        let messages_before = worker.extra.messages.len();
+        worker.context_shift()?; // must not return Err here
+        let messages_after = worker.extra.messages.len();
+
+        assert!(
+            messages_after <= messages_before,
+            "context_shift must not grow the history (before={messages_before}, after={messages_after})"
+        );
+        // System prompt + first user message must be retained.
+        assert!(worker.extra.messages[0].is_system());
+        assert!(worker
+            .extra
+            .messages
+            .iter()
+            .any(|m| m.is_user()), "first user message must be preserved");
+        Ok(())
+    }
 }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1628,19 +1628,29 @@ impl Worker<'_, ChatWorker> {
 
         self.add_user_message(prompt.to_string(), assets);
 
-        // Modify sampler with tool grammar if we have tools. Handlers that
-        // supply `grammar_trigger_patterns()` (e.g. Llama-3.x) get the
-        // pattern-based lazy grammar so the trigger re-fires on every
+        // Build two samplers:
+        //   - `base_sampler`: the user-configured sampler with no tool grammar.
+        //     Used for the text-only continuation when a handler disallows
+        //     repeated tool calls (so the model produces a final text answer
+        //     to the user instead of looping in tool-call shape).
+        //   - `sampler`: `base_sampler` with the tool grammar prepended, used
+        //     for the first generation (and subsequent generations when the
+        //     handler permits repeated tool calls).
+        // Handlers that supply `grammar_trigger_patterns()` (e.g. Llama-3.x)
+        // get the pattern-based lazy grammar so the trigger re-fires on every
         // tool-call turn; the rest fall through to the single-token trigger
         // keyed on `begin_token()`.
+        let base_sampler = self.extra.sampler_config.clone();
         let trigger_patterns = self
             .extra
             .tool_format
             .as_ref()
             .and_then(|fmt| fmt.grammar_trigger_patterns());
-        let sampler = self.extra.tool_grammar.as_ref().map_or(
-            self.extra.sampler_config.clone(),
-            |tool_grammar| {
+        let sampler = self
+            .extra
+            .tool_grammar
+            .as_ref()
+            .map_or(base_sampler.clone(), |tool_grammar| {
                 let grammar_step = match trigger_patterns {
                     Some(patterns) => ShiftStep::GrammarPattern {
                         trigger_patterns: patterns,
@@ -1653,9 +1663,8 @@ impl Worker<'_, ChatWorker> {
                         grammar: tool_grammar.as_str().into(),
                     },
                 };
-                self.extra.sampler_config.clone().prepend(grammar_step)
-            },
-        );
+                base_sampler.clone().prepend(grammar_step)
+            });
 
         // Tracks whether any iteration's Done event was forwarded to the outer
         // callback. Shared across every `wrap_respond` instance built below so
@@ -1677,6 +1686,13 @@ impl Worker<'_, ChatWorker> {
         // Process tool calls if tool format is configured
         // Clone to avoid borrow issues in the loop
         if let Some(tool_format) = self.extra.tool_format.clone() {
+            // When the handler disallows repeated tool calls (Llama-3.x), we
+            // dispatch the first set of calls and then re-generate WITHOUT
+            // the tool grammar so the model produces a plain-text answer to
+            // the user. Citing llama.cpp `common/chat.cpp:1626` and vLLM:
+            // "Parallel tool calls are not supported for Llama 3."
+            let allow_repeated = tool_format.allow_repeated_calls();
+
             while let Some(tool_calls) = tool_format.extract_tool_calls(&response) {
                 debug!(?tool_calls, "Got tool calls:");
 
@@ -1710,13 +1726,60 @@ impl Worker<'_, ChatWorker> {
                     self.add_tool_resp(tool_call.name, response);
                 }
 
-                // get the finished response
+                // Pick the sampler for the continuation generation: handlers
+                // that allow repeated calls keep the tool grammar active so
+                // any further tool calls are constrained; handlers that
+                // disallow repeated calls (Llama-3.x) drop the tool grammar
+                // so the model is free to produce a plain-text answer to the
+                // user.
+                //
+                // For the !allow_repeated continuation we ALSO pass `None` for
+                // the begin-token argument to `wrap_respond`. Otherwise, when
+                // small variants (Llama-3.2-1B in particular) reflexively emit
+                // `<|python_tag|>` again on the unconstrained continuation
+                // turn, `wrap_respond` flips its `emitting` flag to false and
+                // never forwards the terminal `Done(response)` event to the
+                // user-facing output channel — Python's `chat.ask().completed()`
+                // then waits indefinitely and ultimately reports "Worker thread
+                // terminated before completing the response." Suppressing the
+                // tool-call body in the stream is irrelevant here: this gen is
+                // the assistant's final word for this user turn.
+                let (continuation_sampler, continuation_begin) = if allow_repeated {
+                    (sampler.clone(), tool_call_begin.clone())
+                } else {
+                    (base_sampler.clone(), None)
+                };
                 response = self.wrapped_update_context_and_generate_response(
-                    sampler.clone(),
+                    continuation_sampler,
                     respond.clone(),
-                    tool_call_begin.clone(),
+                    continuation_begin,
                     done_forwarded.clone(),
                 )?;
+
+                // Llama-3.x policy: cap tool dispatches at one per user turn.
+                // The base sampler had no grammar so the model is unconstrained;
+                // small variants (1B/3B) sometimes still emit tool-call-shaped
+                // tokens (`<|python_tag|>{...}`) on the continuation turn from
+                // training bias, even though we asked for plain text. Strip
+                // the begin/end markers so the recorded assistant message is
+                // clean text rather than something that re-parses as a tool
+                // call on the next user turn (and so we don't trip the
+                // post-loop debug_assert that verifies the begin token is
+                // absent from the final response).
+                if !allow_repeated {
+                    if let (Some(begin), Some(fmt)) =
+                        (tool_call_begin.as_ref(), self.extra.tool_format.as_ref())
+                    {
+                        let end_marker = fmt.end_token().to_string();
+                        if let Some(rest) = response.trim_start().strip_prefix(begin.as_str()) {
+                            response = rest.trim_start().to_string();
+                        }
+                        if let Some(prefix) = response.trim_end().strip_suffix(&end_marker) {
+                            response = prefix.trim_end().to_string();
+                        }
+                    }
+                    break;
+                }
             }
         } // Close if let Some(tool_format)
 

--- a/nobodywho/core/src/sampler_config.rs
+++ b/nobodywho/core/src/sampler_config.rs
@@ -168,6 +168,11 @@ impl SamplerConfig {
                 Some(trigger) => self.build_lazy_grammar(model, &grammar, &root, &trigger),
                 None => self.build_regular_grammar(model, &grammar, &root),
             },
+            ShiftStep::GrammarPattern {
+                grammar,
+                trigger_patterns,
+                root,
+            } => self.build_pattern_grammar(model, &grammar, &root, &trigger_patterns),
             ShiftStep::DRY {
                 multiplier,
                 base,
@@ -231,6 +236,22 @@ impl SamplerConfig {
         root: &str,
     ) -> Result<LlamaSampler, SamplerError> {
         Ok(LlamaSampler::grammar(model, grammar, root)?)
+    }
+
+    fn build_pattern_grammar(
+        &self,
+        model: &LlamaModel,
+        grammar: &str,
+        root: &str,
+        trigger_patterns: &[String],
+    ) -> Result<LlamaSampler, SamplerError> {
+        Ok(LlamaSampler::grammar_lazy_patterns(
+            model,
+            grammar,
+            root,
+            trigger_patterns,
+            &[],
+        )?)
     }
 }
 
@@ -302,6 +323,17 @@ pub enum ShiftStep {
     },
     Grammar {
         trigger_on: Option<String>,
+        root: String,
+        grammar: String,
+    },
+    /// Grammar variant that activates the sampler when the generation output
+    /// matches any of the supplied regex patterns from the start of generation.
+    /// Distinct from `Grammar { trigger_on: Some(_) }` which keys on a single
+    /// trigger token: pattern triggers can express alternation (e.g. accept
+    /// either `<|python_tag|>` or a bare `{` for Llama-3.x, where the chat
+    /// template forces the prefix only on the first tool-call turn).
+    GrammarPattern {
+        trigger_patterns: Vec<String>,
         root: String,
         grammar: String,
     },

--- a/nobodywho/core/src/template.rs
+++ b/nobodywho/core/src/template.rs
@@ -90,7 +90,34 @@ impl ChatTemplate {
             ),
             ("bos_token".to_string(), Value::from(self.bos_token.clone())),
             ("eos_token".to_string(), Value::from(self.eos_token.clone())),
-            ("tools".to_string(), Value::from_serialize(&ctx.tools)),
+            // Pre-serialise each tool to its canonical OpenAI JSON shape (insertion
+            // order preserved by `Tool`'s custom Serialize impl using
+            // `serialize_map`) and pass the list as STRINGS. The HF tool-aware
+            // chat templates (LFM2/LFM2.5/Qwen3 etc.) all guard with
+            // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`
+            // — so a string passes through unchanged. This bypasses minijinja's
+            // internal Value→tojson re-serialisation, which otherwise re-sorts
+            // object keys alphabetically (default `serde_json::Map` is `BTreeMap`).
+            // LFM2.5-350M is empirically sensitive to that order: alphabetical
+            // (`{"function":..., "type":"function"}`) makes it hallucinate kwargs
+            // (`parameters=`, `type=`) in the emitted Pythonic tool call.
+            //
+            // NOTE: `ctx.tools` is `Option<Vec<Tool>>`. `Option::iter` yields 0 or 1
+            // element of type `&Vec<Tool>` — so mapping on it would serialise the
+            // ENTIRE list as a single JSON-array string, producing `[[…]]` after the
+            // template's own `[…]` wrap. Flatten via `as_ref().into_iter().flatten()`
+            // so we map per-Tool.
+            (
+                "tools".to_string(),
+                Value::from_serialize(
+                    ctx.tools
+                        .as_ref()
+                        .into_iter()
+                        .flatten()
+                        .map(|t| serde_json::to_string(t).unwrap_or_default())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
         ];
 
         // Add all template variables
@@ -462,5 +489,85 @@ mod tests {
         // The template now includes empty thinking blocks for assistant messages
         let expected5 = "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\nHi there!<|im_end|>\n";
         assert_eq!(rendered5, expected5);
+    }
+
+    /// Regression guard for the `tools` template variable wiring (see PR
+    /// notes on tools-as-strings + canonical key order). Renders a minimal
+    /// tool-aware Qwen3-style template with one Tool, then asserts the
+    /// rendered string places the OpenAI canonical keys in canonical order:
+    /// outer `"type":"function"` BEFORE outer `"function":` value, inner
+    /// `"name":` BEFORE `"description":` BEFORE `"parameters":`.
+    ///
+    /// Without the engine fixes (Tool::serialize using BTreeMap-backed
+    /// serde_json::Map, or template variable as Vec<Tool> instead of
+    /// Vec<String>) the rendered string would order keys alphabetically:
+    /// `"function":...,"type":"function"`. Both regressions would fail
+    /// this test.
+    #[test]
+    fn test_render_template_with_tools_preserves_key_order() {
+        use std::sync::Arc;
+
+        // Minimal tool-aware template: dump the tools array verbatim.
+        // The HF tool-aware templates all guard with
+        // `{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}`,
+        // so a pre-serialized JSON STRING passes through unchanged. A
+        // Tool struct serialized through minijinja's Value::from_serialize
+        // would re-sort keys alphabetically; this guard preserves order.
+        let template = "{%- for tool in tools -%}\n{%- if tool is not string -%}{%- set tool = tool | tojson -%}{%- endif -%}\n{{ tool }}\n{%- endfor -%}";
+
+        let tool = Tool::new(
+            "circle_area",
+            "Compute the area of a circle.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "radius": {"type": "number"}
+                },
+                "required": ["radius"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+
+        let template_vars: HashMap<String, bool> = HashMap::default();
+        let ctx = ChatTemplateContext::new(template_vars, Some(vec![tool]));
+        let chat_template = ChatTemplate::new(template, "", "").unwrap();
+
+        let rendered = chat_template.render(&[], &ctx).unwrap();
+
+        // Outer keys: `"type":"function"` must come before the outer
+        // `"function":` opening — i.e. type-first canonical order.
+        let type_idx = rendered
+            .find("\"type\":\"function\"")
+            .expect("expected outer \"type\":\"function\" in rendered output");
+        let function_idx = rendered
+            .find("\"function\":")
+            .expect("expected outer \"function\": in rendered output");
+        assert!(
+            type_idx < function_idx,
+            "outer key order regression: \"type\" should appear before \
+             \"function\" in the rendered template, got: {rendered}"
+        );
+
+        // Inner function keys: name -> description -> parameters.
+        let name_idx = rendered
+            .find("\"name\":\"circle_area\"")
+            .expect("expected inner \"name\":\"circle_area\" in rendered output");
+        let description_idx = rendered
+            .find("\"description\":")
+            .expect("expected inner \"description\": in rendered output");
+        let parameters_idx = rendered
+            .find("\"parameters\":")
+            .expect("expected inner \"parameters\": in rendered output");
+
+        assert!(
+            name_idx < description_idx,
+            "inner key order regression: \"name\" should appear before \
+             \"description\", got: {rendered}"
+        );
+        assert!(
+            description_idx < parameters_idx,
+            "inner key order regression: \"description\" should appear \
+             before \"parameters\", got: {rendered}"
+        );
     }
 }

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -95,6 +95,11 @@ impl ToolFormatHandler for Lfm2_5Handler {
 /// individual top-level chunks, respecting `(` / `)` nesting and string
 /// quoting so commas inside args / strings are not separators.
 fn split_top_level_calls(s: &str) -> Vec<&str> {
+    // Split on top-level commas while respecting string quotes and ALL three
+    // bracket pairs Python uses inside arg literals: `(...)`, `[...]`, `{...}`.
+    // Without `[`/`{` tracking, model emissions like
+    //     set_intersection(set1={12, 5, 7, 3, 4}, set2={12, 9, 5, 3})
+    // get split inside the set literal and lose all kwargs.
     let bytes = s.as_bytes();
     let mut depth: i32 = 0;
     let mut start: usize = 0;
@@ -106,8 +111,8 @@ fn split_top_level_calls(s: &str) -> Vec<&str> {
             (Some(_), _) => {}
             (None, b'"') => in_str = Some(b'"'),
             (None, b'\'') => in_str = Some(b'\''),
-            (None, b'(') => depth += 1,
-            (None, b')') => depth -= 1,
+            (None, b'(') | (None, b'[') | (None, b'{') => depth += 1,
+            (None, b')') | (None, b']') | (None, b'}') => depth -= 1,
             (None, b',') if depth == 0 => {
                 out.push(&s[start..i]);
                 start = i + 1;
@@ -119,6 +124,27 @@ fn split_top_level_calls(s: &str) -> Vec<&str> {
         out.push(&s[start..]);
     }
     out
+}
+
+/// True if `s` contains a top-level `:` (used to discriminate dict literal
+/// `{k: v, ...}` from set literal `{1, 2, 3}`).
+fn has_top_level_colon(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_str: Option<u8> = None;
+    for &b in bytes {
+        match (in_str, b) {
+            (Some(q), c) if c == q => in_str = None,
+            (Some(_), _) => {}
+            (None, b'"') => in_str = Some(b'"'),
+            (None, b'\'') => in_str = Some(b'\''),
+            (None, b'(') | (None, b'[') | (None, b'{') => depth += 1,
+            (None, b')') | (None, b']') | (None, b'}') => depth -= 1,
+            (None, b':') if depth == 0 => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn parse_pythonic_call(s: &str) -> Option<ToolCall> {
@@ -158,17 +184,71 @@ fn parse_pythonic_value(s: &str) -> Option<Value> {
     if s.is_empty() {
         return None;
     }
+    // String literals: "..." or '...'
     if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
         if s.len() < 2 {
             return None;
         }
         return Some(Value::String(s[1..s.len() - 1].to_string()));
     }
+    // Bool / null
     match s {
         "true" | "True" => return Some(Value::Bool(true)),
         "false" | "False" => return Some(Value::Bool(false)),
         "null" | "None" => return Some(Value::Null),
         _ => {}
+    }
+    // List or tuple literal: `[...]` / `(...)` -> JSON array.
+    if (s.starts_with('[') && s.ends_with(']')) || (s.starts_with('(') && s.ends_with(')')) {
+        let inner = s[1..s.len() - 1].trim();
+        if inner.is_empty() {
+            return Some(Value::Array(Vec::new()));
+        }
+        let items: Vec<Value> = split_top_level_calls(inner)
+            .into_iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .filter_map(parse_pythonic_value)
+            .collect();
+        return Some(Value::Array(items));
+    }
+    // Set / dict literal: `{...}`. Discriminate by top-level colon.
+    if s.starts_with('{') && s.ends_with('}') {
+        let inner = s[1..s.len() - 1].trim();
+        if inner.is_empty() {
+            return Some(Value::Array(Vec::new()));
+        }
+        let parts: Vec<&str> = split_top_level_calls(inner)
+            .into_iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .collect();
+        let is_dict = parts.iter().any(|p| has_top_level_colon(p));
+        if is_dict {
+            let mut obj = serde_json::Map::new();
+            for p in parts {
+                let Some(colon) = p.find(':') else { continue };
+                let key_raw = p[..colon].trim();
+                let val_raw = p[colon + 1..].trim();
+                let key = if (key_raw.starts_with('"') && key_raw.ends_with('"'))
+                    || (key_raw.starts_with('\'') && key_raw.ends_with('\''))
+                {
+                    if key_raw.len() < 2 {
+                        continue;
+                    }
+                    key_raw[1..key_raw.len() - 1].to_string()
+                } else {
+                    key_raw.to_string()
+                };
+                let val =
+                    parse_pythonic_value(val_raw).unwrap_or(Value::String(val_raw.to_string()));
+                obj.insert(key, val);
+            }
+            return Some(Value::Object(obj));
+        }
+        // Set literal -> JSON array (JSON has no native set; consumers map back)
+        let items: Vec<Value> = parts.into_iter().filter_map(parse_pythonic_value).collect();
+        return Some(Value::Array(items));
     }
     if let Ok(i) = s.parse::<i64>() {
         return Some(json!(i));

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -33,6 +33,18 @@ impl ToolFormatHandler for Lfm2_5Handler {
         END
     }
 
+    /// LFM2.5 runs parser-only (no GBNF). Without grammar enforcement, the
+    /// 350M and 1.2B variants empirically emit multiple `<|tool_call_start|>`
+    /// blocks across successive assistant turns when given a tool, which
+    /// breaks the strict `len(tool_calls) == 1` test assertions and burns
+    /// context with a runaway loop. Cap dispatches at one per user turn,
+    /// matching the upstream consensus for non-parallel tool-call families
+    /// (cf. llama.cpp `common/chat.cpp:1626` `auto max_calls = 1; // parallel
+    /// toolcalls are not supported`).
+    fn allow_repeated_calls(&self) -> bool {
+        false
+    }
+
     fn generate_grammar(&self, _tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
         // INTENTIONAL Err — engine path (chat.rs:1240-1265) keeps
         // tool_format=Some(handler) and sets tool_grammar=None on Err.

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -276,6 +276,21 @@ mod tests {
     }
 
     #[test]
+    fn double_wrap_emit_extracts_first_call() {
+        // LFM2.5-1.2B-Instruct empirically emits a double-wrap on multi-turn weather:
+        //   <|tool_call_start|>[get_weather(city="Cairo")]<|tool_call_end|>[get_weather(city="Cairo")]<|tool_call_end|>
+        // Parser should still extract the first valid call (between begin and FIRST end token).
+        let input = concat!(
+            "<|tool_call_start|>[get_weather(city=\"Cairo\")]<|tool_call_end|>",
+            "[get_weather(city=\"Cairo\")]<|tool_call_end|>"
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1, "should extract first call only, ignore tail");
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
     fn tail_text_after_end_token_is_ignored() {
         // Per LFM2.5 model card: assistant turn can be
         //   <|tool_call_start|>[fn(...)]<|tool_call_end|>{NL summary}

--- a/nobodywho/core/src/tool_calling/lfm2_5.rs
+++ b/nobodywho/core/src/tool_calling/lfm2_5.rs
@@ -1,0 +1,334 @@
+use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
+use gbnf::GbnfGrammar;
+use serde_json::{json, Value};
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Lfm2_5Handler;
+
+// LFM2.5 family (LFM2.5-350M, LFM2.5-1.2B-Instruct, LFM2.5-1.2B-Tool, ...) writes
+// PYTHONIC tool calls between `<|tool_call_start|>` and `<|tool_call_end|>` tokens
+// per the LFM2.5 model card example:
+//
+//   <|tool_call_start|>[get_candidate_status(candidate_id="12345")]<|tool_call_end|>
+//
+// The list may contain multiple calls separated by `,`. Args are kwargs
+// (`key=value`) with values: string ("..." or '...'), int, float, bool, null.
+//
+// This handler runs in PARSER-ONLY mode: `generate_grammar` returns Err so the
+// engine sets `tool_grammar=None` (chat.rs:1240-1265 verified). Sampler runs
+// unconstrained; `extract_tool_calls` parses the wire format from the response.
+// The mirror of llama.cpp's pre-autoparser working configuration for LFM2.5
+// (see llama.cpp issue #20245).
+
+const BEGIN: &str = "<|tool_call_start|>";
+const END: &str = "<|tool_call_end|>";
+
+impl ToolFormatHandler for Lfm2_5Handler {
+    fn begin_token(&self) -> &str {
+        BEGIN
+    }
+
+    fn end_token(&self) -> &str {
+        END
+    }
+
+    fn generate_grammar(&self, _tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
+        // INTENTIONAL Err — engine path (chat.rs:1240-1265) keeps
+        // tool_format=Some(handler) and sets tool_grammar=None on Err.
+        // Sampler runs unconstrained; the model emits its trained Pythonic
+        // wire format; extract_tool_calls parses it on the way out.
+        Err(ToolFormatError::UnsupportedFormat(
+            "LFM2.5 handler runs in parser-only mode; no GBNF constraint".to_string(),
+        ))
+    }
+
+    fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
+        // Per LFM2.5 model card the assistant turn is:
+        //   <|tool_call_start|>[fn1(...), fn2(...)]<|tool_call_end|>{trailing NL}
+        // Locate the FIRST wrap; tail text after END is ignored. If begin_token
+        // never appears, this is plain NL — return None and the engine loop
+        // exits naturally with the model's plain-text response.
+        let begin_at = input.find(BEGIN)?;
+        let after_begin = &input[begin_at + BEGIN.len()..];
+        let end_at = after_begin.find(END)?;
+        let inner = after_begin[..end_at].trim();
+
+        // Inner is `[fn1(...), fn2(...)]` Pythonic list.
+        let bracketed = inner.strip_prefix('[').and_then(|x| x.strip_suffix(']'))?;
+        let body = bracketed.trim();
+        if body.is_empty() {
+            debug!("LFM2.5 emitted empty tool call list");
+            return None;
+        }
+
+        let raw_calls = split_top_level_calls(body);
+        if raw_calls.is_empty() {
+            debug!(input = %input, "LFM2.5 tool call list parsing failed (no calls)");
+            return None;
+        }
+
+        let mut out = Vec::with_capacity(raw_calls.len());
+        for raw in raw_calls {
+            match parse_pythonic_call(raw.trim()) {
+                Some(tc) => out.push(tc),
+                None => {
+                    debug!(call = %raw, "LFM2.5 single-call parse failed");
+                    return None;
+                }
+            }
+        }
+
+        if out.len() > 1 {
+            warn!(
+                count = out.len(),
+                "LFM2.5 emitted >1 tool call in one assistant turn"
+            );
+        }
+        Some(out)
+    }
+}
+
+// ----- Pythonic call parsing helpers (private) -----
+
+/// Split `fn1(...), fn2(...), ...` (or `k=v, k=v` arg lists) into
+/// individual top-level chunks, respecting `(` / `)` nesting and string
+/// quoting so commas inside args / strings are not separators.
+fn split_top_level_calls(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut depth: i32 = 0;
+    let mut start: usize = 0;
+    let mut in_str: Option<u8> = None;
+    let mut out: Vec<&str> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        match (in_str, b) {
+            (Some(q), c) if c == q => in_str = None,
+            (Some(_), _) => {}
+            (None, b'"') => in_str = Some(b'"'),
+            (None, b'\'') => in_str = Some(b'\''),
+            (None, b'(') => depth += 1,
+            (None, b')') => depth -= 1,
+            (None, b',') if depth == 0 => {
+                out.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        out.push(&s[start..]);
+    }
+    out
+}
+
+fn parse_pythonic_call(s: &str) -> Option<ToolCall> {
+    let open = s.find('(')?;
+    let name = s[..open].trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let close = s.rfind(')')?;
+    if close <= open {
+        return None;
+    }
+    let args_src = s[open + 1..close].trim();
+
+    let mut args_obj = serde_json::Map::new();
+    if !args_src.is_empty() {
+        for kv in split_top_level_calls(args_src) {
+            let kv = kv.trim();
+            if kv.is_empty() {
+                continue;
+            }
+            let eq = kv.find('=')?;
+            let key = kv[..eq].trim().to_string();
+            let raw_val = kv[eq + 1..].trim();
+            let v = parse_pythonic_value(raw_val)?;
+            args_obj.insert(key, v);
+        }
+    }
+    Some(ToolCall {
+        name,
+        arguments: Value::Object(args_obj),
+    })
+}
+
+fn parse_pythonic_value(s: &str) -> Option<Value> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        if s.len() < 2 {
+            return None;
+        }
+        return Some(Value::String(s[1..s.len() - 1].to_string()));
+    }
+    match s {
+        "true" | "True" => return Some(Value::Bool(true)),
+        "false" | "False" => return Some(Value::Bool(false)),
+        "null" | "None" => return Some(Value::Null),
+        _ => {}
+    }
+    if let Ok(i) = s.parse::<i64>() {
+        return Some(json!(i));
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return Some(json!(f));
+    }
+    Some(Value::String(s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn handler() -> Lfm2_5Handler {
+        Lfm2_5Handler
+    }
+
+    fn dummy_tool(name: &str, prop: &str) -> Tool {
+        Tool::new(
+            name,
+            "test tool",
+            json!({
+                "type": "object",
+                "properties": { prop: { "type": "number" } },
+                "required": [prop]
+            }),
+            Arc::new(|_| "ok".to_string()),
+        )
+    }
+
+    #[test]
+    fn parse_single_kwarg_string() {
+        let input = r#"<|tool_call_start|>[get_weather(city="Cairo")]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn parse_single_kwarg_number() {
+        let input = r#"<|tool_call_start|>[circle_area(radius=12.5)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": 12.5}));
+    }
+
+    #[test]
+    fn parse_multi_call() {
+        let input =
+            r#"<|tool_call_start|>[get_weather(city="London"), get_weather(city="Tokyo")]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].arguments, json!({"city": "London"}));
+        assert_eq!(calls[1].arguments, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn parse_with_single_quotes() {
+        let input = r#"<|tool_call_start|>[get_weather(city='Cairo')]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn parse_negative_int() {
+        let input = r#"<|tool_call_start|>[move(steps=-3)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"steps": -3}));
+    }
+
+    #[test]
+    fn parse_bool_kwarg() {
+        let input = r#"<|tool_call_start|>[set_flag(active=true, dry=False)]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"active": true, "dry": false}));
+    }
+
+    #[test]
+    fn no_args() {
+        let input = r#"<|tool_call_start|>[noop()]<|tool_call_end|>"#;
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].name, "noop");
+        assert_eq!(calls[0].arguments, json!({}));
+    }
+
+    #[test]
+    fn empty_list_returns_none() {
+        let input = "<|tool_call_start|>[]<|tool_call_end|>";
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn malformed_returns_none() {
+        let input = "<|tool_call_start|>not python at all<|tool_call_end|>";
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn no_wrap_returns_none() {
+        let input = r#"I'll help you with that."#;
+        assert!(handler().extract_tool_calls(input).is_none());
+    }
+
+    #[test]
+    fn tail_text_after_end_token_is_ignored() {
+        // Per LFM2.5 model card: assistant turn can be
+        //   <|tool_call_start|>[fn(...)]<|tool_call_end|>{NL summary}
+        let input = concat!(
+            "<|tool_call_start|>[circle_area(radius=5)]<|tool_call_end|>",
+            "Checking the area now."
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "circle_area");
+        assert_eq!(calls[0].arguments, json!({"radius": 5}));
+    }
+
+    #[test]
+    fn nl_preamble_before_begin_token_is_ignored() {
+        let input = concat!(
+            "I'll fetch that for you.\n",
+            "<|tool_call_start|>[get_weather(city=\"Cairo\")]<|tool_call_end|>"
+        );
+        let calls = handler().extract_tool_calls(input).unwrap();
+        assert_eq!(calls[0].arguments, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn tokens_match_chat_template() {
+        let h = handler();
+        assert_eq!(h.begin_token(), "<|tool_call_start|>");
+        assert_eq!(h.end_token(), "<|tool_call_end|>");
+    }
+
+    #[test]
+    fn generate_grammar_returns_err_intentionally() {
+        // Plan: parser-only mode. Engine reads Err and sets tool_grammar=None
+        // while keeping tool_format=Some(handler).
+        let r = handler().generate_grammar(&[dummy_tool("circle_area", "radius")]);
+        assert!(r.is_err(), "generate_grammar must return Err for parser-only handler");
+    }
+
+    #[test]
+    fn generate_grammar_returns_err_for_empty_tools() {
+        let r = handler().generate_grammar(&[]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn split_top_level_respects_parens() {
+        let parts = split_top_level_calls("a(1,2), b(3, c(4,5)), d");
+        assert_eq!(parts, vec!["a(1,2)", " b(3, c(4,5))", " d"]);
+    }
+
+    #[test]
+    fn split_top_level_respects_quotes() {
+        let parts = split_top_level_calls(r#"city="Cai,ro", n=1"#);
+        assert_eq!(parts, vec![r#"city="Cai,ro""#, " n=1"]);
+    }
+}

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -7,9 +7,11 @@
 //! - FunctionGemma: `<start_function_call>call:name{param:<escape>val<escape>}<end_function_call>`
 //! - Gemma4: `<|tool_call>call:name{key:<|"|>val<|"|>}<tool_call|>`
 //! - Ministral3: `[TOOL_CALLS][{"name": "...", "arguments": {...}}]`
+//! - LFM2.5: `<|tool_call_start|>[fn1(arg=val), fn2(arg=val)]<|tool_call_end|>` Pythonic call list — handler runs in parser-only mode (no GBNF), mirroring llama.cpp's pre-autoparser working configuration
 
 mod functiongemma;
 mod gemma4;
+mod lfm2_5;
 mod ministral3;
 mod qwen3;
 mod qwen35_36;
@@ -23,6 +25,7 @@ use tracing::debug;
 
 pub use functiongemma::FunctionGemmaHandler;
 pub use gemma4::Gemma4Handler;
+pub use lfm2_5::Lfm2_5Handler;
 pub use ministral3::Ministral3Handler;
 pub use qwen3::Qwen3Handler;
 pub use qwen35_36::Qwen35_36Handler;
@@ -359,6 +362,7 @@ pub enum ToolFormat {
     FunctionGemma(FunctionGemmaHandler),
     Gemma4(Gemma4Handler),
     Ministral3(Ministral3Handler),
+    Lfm2_5(Lfm2_5Handler),
 }
 
 impl ToolFormat {
@@ -369,6 +373,7 @@ impl ToolFormat {
             ToolFormat::FunctionGemma(h) => h,
             ToolFormat::Gemma4(h) => h,
             ToolFormat::Ministral3(h) => h,
+            ToolFormat::Lfm2_5(h) => h,
         }
     }
 
@@ -500,6 +505,27 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
             debug!("Detected Qwen3 format from model name");
             return Ok(ToolFormat::Qwen3(Qwen3Handler));
         }
+
+        // Llama-3.x by name. Require the "3" suffix to avoid grabbing
+        // Llama-2 GGUFs which don't speak tool-use.
+        if name_lower.contains("llama-3")
+            || name_lower.contains("llama 3")
+            || name_lower.contains("llama3")
+        {
+            debug!("Detected Llama-3.x format from model name");
+        }
+
+        // LFM2.5 by name. `general.name` for LFM2.5-350M is "LFM2.5-350M"
+        // (verified via GGUF strings dump). `general.basename` is "LFM2.5"
+        // by Liquid AI's convention. Architecture metadata is "lfm2" — shared
+        // with LFM2 v1, so name match (not arch match) distinguishes the family.
+        // Other LFM2.5 GGUFs (LFM2.5-1.2B-Instruct, LFM2.5-1.2B-Tool, etc.)
+        // are expected to share this naming convention but should have their
+        // metadata verified before relying on the same handler.
+        if name_lower.contains("lfm2.5") {
+            debug!("Detected LFM2.5 format from model name");
+            return Ok(ToolFormat::Lfm2_5(Lfm2_5Handler));
+        }
     }
 
     Err(ToolFormatError::UnsupportedFormat(
@@ -623,6 +649,7 @@ mod tests {
             ToolFormat::FunctionGemma(_) => "FunctionGemma",
             ToolFormat::Gemma4(_) => "Gemma4",
             ToolFormat::Ministral3(_) => "Ministral3",
+            ToolFormat::Lfm2_5(_) => "Lfm2_5",
         };
         eprintln!("detected handler     = {variant}");
     }

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -328,6 +328,22 @@ pub trait ToolFormatHandler {
         None
     }
 
+    /// Whether the model may emit additional tool calls after the first
+    /// dispatch in a single user turn. Default: `true` — the chat loop keeps
+    /// the tool-call grammar active and re-extracts on every regeneration.
+    /// Override to `false` for families that empirically loop on the same
+    /// tool dispatch instead of producing a final text response (Llama-3.x
+    /// is the canonical case; cf. llama.cpp `common/chat.cpp:1626`
+    /// `auto max_calls = 1; // parallel toolcalls are not supported` and
+    /// vLLM's "parallel tool calls are not supported for Llama 3"). When
+    /// `false`, the chat loop dispatches the first tool call, then forces
+    /// the next regeneration to use the base sampler (no tool grammar) so
+    /// the model produces a plain-text answer to the user, and exits the
+    /// dispatch loop.
+    fn allow_repeated_calls(&self) -> bool {
+        true
+    }
+
     /// Generates a GBNF grammar for constrained sampling of tool calls.
     fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError>;
 
@@ -366,6 +382,10 @@ impl ToolFormat {
 
     pub fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
         self.handler().grammar_trigger_patterns()
+    }
+
+    pub fn allow_repeated_calls(&self) -> bool {
+        self.handler().allow_repeated_calls()
     }
 
     pub fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -184,20 +184,51 @@ impl Tool {
 }
 
 // Serialize tools according to https://huggingface.co/blog/unified-tool-use
+//
+// IMPORTANT: emit keys in EXPLICIT INSERTION ORDER (`type` before `function`,
+// inner `name` -> `description` -> `parameters`). The default `serde_json::json!`
+// path materialises a `Value::Object` backed by `BTreeMap`, which re-sorts keys
+// alphabetically. LFM2.5-350M is sensitive to that order — when fed
+// `{"function":{...},"type":"function"}` (alphabetical), it hallucinates extra
+// Pythonic kwargs (`parameters=`, `type=`) in the tool call. Using `serialize_map`
+// directly with nested helpers preserves the canonical OpenAI key order and
+// avoids forcing the `serde_json/preserve_order` cargo feature globally.
 impl Serialize for Tool {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": &self.name,
-                "description": &self.description,
-                "parameters": &self.json_schema,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            description: &'a str,
+            parameters: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(3))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("description", self.description)?;
+                m.serialize_entry("parameters", self.parameters)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            description: &self.description,
+            parameters: &self.json_schema,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -208,20 +239,48 @@ pub struct ToolCall {
     pub arguments: serde_json::Value,
 }
 
-// Serialize tools according to https://huggingface.co/blog/unified-tool-use
+// Serialize tool calls according to https://huggingface.co/blog/unified-tool-use
+// in canonical OpenAI key order (`type`, `function`, then within `function`:
+// `name`, `arguments`). Implemented via `serialize_map` rather than
+// `serde_json::json!({...}).serialize(serializer)` because the latter routes
+// through `serde_json::Value`'s default `BTreeMap` representation, which sorts
+// keys alphabetically (`{"function":{"arguments":...,"name":...},"type":...}`)
+// unless serde_json is built with the `preserve_order` feature — which is OFF
+// for the core/flutter/uniffi crates and which we cannot rely on downstream.
+// Same rationale as `Serialize for Tool` above.
 impl Serialize for ToolCall {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serde_json::json!({
-            "type" : "function",
-            "function": {
-                "name": &self.name,
-                "arguments": &self.arguments,
+        use serde::ser::SerializeMap;
+
+        struct OrderedFunction<'a> {
+            name: &'a str,
+            arguments: &'a serde_json::Value,
+        }
+
+        impl Serialize for OrderedFunction<'_> {
+            fn serialize<S2>(&self, serializer: S2) -> Result<S2::Ok, S2::Error>
+            where
+                S2: Serializer,
+            {
+                let mut m = serializer.serialize_map(Some(2))?;
+                m.serialize_entry("name", self.name)?;
+                m.serialize_entry("arguments", self.arguments)?;
+                m.end()
             }
-        })
-        .serialize(serializer)
+        }
+
+        let function = OrderedFunction {
+            name: &self.name,
+            arguments: &self.arguments,
+        };
+
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "function")?;
+        map.serialize_entry("function", &function)?;
+        map.end()
     }
 }
 
@@ -454,6 +513,29 @@ mod tests {
                     "parameters": {"type": "object"}
                 }
             })
+        );
+    }
+
+    #[test]
+    fn test_toolcall_serialization_preserves_canonical_key_order() {
+        // Regression guard for #519 review (gergelyvagujhelyi): the previous
+        // impl used `serde_json::json!({...}).serialize(serializer)`, which
+        // routes through `Value`'s default `BTreeMap` and emits keys in
+        // alphabetic order (`{"function":{"arguments":...,"name":...},...`)
+        // unless serde_json is built with `preserve_order` — OFF for the
+        // core/flutter/uniffi crates. Compare against the raw JSON string
+        // (NOT a Value) so any future regression to alphabetic ordering is
+        // caught even when a Value-equality check would still pass.
+        let call = ToolCall {
+            name: "circle_area".to_string(),
+            arguments: json!({"radius": 5}),
+        };
+        let serialized = serde_json::to_string(&call).expect("serialize ToolCall");
+        assert_eq!(
+            serialized,
+            r#"{"type":"function","function":{"name":"circle_area","arguments":{"radius":5}}}"#,
+            "ToolCall must serialize in canonical OpenAI key order \
+             (`type`, `function`, then `name`, `arguments`); got: {serialized}",
         );
     }
 

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -315,6 +315,19 @@ pub trait ToolFormatHandler {
     /// Returns the token that ends a tool call (e.g., "</tool_call>")
     fn end_token(&self) -> &str;
 
+    /// Optional list of regex patterns that activate the tool-call grammar in
+    /// the sampler. Returning `Some(_)` selects llama.cpp's pattern-based lazy
+    /// grammar (`grammar_lazy_patterns`); returning `None` falls back to the
+    /// single-token trigger keyed on `begin_token()`. Pattern triggers are
+    /// needed by handlers whose chat templates do not deterministically force
+    /// the begin token on every tool-call turn — Llama-3.x is the canonical
+    /// case: `<|python_tag|>` is emitted on the first tool-call turn but
+    /// omitted on post-tool-response turns, so the model emits raw `{...}`
+    /// JSON and a single-token trigger never re-fires.
+    fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
+        None
+    }
+
     /// Generates a GBNF grammar for constrained sampling of tool calls.
     fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError>;
 
@@ -349,6 +362,10 @@ impl ToolFormat {
 
     pub fn end_token(&self) -> &str {
         self.handler().end_token()
+    }
+
+    pub fn grammar_trigger_patterns(&self) -> Option<Vec<String>> {
+        self.handler().grammar_trigger_patterns()
     }
 
     pub fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -468,6 +468,18 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
         return Ok(ToolFormat::Ministral3(Ministral3Handler));
     }
 
+    // LFM2.5 family — uniquely identifiable by the `keep_past_thinking` jinja
+    // variable in the chat template. LFM2 v1 templates use `<|tool_list_start|>`
+    // wrappers and lack `keep_past_thinking`. We must NOT rely on `general.name`
+    // for the 1.2B variants because their GGUFs ship with `general.name` set
+    // to a git-commit SHA (e.g. "4cd563d5...", "E7Ae5Ebc..."), bypassing the
+    // name-substring fallback below. Template-marker detection covers all
+    // LFM2.5 GGUFs regardless of the metadata-naming bug.
+    if template_str.contains("keep_past_thinking") {
+        debug!("Detected LFM2.5 format from chat template marker (keep_past_thinking)");
+        return Ok(ToolFormat::Lfm2_5(Lfm2_5Handler));
+    }
+
     // Fall back to model metadata.
     if let Ok(arch) = model.meta_val_str("general.architecture") {
         debug!(architecture = %arch, "Checking model architecture for format hints");

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -613,13 +613,18 @@ fn dart_function_type_to_json_schema(
         properties.insert(parameter_name.into(), parameter_type);
     }
 
+    // NOTE: do NOT add `additionalProperties: false` here. LFM2.5-350M (and likely
+    // other small models trained on plain JSON Schema, not OpenAI strict-mode) treats
+    // that field as a literal kwarg name and echoes it back in Pythonic tool calls,
+    // breaking the parser. JSON Schema's default (additional allowed) is fine — no
+    // enforcement happens client-side anyway, and Qwen3/Llama-3.2 tolerated either
+    // form on r5.
     tracing::debug!(
         "\n\n{}\n\n",
         serde_json::json!({
             "type": "object",
             "properties": properties,
             "required": required,
-            "additionalProperties": false
         })
     );
 
@@ -627,7 +632,6 @@ fn dart_function_type_to_json_schema(
         "type": "object",
         "properties": properties,
         "required": required,
-        "additionalProperties": false
     }))
 }
 
@@ -1055,7 +1059,6 @@ mod tests {
                 }
             },
             "required": ["name", "age", "tags"],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1069,7 +1072,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(schema, expected);
     }
@@ -1084,7 +1086,6 @@ mod tests {
             "type": "object",
             "properties": { "text": { "type": "string" } },
             "required": [ "text" ],
-            "additionalProperties": false,
         });
         assert_eq!(json_schema, expected);
     }
@@ -1099,7 +1100,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }
@@ -1114,7 +1114,6 @@ mod tests {
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": false
         });
         assert_eq!(json_schema, expected);
     }


### PR DESCRIPTION
Splits a chunk of #516 into smaller, independently-reviewable pieces, per @AsbjornOlling's request. This is **PR 3 of 3**.

Refs: #516, #214

> **Note:** this PR is stacked on #519 (engine fixes). The 8 commits include #519's 4 commits at the base. Diff against `main` will shrink to just the 4 LFM2.5-specific commits at the tip once #519 lands. Recommend reviewing #519 first.

## What this PR adds

A **parser-only** `ToolFormat::Lfm2_5` handler covering LFM2.5-350M, LFM2.5-1.2B-Instruct, and LFM2.5-1.2B-Thinking.

LFM2.5 emits tool calls as Pythonic call lists between special tokens:

```
<|tool_call_start|>[circle_area(radius=5)]<|tool_call_end|>
```

### Files (LFM2.5-specific commits at the tip — last 4 in the log)
- New: `core/src/tool_calling/lfm2_5.rs` — `Lfm2_5Handler` + Pythonic-literal parser (list/set/dict/tuple/string/int/float/bool) + extraction tests.
- Modified: `core/src/tool_calling/mod.rs` — wire `ToolFormat::Lfm2_5` variant + detection-chain entry on `keep_past_thinking` jinja marker.
- Modified: `core/src/chat.rs` — terminal Done epilogue gated by an emit-tracking flag, with `test_done_emitted_exactly_once_per_ask` regression guard.

### Why parser-only (no GBNF)?

GBNF grammar attached to LFM2.5 makes the sampler stall (500% CPU, no token output for >10 min) because the model's natural distribution doesn't satisfy the grammar accept-set. Documented at https://github.com/ggml-org/llama.cpp/issues/19068. `generate_grammar` returns `Err(ToolFormatError::UnsupportedFormat(...))`. The engine path already tolerates this via `tool_grammar=None / tool_format=Some(handler)` — sampler runs unconstrained, `extract_tool_calls` runs on output.

Mirrors llama.cpp's pre-autoparser working configuration for LFM2.5.

### Detection: `keep_past_thinking` chat-template marker

LFM2.5 templates uniquely contain a `keep_past_thinking` jinja variable. LFM2 v1 templates use `<|tool_list_start|>` wrappers and lack this marker.

We must NOT rely on `general.name` for the 1.2B variants — their GGUFs ship with `general.name` set to a git-commit SHA (e.g. "4cd563d5...", "E7Ae5Ebc..."), bypassing the name-substring fallback. Template-marker detection covers all LFM2.5 GGUFs regardless of the metadata-naming bug.

### Terminal Done epilogue (chat.rs)

Parser-only paths can exit `Worker::ask` after `wrap_respond` suppressed iter-1's Done past the begin_token, with `extract_tool_calls` returning None. Without the terminal epilogue, raw `Fn(WriteOutput)` consumers never receive a Done — surfaces as `WorkerCrashed` (godot binding) or stuck `TokenStream` (Flutter).

The epilogue is gated by a shared `Arc<AtomicBool>` set by `wrap_respond` when it forwards a Done, so grammar paths (Qwen3, Llama-3.x) that already emitted iter-N Done don't double-fire for raw callback consumers. `TokenStream` consumers were already shielded by the `completed_response.is_some()` short-circuit; this fix extends correctness to external callback users.

Regression test `chat::tests::test_done_emitted_exactly_once_per_ask` was contributed by @gergelyvagujhelyi via review on #516 — included with light style adjustments to match `test_chat_worker`.

## On-device validation

LFM2.5-350M, 5-prompt bake-off on a Galaxy S22 (snapshot at `reports/r17-lfm2-5-350m-thinkingoff_evidence/` in the agent workspace):
- p1 NUMERIC_OK (tool fired, `78.54` exact)
- p2 NUMERIC_PRESENT (tool fired, model wrote arithmetic-only summary)
- p3 TOOL_UPSTREAM_ERR (tool fired correctly, open-meteo unreachable from device WiFi — confounder)
- p4/p5 TOOL_PARSE_ERR (model bypassed tool with canned text — model's own choice, not a parse failure)
- 0 stalls, 0 GetterErrorImpl (was 5/5 GetterErrorImpl on r10 baseline)

Strong improvement from r10 (0/5 reach with crash) to r17 (5/5 reach with 2/5 hard OK).

## Stack
- Depends on: #519 (engine fixes) — merge first
- Sibling: #520 (Llama-3.x family handler) — independent