### PR TITLE
fix(chat): context_shift gracefully handles single-user-message history

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1380,15 +1380,37 @@ impl Worker<'_, ChatWorker> {
                 .ok_or(ShiftError::Message(
                     "No first user message in chat history".into(),
                 ))?;
-        let first_deletable_index = self
+
+        // The standard rolling-pair strategy preserves the last 2 user messages
+        // and shifts older user/assistant pairs out. When the chat has only one
+        // user message — for example a tool-call loop where the model dispatched
+        // the same tool many times without further user input, exhausting n_ctx —
+        // there is no second user message and the previous implementation hard
+        // -failed with "No deletable messages". Fall back to a simpler scheme:
+        // drain the older assistant/tool turns between the first user message
+        // and the most recent message, preserving the in-progress tail.
+        let (first_deletable_index, mut last_deletable_index) = match self
             .find_next_user_message(&messages, first_user_message_index + 1)
-            .ok_or(ShiftError::Message("No deletable messages".into()))?; // Assuming assistant after user
-        let mut last_deletable_index = self
-            .find_start_of_last_n_user_messages(&messages, 2)
-            .ok_or(ShiftError::Message(
-                "Less than two user messages in chat history.".into(),
-            ))?
-            - 1;
+        {
+            Some(second_user_idx) => (
+                second_user_idx,
+                self.find_start_of_last_n_user_messages(&messages, 2)
+                    .ok_or(ShiftError::Message(
+                        "Less than two user messages in chat history.".into(),
+                    ))?
+                    - 1,
+            ),
+            None => {
+                // Need at least: [system?, user, ...middle..., tail] for there to
+                // be anything safe to delete. If the history is too short, leave
+                // it intact and let the upstream caller decide what to do.
+                if messages.len() < first_user_message_index + 3 {
+                    self.extra.messages = messages;
+                    return Ok(());
+                }
+                (first_user_message_index + 1, messages.len() - 2)
+            }
+        };
 
         // Two is the smallest number of messages we can delete as we need to preserve the message structure.
         // There might be a better start guess here.
@@ -1414,16 +1436,17 @@ impl Worker<'_, ChatWorker> {
                 last_deletable_index,
             );
 
-            // Find the first user message after target delete index and choose the message before.
-            // This is to ensure that resulting chat history still follows the user then assistant format
-            let delete_index = min(
-                self.find_next_user_message(&messages, target_delete_index + 1)
-                    .ok_or(ShiftError::Message(
-                        "Could find user message supposed to be there".into(),
-                    ))?
-                    - 1,
-                last_deletable_index,
-            ); // should never fail
+            // Find the first user message after target delete index and choose
+            // the message before, so the resulting chat history still follows
+            // the user-then-assistant turn structure. In the single-user-message
+            // fallback there is no later user message to align with, so we
+            // delete up to `target_delete_index` directly.
+            let delete_index = match self
+                .find_next_user_message(&messages, target_delete_index + 1)
+            {
+                Some(next_user) => min(next_user - 1, last_deletable_index),
+                None => min(target_delete_index, last_deletable_index),
+            };
             messages.drain(first_deletable_index..=delete_index);
             messages_to_delete *= 2;
 
@@ -2825,4 +2848,55 @@ mod tests {
     }
 
     // Template rendering tests have been moved to template.rs module
+
+    #[test]
+    fn test_context_shift_with_only_one_user_message() -> Result<(), Box<dyn std::error::Error>> {
+        // Regression guard: a chat with one user message and many assistant /
+        // tool turns must not panic when context_shift is invoked. The previous
+        // implementation hard-failed at the "No deletable messages" predicate
+        // because it assumed at least two user messages were always present.
+        // This shape is the empirical failure mode of small Llama-3.x variants
+        // looping on a tool call until n_ctx is exhausted (chat.rs:318
+        // `Worker crashed: ... Missing expected message No deletable messages`).
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+
+        let mut worker = Worker::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You are a helpful assistant.".into()),
+                n_ctx: 512,
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )?;
+
+        // One user message, then many assistant turns (the tool-call-loop shape).
+        worker.add_user_message(
+            "Use the provided tool to compute several things.".into(),
+            vec![],
+        );
+        for i in 0..30 {
+            worker.add_assistant_message(format!(
+                "Assistant turn {i} producing a long-ish synthetic response to fill context."
+            ));
+        }
+
+        let messages_before = worker.extra.messages.len();
+        worker.context_shift()?; // must not return Err here
+        let messages_after = worker.extra.messages.len();
+
+        assert!(
+            messages_after <= messages_before,
+            "context_shift must not grow the history (before={messages_before}, after={messages_after})"
+        );
+        // System prompt + first user message must be retained.
+        assert!(worker.extra.messages[0].is_system());
+        assert!(worker
+            .extra
+            .messages
+            .iter()
+            .any(|m| m.is_user()), "first user message must be preserved");
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

`Worker::context_shift` (chat.rs) hard-fails with `ShiftError::Message("No deletable messages")` when the chat history contains exactly one user message but the rendered context exceeds `n_ctx`. This shape is the empirical failure mode of small models looping on a tool-call dispatch until `n_ctx` is exhausted with one user prompt + many assistant/tool turns.

This PR adds a fallback path: when no second user message exists, drain the older assistant/tool turns between the first user message and the most recent message, leaving the in-progress tail intact. The standard rolling-pair path (≥ 2 user messages) is unchanged.

## Reproduction (pre-fix)

`pytest tests/test_tool_calling.py::test_tool_with_sets` against `Llama-3.2-1B-Instruct-Q4_K_M.gguf`:

```
ERROR nobodywho.chat:chat.rs:318 Worker crashed:
  Error reading string: Error creating response:
  Error while generating response:
  Error during context shift: Missing expected message No deletable messages
```

Trace: model dispatches `set_intersection` → tool returns → model dispatches AGAIN with stringified args → tool returns → context fills to 1044 tokens (`n_ctx=1024`) → `context_shift` triggered → only 1 user message in history → hard fails.

The predicate (`chat.rs:1383-1385`) and error message (`chat.rs:1388-1391`) predate this PR; git blame: `s194042 2025-10-06`, `Marek Hradil jr 2025-11-07`. The fall-back path in this PR preserves the existing rolling-pair semantics for the multi-user case unchanged.

## What changed

- `nobodywho/core/src/chat.rs::Worker::context_shift` — when `find_next_user_message(first_user_message_index + 1)` returns `None`, use `(first_user_message_index + 1, messages.len() - 2)` as deletable bounds and degrade `find_next_user_message` to fall through to `target_delete_index` instead of `?`-propagating an error.
- `chat::tests::test_context_shift_with_only_one_user_message` regression guard — pre-fills 1 user msg + 30 assistant turns, asserts `context_shift` returns `Ok` and history shrinks (or doesn't grow) while preserving the system prompt and the first user message.

## Test plan

- [x] \`cargo test --release --lib -p nobodywho chat::tests\` — 14 passed (4 context_shift tests including new regression)
- [x] \`cargo clippy --no-deps -p nobodywho -- -D warnings\` — clean
- [x] Manual: \`TEST_MODEL=Qwen3-0.6B pytest test_tool_calling.py\` — 14/14 (no regression)

## Note on scope

This addresses ONLY the "No deletable messages" predicate path. A separate failure mode `NoKvCacheSlot` (chat.rs:1492 guard uses \`==\` instead of \`>=\`, plus missing token-budget recheck after \`read_chunks\`) surfaces on Llama-3.2-3B during longer tool-call loops; it is independent and will be addressed in a follow-up PR.