### PR TITLE
Wasm pr1 foundation

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#606c47599755fd402135e5faf88e6f5ef4612ba2"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#85987657a55633e5d3ff774fd73e15948d3872e8"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#606c47599755fd402135e5faf88e6f5ef4612ba2"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#85987657a55633e5d3ff774fd73e15948d3872e8"
 dependencies = [
  "bindgen",
  "cc",
@@ -4581,7 +4581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#754423f1585c02febbb2c92ce1d74b0f2c9bc89a"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#6c35d9a031409cb7dee84557209d628c79b5d391"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#754423f1585c02febbb2c92ce1d74b0f2c9bc89a"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#6c35d9a031409cb7dee84557209d628c79b5d391"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -228,12 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "attribute-derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,16 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,16 +696,6 @@ name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1215,12 +1189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,25 +1564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,92 +1659,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -2023,12 +1890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,55 +1984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,8 +2026,6 @@ dependencies = [
  "referencing 0.41.0",
  "regex",
  "regex-syntax",
- "reqwest",
- "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -2312,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a35e66a8767db7acbeb7c773a6a6e118ec94b206"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#754423f1585c02febbb2c92ce1d74b0f2c9bc89a"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2327,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a35e66a8767db7acbeb7c773a6a6e118ec94b206"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#754423f1585c02febbb2c92ce1d74b0f2c9bc89a"
 dependencies = [
  "bindgen",
  "cc",
@@ -2812,12 +2622,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -3355,45 +3159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,18 +3288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,33 +3295,6 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3600,15 +3326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3680,29 +3397,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3891,22 +3585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,9 +3733,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -4190,35 +3865,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -4341,27 +3993,8 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
- "tokio",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
-dependencies = [
- "bitflags 2.11.1",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -4448,12 +4081,6 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -4781,15 +4408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,15 +4541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,7 +4580,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2626,6 +2626,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nobodywho-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "futures",
+ "js-sys",
+ "nobodywho",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-wasm",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4409,6 +4439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +4971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#94e59043c4b0288dd752e0afc781d27e6ebd1124"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a35e66a8767db7acbeb7c773a6a6e118ec94b206"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#94e59043c4b0288dd752e0afc781d27e6ebd1124"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a35e66a8767db7acbeb7c773a6a6e118ec94b206"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#6c35d9a031409cb7dee84557209d628c79b5d391"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#606c47599755fd402135e5faf88e6f5ef4612ba2"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#6c35d9a031409cb7dee84557209d628c79b5d391"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#606c47599755fd402135e5faf88e6f5ef4612ba2"
 dependencies = [
  "bindgen",
  "cc",
@@ -4580,7 +4580,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#85987657a55633e5d3ff774fd73e15948d3872e8"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#85987657a55633e5d3ff774fd73e15948d3872e8"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "bindgen",
  "cc",
@@ -4581,7 +4581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -113,6 +113,16 @@ rec {
       # File a bug if you depend on any for non-debug work!
       debug = internal.debugCrate { inherit packageId; };
     };
+    "nobodywho-wasm" = rec {
+      packageId = "nobodywho-wasm";
+      build = internal.buildRustCrateWithFeatures {
+        packageId = "nobodywho-wasm";
+      };
+
+      # Debug support which might change between releases.
+      # File a bug if you depend on any for non-debug work!
+      debug = internal.debugCrate { inherit packageId; };
+    };
   };
 
 
@@ -755,20 +765,6 @@ rec {
           }
         ];
 
-      };
-      "atomic-waker" = rec {
-        crateName = "atomic-waker";
-        version = "1.1.2";
-        edition = "2018";
-        sha256 = "1h5av1lw56m0jf0fd3bchxq8a30xv0b4wv8s4zkp4s0i7mfvs18m";
-        libName = "atomic_waker";
-        authors = [
-          "Stjepan Glavina <stjepang@gmail.com>"
-          "Contributors to futures-rs"
-        ];
-        features = {
-          "portable-atomic" = [ "dep:portable-atomic" ];
-        };
       };
       "attribute-derive" = rec {
         crateName = "attribute-derive";
@@ -2040,53 +2036,6 @@ rec {
         features = {
         };
       };
-      "combine" = rec {
-        crateName = "combine";
-        version = "4.6.7";
-        edition = "2018";
-        sha256 = "1z8rh8wp59gf8k23ar010phgs0wgf5i8cx4fg01gwcnzfn5k0nms";
-        authors = [
-          "Markus Westerlind <marwes91@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-            optional = true;
-          }
-          {
-            name = "memchr";
-            packageId = "memchr";
-            usesDefaultFeatures = false;
-          }
-        ];
-        devDependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-        ];
-        features = {
-          "bytes" = [ "dep:bytes" ];
-          "bytes_05" = [ "dep:bytes_05" ];
-          "default" = [ "std" ];
-          "futures-03" = [ "pin-project" "std" "futures-core-03" "futures-io-03" "pin-project-lite" ];
-          "futures-core-03" = [ "dep:futures-core-03" ];
-          "futures-io-03" = [ "dep:futures-io-03" ];
-          "pin-project" = [ "pin-project-lite" ];
-          "pin-project-lite" = [ "dep:pin-project-lite" ];
-          "regex" = [ "dep:regex" ];
-          "std" = [ "memchr/std" "bytes" "alloc" ];
-          "tokio" = [ "tokio-dep" "tokio-util/io" "futures-core-03" "pin-project-lite" ];
-          "tokio-02" = [ "pin-project" "std" "tokio-02-dep" "futures-core-03" "pin-project-lite" "bytes_05" ];
-          "tokio-02-dep" = [ "dep:tokio-02-dep" ];
-          "tokio-03" = [ "pin-project" "std" "tokio-03-dep" "futures-core-03" "pin-project-lite" ];
-          "tokio-03-dep" = [ "dep:tokio-03-dep" ];
-          "tokio-dep" = [ "dep:tokio-dep" ];
-          "tokio-util" = [ "dep:tokio-util" ];
-        };
-        resolvedDefaultFeatures = [ "alloc" "bytes" "default" "std" ];
-      };
       "compact_str" = rec {
         crateName = "compact_str";
         version = "0.9.0";
@@ -2217,35 +2166,6 @@ rec {
           "rand" = [ "dep:rand" ];
           "random" = [ "rand" ];
         };
-      };
-      "core-foundation" = rec {
-        crateName = "core-foundation";
-        version = "0.10.1";
-        edition = "2021";
-        sha256 = "1xjns6dqf36rni2x9f47b65grxwdm20kwdg9lhmzdrrkwadcv9mj";
-        libName = "core_foundation";
-        authors = [
-          "The Servo Project Developers"
-        ];
-        dependencies = [
-          {
-            name = "core-foundation-sys";
-            packageId = "core-foundation-sys";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-          }
-        ];
-        features = {
-          "default" = [ "link" ];
-          "link" = [ "core-foundation-sys/link" ];
-          "mac_os_10_7_support" = [ "core-foundation-sys/mac_os_10_7_support" ];
-          "mac_os_10_8_features" = [ "core-foundation-sys/mac_os_10_8_features" ];
-          "with-uuid" = [ "dep:uuid" ];
-        };
-        resolvedDefaultFeatures = [ "default" "link" ];
       };
       "core-foundation-sys" = rec {
         crateName = "core-foundation-sys";
@@ -3039,7 +2959,7 @@ rec {
           }
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
+            packageId = "windows-sys 0.61.2";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_System_Diagnostics_Debug" ];
           }
@@ -3660,20 +3580,6 @@ rec {
         ];
 
       };
-      "fnv" = rec {
-        crateName = "fnv";
-        version = "1.0.7";
-        edition = "2015";
-        sha256 = "1hc2mcqha06aibcaza94vbi81j6pr9a1bbxrxjfhc91zin8yr7iz";
-        libPath = "lib.rs";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
       "foldhash 0.1.5" = rec {
         crateName = "foldhash";
         version = "0.1.5";
@@ -3971,7 +3877,7 @@ rec {
           "default" = [ "std" ];
           "std" = [ "alloc" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
+        resolvedDefaultFeatures = [ "alloc" "std" ];
       };
       "futures-task" = rec {
         crateName = "futures-task";
@@ -4079,6 +3985,7 @@ rec {
           {
             name = "jsonschema";
             packageId = "jsonschema";
+            usesDefaultFeatures = false;
           }
           {
             name = "serde_json";
@@ -4939,78 +4846,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "codegen-full" "experimental-wasm" "register-docs" ];
       };
-      "h2" = rec {
-        crateName = "h2";
-        version = "0.4.14";
-        edition = "2021";
-        sha256 = "0cw7jk7kn2vn6f8w8ssh6gis1mljnfjxd606gvi4sjpyjayfy7qp";
-        authors = [
-          "Carl Lerche <me@carllerche.com>"
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "atomic-waker";
-            packageId = "atomic-waker";
-          }
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "fnv";
-            packageId = "fnv";
-          }
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "futures-sink";
-            packageId = "futures-sink";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "indexmap";
-            packageId = "indexmap";
-            features = [ "std" ];
-          }
-          {
-            name = "slab";
-            packageId = "slab";
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "io-util" ];
-          }
-          {
-            name = "tokio-util";
-            packageId = "tokio-util";
-            features = [ "codec" "io" ];
-          }
-          {
-            name = "tracing";
-            packageId = "tracing";
-            usesDefaultFeatures = false;
-            features = [ "std" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "rt-multi-thread" "macros" "sync" "net" ];
-          }
-        ];
-        features = {
-        };
-      };
       "hash32" = rec {
         crateName = "hash32";
         version = "0.2.1";
@@ -5311,70 +5146,7 @@ rec {
         features = {
           "default" = [ "std" ];
         };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
-      "http-body" = rec {
-        crateName = "http-body";
-        version = "1.0.1";
-        edition = "2018";
-        sha256 = "111ir5k2b9ihz5nr9cz7cwm7fnydca7dx4hc7vr16scfzghxrzhy";
-        libName = "http_body";
-        authors = [
-          "Carl Lerche <me@carllerche.com>"
-          "Lucio Franco <luciofranco14@gmail.com>"
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-        ];
-
-      };
-      "http-body-util" = rec {
-        crateName = "http-body-util";
-        version = "0.1.3";
-        edition = "2018";
-        sha256 = "0jm6jv4gxsnlsi1kzdyffjrj8cfr3zninnxpw73mvkxy4qzdj8dh";
-        libName = "http_body_util";
-        authors = [
-          "Carl Lerche <me@carllerche.com>"
-          "Lucio Franco <luciofranco14@gmail.com>"
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-        ];
-        features = {
-          "channel" = [ "dep:tokio" ];
-          "full" = [ "channel" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
+        resolvedDefaultFeatures = [ "std" ];
       };
       "httparse" = rec {
         crateName = "httparse";
@@ -5387,311 +5159,6 @@ rec {
         features = {
           "default" = [ "std" ];
         };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
-      "hyper" = rec {
-        crateName = "hyper";
-        version = "1.9.0";
-        edition = "2021";
-        sha256 = "1jmwbwqcaficskg76kq402gbymbnh2z4v99xwq3l5aa6n8bg16b2";
-        authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "atomic-waker";
-            packageId = "atomic-waker";
-            optional = true;
-          }
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-channel";
-            packageId = "futures-channel";
-            optional = true;
-          }
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-            optional = true;
-          }
-          {
-            name = "h2";
-            packageId = "h2";
-            optional = true;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-          }
-          {
-            name = "httparse";
-            packageId = "httparse";
-            optional = true;
-          }
-          {
-            name = "itoa";
-            packageId = "itoa";
-            optional = true;
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-            optional = true;
-          }
-          {
-            name = "smallvec";
-            packageId = "smallvec";
-            optional = true;
-            features = [ "const_generics" "const_new" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "sync" ];
-          }
-          {
-            name = "want";
-            packageId = "want";
-            optional = true;
-          }
-        ];
-        devDependencies = [
-          {
-            name = "futures-channel";
-            packageId = "futures-channel";
-            features = [ "sink" ];
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "fs" "macros" "net" "io-std" "io-util" "rt" "rt-multi-thread" "sync" "time" "test-util" ];
-          }
-        ];
-        features = {
-          "client" = [ "dep:want" "dep:pin-project-lite" "dep:smallvec" ];
-          "ffi" = [ "dep:http-body-util" "dep:futures-util" ];
-          "full" = [ "client" "http1" "http2" "server" ];
-          "http1" = [ "dep:atomic-waker" "dep:futures-channel" "dep:futures-core" "dep:httparse" "dep:itoa" ];
-          "http2" = [ "dep:futures-channel" "dep:futures-core" "dep:h2" ];
-          "server" = [ "dep:httpdate" "dep:pin-project-lite" "dep:smallvec" ];
-          "tracing" = [ "dep:tracing" ];
-        };
-        resolvedDefaultFeatures = [ "client" "default" "http1" "http2" ];
-      };
-      "hyper-rustls" = rec {
-        crateName = "hyper-rustls";
-        version = "0.27.9";
-        edition = "2021";
-        sha256 = "03vfnsm873wsp1dk0q85nxvk7w6syp8c2m5bcdjcyfgg4786ijik";
-        libName = "hyper_rustls";
-        dependencies = [
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "hyper-util";
-            packageId = "hyper-util";
-            usesDefaultFeatures = false;
-            features = [ "client-legacy" "tokio" ];
-          }
-          {
-            name = "rustls";
-            packageId = "rustls";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-          }
-          {
-            name = "tokio-rustls";
-            packageId = "tokio-rustls";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-          }
-        ];
-        devDependencies = [
-          {
-            name = "hyper-util";
-            packageId = "hyper-util";
-            usesDefaultFeatures = false;
-            features = [ "server-auto" ];
-          }
-          {
-            name = "rustls";
-            packageId = "rustls";
-            usesDefaultFeatures = false;
-            features = [ "tls12" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "io-std" "macros" "net" "rt-multi-thread" ];
-          }
-        ];
-        features = {
-          "aws-lc-rs" = [ "rustls/aws_lc_rs" ];
-          "default" = [ "native-tokio" "http1" "tls12" "logging" "aws-lc-rs" ];
-          "fips" = [ "aws-lc-rs" "rustls/fips" ];
-          "http1" = [ "hyper-util/http1" ];
-          "http2" = [ "hyper-util/http2" ];
-          "log" = [ "dep:log" ];
-          "logging" = [ "log" "tokio-rustls/logging" "rustls/logging" ];
-          "native-tokio" = [ "rustls-native-certs" ];
-          "ring" = [ "rustls/ring" ];
-          "rustls-native-certs" = [ "dep:rustls-native-certs" ];
-          "rustls-platform-verifier" = [ "dep:rustls-platform-verifier" ];
-          "tls12" = [ "tokio-rustls/tls12" "rustls/tls12" ];
-          "webpki-roots" = [ "dep:webpki-roots" ];
-          "webpki-tokio" = [ "webpki-roots" ];
-        };
-        resolvedDefaultFeatures = [ "http1" "http2" "tls12" ];
-      };
-      "hyper-util" = rec {
-        crateName = "hyper-util";
-        version = "0.1.20";
-        edition = "2021";
-        sha256 = "186zdc58hmm663csmjvrzgkr6jdh93sfmi3q2pxi57gcaqjpqm4n";
-        libName = "hyper_util";
-        authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "base64";
-            packageId = "base64";
-            optional = true;
-          }
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-channel";
-            packageId = "futures-channel";
-            optional = true;
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-          }
-          {
-            name = "ipnet";
-            packageId = "ipnet";
-            optional = true;
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-            optional = true;
-          }
-          {
-            name = "percent-encoding";
-            packageId = "percent-encoding";
-            optional = true;
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-          {
-            name = "socket2";
-            packageId = "socket2";
-            optional = true;
-            features = [ "all" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-            optional = true;
-          }
-          {
-            name = "tracing";
-            packageId = "tracing";
-            optional = true;
-            usesDefaultFeatures = false;
-            features = [ "std" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            usesDefaultFeatures = false;
-            features = [ "alloc" ];
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-            features = [ "full" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "macros" "test-util" "signal" ];
-          }
-        ];
-        features = {
-          "client" = [ "hyper/client" "tokio/net" "dep:tracing" "dep:futures-channel" "dep:tower-service" ];
-          "client-legacy" = [ "client" "dep:socket2" "tokio/sync" "dep:libc" "dep:futures-util" ];
-          "client-pool" = [ "client" "dep:futures-util" "dep:tower-layer" ];
-          "client-proxy" = [ "client" "dep:base64" "dep:ipnet" "dep:percent-encoding" ];
-          "client-proxy-system" = [ "dep:system-configuration" "dep:windows-registry" ];
-          "full" = [ "client" "client-legacy" "client-pool" "client-proxy" "client-proxy-system" "server" "server-auto" "server-graceful" "service" "http1" "http2" "tokio" "tracing" ];
-          "http1" = [ "hyper/http1" ];
-          "http2" = [ "hyper/http2" ];
-          "server" = [ "hyper/server" ];
-          "server-auto" = [ "server" "http1" "http2" ];
-          "server-graceful" = [ "server" "tokio/sync" ];
-          "service" = [ "dep:tower-service" ];
-          "tokio" = [ "dep:tokio" "tokio/rt" "tokio/time" ];
-          "tracing" = [ "dep:tracing" ];
-        };
-        resolvedDefaultFeatures = [ "client" "client-legacy" "client-proxy" "default" "http1" "http2" "tokio" ];
       };
       "iana-time-zone" = rec {
         crateName = "iana-time-zone";
@@ -6395,26 +5862,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "iter" ];
       };
-      "ipnet" = rec {
-        crateName = "ipnet";
-        version = "2.12.0";
-        edition = "2018";
-        sha256 = "1qpq2y0asyv0jppw7zww9y96fpnpinwap8a0phhqqgyy3znnz3yr";
-        authors = [
-          "Kris Price <kris@krisprice.nz>"
-        ];
-        features = {
-          "default" = [ "std" ];
-          "heapless" = [ "dep:heapless" "serde" ];
-          "json" = [ "schemars08" "serde" ];
-          "schemars" = [ "schemars08" ];
-          "schemars08" = [ "dep:schemars08" ];
-          "schemars1" = [ "dep:schemars1" ];
-          "ser_as_str" = [ "dep:heapless" ];
-          "serde" = [ "dep:serde" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
       "is-macro" = rec {
         crateName = "is-macro";
         version = "0.3.7";
@@ -6469,7 +5916,7 @@ rec {
           }
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
+            packageId = "windows-sys 0.61.2";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" "Win32_System_Console" ];
           }
@@ -6695,134 +6142,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "aho-corasick" "base64" "chrono" "default" "format" "libm" "log" "math" "regex" "regex-lite" "std" "time" "urlencoding" ];
       };
-      "jni" = rec {
-        crateName = "jni";
-        version = "0.22.4";
-        edition = "2024";
-        sha256 = "161lza8gz071h22pgyqyx4n91ixd691z2dbb1pq2g97k5i49mzay";
-        authors = [
-          "jni team"
-        ];
-        dependencies = [
-          {
-            name = "cfg-if";
-            packageId = "cfg-if";
-          }
-          {
-            name = "combine";
-            packageId = "combine";
-          }
-          {
-            name = "jni-macros";
-            packageId = "jni-macros";
-          }
-          {
-            name = "jni-sys";
-            packageId = "jni-sys";
-          }
-          {
-            name = "log";
-            packageId = "log";
-          }
-          {
-            name = "simd_cesu8";
-            packageId = "simd_cesu8";
-          }
-          {
-            name = "thiserror";
-            packageId = "thiserror";
-          }
-          {
-            name = "windows-link";
-            packageId = "windows-link";
-            target = { target, features }: (target."windows" or false);
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "walkdir";
-            packageId = "walkdir";
-          }
-        ];
-        features = {
-          "invocation" = [ "dep:java-locator" "dep:libloading" ];
-        };
-      };
-      "jni-macros" = rec {
-        crateName = "jni-macros";
-        version = "0.22.4";
-        edition = "2024";
-        sha256 = "18v02mcn5c7mb2yw6r930xg6ynsn7hwkxv8z2kdhn3qprjn0j0d0";
-        procMacro = true;
-        libName = "jni_macros";
-        dependencies = [
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "simd_cesu8";
-            packageId = "simd_cesu8";
-          }
-          {
-            name = "syn";
-            packageId = "syn 2.0.117";
-            features = [ "full" ];
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "rustc_version";
-            packageId = "rustc_version";
-          }
-        ];
-
-      };
-      "jni-sys" = rec {
-        crateName = "jni-sys";
-        version = "0.4.1";
-        edition = "2021";
-        sha256 = "1wlahx6f2zhczdjqyn8mk7kshb8x5vsd927sn3lvw41rrf47ldy6";
-        libName = "jni_sys";
-        authors = [
-          "Steven Fackler <sfackler@gmail.com>"
-          "Robert Bragg <robert@sixbynine.org>"
-        ];
-        dependencies = [
-          {
-            name = "jni-sys-macros";
-            packageId = "jni-sys-macros";
-          }
-        ];
-
-      };
-      "jni-sys-macros" = rec {
-        crateName = "jni-sys-macros";
-        version = "0.4.1";
-        edition = "2021";
-        sha256 = "0r32gbabrak15a7p487765b5wc0jcna2yv88mk6m1zjqyi1bkh1q";
-        procMacro = true;
-        libName = "jni_sys_macros";
-        authors = [
-          "Robert Bragg <robert@sixbynine.org>"
-        ];
-        dependencies = [
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "syn";
-            packageId = "syn 2.0.117";
-            features = [ "full" ];
-          }
-        ];
-
-      };
       "jobserver" = rec {
         crateName = "jobserver";
         version = "0.1.34";
@@ -6961,30 +6280,6 @@ rec {
             packageId = "regex-syntax";
           }
           {
-            name = "reqwest";
-            packageId = "reqwest";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (!("wasm32" == target."arch" or null));
-            features = [ "blocking" "json" "http2" "rustls-no-provider" ];
-          }
-          {
-            name = "reqwest";
-            packageId = "reqwest";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: ("wasm32" == target."arch" or null);
-            features = [ "json" ];
-          }
-          {
-            name = "rustls";
-            packageId = "rustls";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (!("wasm32" == target."arch" or null));
-            features = [ "ring" "std" "tls12" ];
-          }
-          {
             name = "serde";
             packageId = "serde";
             features = [ "derive" ];
@@ -7012,7 +6307,6 @@ rec {
           "resolve-http" = [ "reqwest" "rustls" ];
           "rustls" = [ "dep:rustls" ];
         };
-        resolvedDefaultFeatures = [ "default" "reqwest" "resolve-file" "resolve-http" "rustls" ];
       };
       "kqueue" = rec {
         crateName = "kqueue";
@@ -7242,9 +6536,9 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/marek-hradil/llama-cpp-rs";
-          rev = "8550f04e3dbc6eb1e30ed50466356a253d7bb652";
-          sha256 = "1cwbj0wiq9s3kbng5kbygg9ddg5xqgw4nazsv5zd4mbhcjykgzqz";
+          url = "https://github.com/nobodywho-ooo/llama-cpp-rs";
+          rev = "10d12300ff1f50a472c7cce5a5b834e2c83d29ef";
+          sha256 = "18pwz1r43dj6918dajlg61ak9zlhwazsblqj6hv9aj0qaks7rz4n";
         };
         libName = "llama_cpp_2";
         dependencies = [
@@ -7322,9 +6616,9 @@ rec {
         links = "llama";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/marek-hradil/llama-cpp-rs";
-          rev = "8550f04e3dbc6eb1e30ed50466356a253d7bb652";
-          sha256 = "1cwbj0wiq9s3kbng5kbygg9ddg5xqgw4nazsv5zd4mbhcjykgzqz";
+          url = "https://github.com/nobodywho-ooo/llama-cpp-rs";
+          rev = "10d12300ff1f50a472c7cce5a5b834e2c83d29ef";
+          sha256 = "18pwz1r43dj6918dajlg61ak9zlhwazsblqj6hv9aj0qaks7rz4n";
         };
         libName = "llama_cpp_sys_2";
         buildDependencies = [
@@ -8016,6 +7310,7 @@ rec {
           {
             name = "bashkit";
             packageId = "bashkit";
+            target = { target, features }: (!("wasm32" == target."arch" or null));
           }
           {
             name = "chrono";
@@ -8024,7 +7319,7 @@ rec {
           {
             name = "dirs";
             packageId = "dirs";
-            target = { target, features }: (!("android" == target."os" or null));
+            target = { target, features }: ((!("android" == target."os" or null)) && (!("wasm32" == target."arch" or null)));
           }
           {
             name = "encoding_rs";
@@ -8049,6 +7344,7 @@ rec {
           {
             name = "indicatif";
             packageId = "indicatif";
+            target = { target, features }: (!("wasm32" == target."arch" or null));
           }
           {
             name = "lazy_static";
@@ -8069,7 +7365,7 @@ rec {
             name = "llama-cpp-2";
             packageId = "llama-cpp-2";
             usesDefaultFeatures = false;
-            target = { target, features }: ((!("macos" == target."os" or null)) && (!("ios" == target."os" or null)) && (!("android" == target."os" or null)) && (("x86_64" == target."arch" or null) || ("x86" == target."arch" or null) || ("aarch64" == target."arch" or null)));
+            target = { target, features }: ((!("macos" == target."os" or null)) && (!("ios" == target."os" or null)) && (!("visionos" == target."os" or null)) && (!("watchos" == target."os" or null)) && (!("android" == target."os" or null)) && (("x86_64" == target."arch" or null) || ("x86" == target."arch" or null) || ("aarch64" == target."arch" or null)));
             features = [ "openmp" "vulkan" "mtmd" "android-static-stdcxx" "llguidance" ];
           }
           {
@@ -8092,6 +7388,7 @@ rec {
           {
             name = "monty";
             packageId = "monty";
+            target = { target, features }: (!("wasm32" == target."arch" or null));
           }
           {
             name = "nom";
@@ -8121,7 +7418,14 @@ rec {
           {
             name = "tokio";
             packageId = "tokio";
+            target = { target, features }: (!("wasm32" == target."arch" or null));
             features = [ "sync" "rt" "rt-multi-thread" "macros" ];
+          }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            target = { target, features }: ("wasm32" == target."arch" or null);
+            features = [ "sync" "rt" "macros" ];
           }
           {
             name = "tokio-stream";
@@ -8139,14 +7443,20 @@ rec {
           {
             name = "ureq";
             packageId = "ureq";
+            target = { target, features }: (!("wasm32" == target."arch" or null));
             features = [ "rustls" ];
+          }
+          {
+            name = "wasm-bindgen-futures";
+            packageId = "wasm-bindgen-futures";
+            target = { target, features }: ("wasm32" == target."arch" or null);
           }
         ];
 
       };
       "nobodywho-flutter" = rec {
         crateName = "nobodywho-flutter";
-        version = "1.2.0";
+        version = "2.1.0";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./flutter/rust; };
         libName = "nobodywho_flutter";type = [ "cdylib" ];
@@ -8194,7 +7504,7 @@ rec {
       };
       "nobodywho-godot" = rec {
         crateName = "nobodywho-godot";
-        version = "9.1.0";
+        version = "9.2.0";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./godot; };
         libName = "nobodywho_godot";type = [ "cdylib" ];
@@ -8234,7 +7544,7 @@ rec {
       };
       "nobodywho-python" = rec {
         crateName = "nobodywho-python";
-        version = "1.2.0";
+        version = "1.3.0";
         edition = "2021";
         crateBin = [
           {
@@ -8366,6 +7676,71 @@ rec {
             name = "uniffi";
             packageId = "uniffi";
             features = [ "cli" ];
+          }
+        ];
+
+      };
+      "nobodywho-wasm" = rec {
+        crateName = "nobodywho-wasm";
+        version = "0.1.0";
+        edition = "2021";
+        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./wasm; };
+        libName = "nobodywho_wasm";type = [ "cdylib" "rlib" ];
+        dependencies = [
+          {
+            name = "console_error_panic_hook";
+            packageId = "console_error_panic_hook";
+          }
+          {
+            name = "futures";
+            packageId = "futures";
+          }
+          {
+            name = "js-sys";
+            packageId = "js-sys";
+          }
+          {
+            name = "nobodywho";
+            packageId = "nobodywho";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "serde-wasm-bindgen";
+            packageId = "serde-wasm-bindgen";
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+          }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "sync" ];
+          }
+          {
+            name = "tracing";
+            packageId = "tracing";
+          }
+          {
+            name = "tracing-wasm";
+            packageId = "tracing-wasm";
+          }
+          {
+            name = "wasm-bindgen";
+            packageId = "wasm-bindgen";
+          }
+          {
+            name = "wasm-bindgen-futures";
+            packageId = "wasm-bindgen-futures";
+          }
+          {
+            name = "web-sys";
+            packageId = "web-sys";
+            features = [ "console" ];
           }
         ];
 
@@ -8909,17 +8284,6 @@ rec {
         features = {
         };
         resolvedDefaultFeatures = [ "default" ];
-      };
-      "openssl-probe" = rec {
-        crateName = "openssl-probe";
-        version = "0.2.1";
-        edition = "2021";
-        sha256 = "1gpwpb7smfhkscwvbri8xzbab39wcnby1jgz1s49vf1aqgsdx1vw";
-        libName = "openssl_probe";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
-
       };
       "option-ext" = rec {
         crateName = "option-ext";
@@ -10567,271 +9931,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" "unicode" "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
       };
-      "reqwest" = rec {
-        crateName = "reqwest";
-        version = "0.13.3";
-        edition = "2021";
-        sha256 = "1h7fgnllk7ihw7836b7z73h9fb5vk90y3irvcm0ysan2l8g05q32";
-        authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "base64";
-            packageId = "base64";
-          }
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-channel";
-            packageId = "futures-channel";
-            optional = true;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "h2";
-            packageId = "h2";
-            optional = true;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "http-body-util";
-            packageId = "http-body-util";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "http1" "client" ];
-          }
-          {
-            name = "hyper-rustls";
-            packageId = "hyper-rustls";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "http1" "tls12" ];
-          }
-          {
-            name = "hyper-util";
-            packageId = "hyper-util";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "http1" "client" "client-legacy" "client-proxy" "tokio" ];
-          }
-          {
-            name = "js-sys";
-            packageId = "js-sys";
-            target = { target, features }: (("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null)));
-          }
-          {
-            name = "log";
-            packageId = "log";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "percent-encoding";
-            packageId = "percent-encoding";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "rustls";
-            packageId = "rustls";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "std" "tls12" ];
-          }
-          {
-            name = "rustls-pki-types";
-            packageId = "rustls-pki-types";
-            optional = true;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "std" ];
-          }
-          {
-            name = "rustls-platform-verifier";
-            packageId = "rustls-platform-verifier";
-            optional = true;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-            optional = true;
-          }
-          {
-            name = "serde_json";
-            packageId = "serde_json";
-            optional = true;
-          }
-          {
-            name = "sync_wrapper";
-            packageId = "sync_wrapper";
-            features = [ "futures" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "net" "time" ];
-          }
-          {
-            name = "tokio-rustls";
-            packageId = "tokio-rustls";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "tls12" ];
-          }
-          {
-            name = "tower";
-            packageId = "tower";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "retry" "timeout" "util" ];
-          }
-          {
-            name = "tower-http";
-            packageId = "tower-http";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "follow-redirect" ];
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-          }
-          {
-            name = "url";
-            packageId = "url";
-          }
-          {
-            name = "wasm-bindgen";
-            packageId = "wasm-bindgen";
-            target = { target, features }: (("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null)));
-          }
-          {
-            name = "wasm-bindgen-futures";
-            packageId = "wasm-bindgen-futures";
-            target = { target, features }: (("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null)));
-          }
-          {
-            name = "web-sys";
-            packageId = "web-sys";
-            target = { target, features }: (("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null)));
-            features = [ "AbortController" "AbortSignal" "Headers" "Request" "RequestInit" "RequestMode" "Response" "Window" "FormData" "Blob" "BlobPropertyBag" "ServiceWorkerGlobalScope" "RequestCredentials" "File" "ReadableStream" "RequestCache" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "std" "alloc" ];
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "http1" "http2" "client" "server" ];
-          }
-          {
-            name = "hyper-util";
-            packageId = "hyper-util";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "http1" "http2" "client" "client-legacy" "server-auto" "server-graceful" "tokio" ];
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "derive" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            usesDefaultFeatures = false;
-            target = { target, features }: (!(("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null))));
-            features = [ "macros" "rt-multi-thread" ];
-          }
-          {
-            name = "tower";
-            packageId = "tower";
-            usesDefaultFeatures = false;
-            features = [ "limit" ];
-          }
-          {
-            name = "wasm-bindgen";
-            packageId = "wasm-bindgen";
-            target = { target, features }: (("wasm32" == target."arch" or null) && (("unknown" == target."os" or null) || ("none" == target."os" or null)));
-            features = [ "serde-serialize" ];
-          }
-        ];
-        features = {
-          "__native-tls" = [ "dep:hyper-tls" "dep:native-tls-crate" "__tls" "dep:tokio-native-tls" ];
-          "__native-tls-alpn" = [ "native-tls-crate?/alpn" "hyper-tls?/alpn" ];
-          "__rustls" = [ "dep:hyper-rustls" "dep:tokio-rustls" "dep:rustls" "__tls" ];
-          "__rustls-aws-lc-rs" = [ "hyper-rustls?/aws-lc-rs" "tokio-rustls?/aws-lc-rs" "rustls?/aws-lc-rs" "quinn?/rustls-aws-lc-rs" ];
-          "__tls" = [ "dep:rustls-pki-types" "tokio/io-util" ];
-          "blocking" = [ "dep:futures-channel" "futures-channel?/sink" "dep:futures-util" "futures-util?/io" "futures-util?/sink" "tokio/sync" ];
-          "brotli" = [ "tower-http/decompression-br" ];
-          "charset" = [ "dep:encoding_rs" "dep:mime" ];
-          "cookies" = [ "dep:cookie_crate" "dep:cookie_store" ];
-          "default" = [ "default-tls" "charset" "http2" "system-proxy" ];
-          "default-tls" = [ "rustls" ];
-          "deflate" = [ "tower-http/decompression-deflate" ];
-          "form" = [ "dep:serde" "dep:serde_urlencoded" ];
-          "gzip" = [ "tower-http/decompression-gzip" ];
-          "hickory-dns" = [ "dep:hickory-resolver" "dep:once_cell" ];
-          "http2" = [ "dep:h2" "hyper/http2" "hyper-util/http2" "hyper-rustls?/http2" ];
-          "http3" = [ "rustls" "dep:h3" "dep:h3-quinn" "dep:quinn" "tokio/macros" ];
-          "json" = [ "dep:serde" "dep:serde_json" ];
-          "multipart" = [ "dep:mime_guess" "dep:futures-util" ];
-          "native-tls" = [ "__native-tls" "__native-tls-alpn" ];
-          "native-tls-no-alpn" = [ "__native-tls" ];
-          "native-tls-vendored" = [ "__native-tls" "native-tls-crate?/vendored" "__native-tls-alpn" ];
-          "native-tls-vendored-no-alpn" = [ "__native-tls" "native-tls-crate?/vendored" ];
-          "query" = [ "dep:serde" "dep:serde_urlencoded" ];
-          "rustls" = [ "__rustls-aws-lc-rs" "dep:rustls-platform-verifier" "__rustls" ];
-          "rustls-no-provider" = [ "dep:rustls-platform-verifier" "__rustls" ];
-          "stream" = [ "tokio/fs" "dep:futures-util" "dep:tokio-util" "dep:wasm-streams" ];
-          "system-proxy" = [ "hyper-util/client-proxy-system" ];
-          "zstd" = [ "tower-http/decompression-zstd" ];
-        };
-        resolvedDefaultFeatures = [ "__rustls" "__tls" "blocking" "http2" "json" "rustls-no-provider" ];
-      };
       "ring" = rec {
         crateName = "ring";
         version = "0.17.14";
@@ -11240,7 +10339,7 @@ rec {
           }
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
+            packageId = "windows-sys 0.61.2";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Networking_WinSock" ];
           }
@@ -11350,37 +10449,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "log" "logging" "ring" "std" "tls12" ];
       };
-      "rustls-native-certs" = rec {
-        crateName = "rustls-native-certs";
-        version = "0.8.3";
-        edition = "2021";
-        sha256 = "0qrajg2n90bcr3bcq6j95gjm7a9lirfkkdmjj32419dyyzan0931";
-        libName = "rustls_native_certs";
-        dependencies = [
-          {
-            name = "openssl-probe";
-            packageId = "openssl-probe";
-            target = { target, features }: ((target."unix" or false) && (!("macos" == target."os" or null)));
-          }
-          {
-            name = "rustls-pki-types";
-            packageId = "rustls-pki-types";
-            rename = "pki-types";
-            features = [ "std" ];
-          }
-          {
-            name = "schannel";
-            packageId = "schannel";
-            target = { target, features }: (target."windows" or false);
-          }
-          {
-            name = "security-framework";
-            packageId = "security-framework";
-            target = { target, features }: ("macos" == target."os" or null);
-          }
-        ];
-
-      };
       "rustls-pki-types" = rec {
         crateName = "rustls-pki-types";
         version = "1.14.1";
@@ -11402,139 +10470,6 @@ rec {
           "web-time" = [ "dep:web-time" ];
         };
         resolvedDefaultFeatures = [ "alloc" "default" "std" ];
-      };
-      "rustls-platform-verifier" = rec {
-        crateName = "rustls-platform-verifier";
-        version = "0.7.0";
-        edition = "2021";
-        sha256 = "181v4d0vl53vdh2wq56vghal1zyhdgqvy4xa8r45zwz4di9y5l96";
-        libName = "rustls_platform_verifier";
-        dependencies = [
-          {
-            name = "core-foundation";
-            packageId = "core-foundation";
-            target = { target, features }: (("apple" == target."vendor" or null));
-          }
-          {
-            name = "core-foundation-sys";
-            packageId = "core-foundation-sys";
-            target = { target, features }: (("apple" == target."vendor" or null));
-          }
-          {
-            name = "jni";
-            packageId = "jni";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "jni";
-            packageId = "jni";
-            usesDefaultFeatures = false;
-            target = { target, features }: ("android" == target."os" or null);
-          }
-          {
-            name = "log";
-            packageId = "log";
-          }
-          {
-            name = "once_cell";
-            packageId = "once_cell";
-            optional = true;
-          }
-          {
-            name = "once_cell";
-            packageId = "once_cell";
-            target = { target, features }: ("android" == target."os" or null);
-          }
-          {
-            name = "rustls";
-            packageId = "rustls";
-            usesDefaultFeatures = false;
-            features = [ "std" ];
-          }
-          {
-            name = "rustls-native-certs";
-            packageId = "rustls-native-certs";
-            target = { target, features }: ((target."unix" or false) && (!("android" == target."os" or null)) && (!("apple" == target."vendor" or null)) && (!("wasm32" == target."arch" or null)));
-          }
-          {
-            name = "rustls-platform-verifier-android";
-            packageId = "rustls-platform-verifier-android";
-            target = { target, features }: ("android" == target."os" or null);
-          }
-          {
-            name = "rustls-webpki";
-            packageId = "rustls-webpki";
-            rename = "webpki";
-            usesDefaultFeatures = false;
-            target = { target, features }: ((target."unix" or false) && (!("android" == target."os" or null)) && (!("apple" == target."vendor" or null)) && (!("wasm32" == target."arch" or null)));
-          }
-          {
-            name = "rustls-webpki";
-            packageId = "rustls-webpki";
-            rename = "webpki";
-            usesDefaultFeatures = false;
-            target = { target, features }: ("wasm32" == target."arch" or null);
-          }
-          {
-            name = "rustls-webpki";
-            packageId = "rustls-webpki";
-            rename = "webpki";
-            usesDefaultFeatures = false;
-            target = { target, features }: ("android" == target."os" or null);
-          }
-          {
-            name = "security-framework";
-            packageId = "security-framework";
-            target = { target, features }: (("apple" == target."vendor" or null));
-          }
-          {
-            name = "security-framework-sys";
-            packageId = "security-framework-sys";
-            target = { target, features }: (("apple" == target."vendor" or null));
-          }
-          {
-            name = "webpki-root-certs";
-            packageId = "webpki-root-certs";
-            target = { target, features }: ("wasm32" == target."arch" or null);
-          }
-          {
-            name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
-            usesDefaultFeatures = false;
-            target = { target, features }: (target."windows" or false);
-            features = [ "Win32_Foundation" "Win32_Security_Cryptography" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "rustls";
-            packageId = "rustls";
-            usesDefaultFeatures = false;
-            features = [ "ring" ];
-          }
-          {
-            name = "webpki-root-certs";
-            packageId = "webpki-root-certs";
-          }
-        ];
-        features = {
-          "android_logger" = [ "dep:android_logger" ];
-          "base64" = [ "dep:base64" ];
-          "cert-logging" = [ "base64" ];
-          "docsrs" = [ "jni" "once_cell" ];
-          "ffi-testing" = [ "android_logger" "rustls/ring" ];
-          "jni" = [ "dep:jni" ];
-          "once_cell" = [ "dep:once_cell" ];
-        };
-      };
-      "rustls-platform-verifier-android" = rec {
-        crateName = "rustls-platform-verifier-android";
-        version = "0.1.1";
-        edition = "2021";
-        sha256 = "13vq6sxsgz9547xm2zbdxiw8x7ad1g8n8ax6xvxsjqszk7q6awgq";
-        libName = "rustls_platform_verifier_android";
-
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
@@ -11609,31 +10544,6 @@ rec {
             name = "winapi-util";
             packageId = "winapi-util";
             target = { target, features }: (target."windows" or false);
-          }
-        ];
-
-      };
-      "schannel" = rec {
-        crateName = "schannel";
-        version = "0.1.29";
-        edition = "2018";
-        sha256 = "0ffrzz5vf2s3gnzvphgb5gg8fqifvryl07qcf7q3x1scj3jbghci";
-        authors = [
-          "Steven Fackler <sfackler@gmail.com>"
-          "Steffen Butzer <steffen.butzer@outlook.com>"
-        ];
-        dependencies = [
-          {
-            name = "windows-sys";
-            packageId = "windows-sys 0.61.2";
-            features = [ "Win32_Foundation" "Win32_Security_Cryptography" "Win32_Security_Authentication_Identity" "Win32_Security_Credentials" "Win32_System_LibraryLoader" "Win32_System_Memory" "Win32_System_SystemInformation" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "windows-sys";
-            packageId = "windows-sys 0.61.2";
-            features = [ "Win32_System_SystemInformation" "Win32_System_Time" ];
           }
         ];
 
@@ -11849,73 +10759,6 @@ rec {
         ];
 
       };
-      "security-framework" = rec {
-        crateName = "security-framework";
-        version = "3.7.0";
-        edition = "2024";
-        sha256 = "07fd0j29j8yczb3hd430vwz784lx9knb5xwbvqna1nbkbivvrx5p";
-        libName = "security_framework";
-        authors = [
-          "Steven Fackler <sfackler@gmail.com>"
-          "Kornel <kornel@geekhood.net>"
-        ];
-        dependencies = [
-          {
-            name = "bitflags";
-            packageId = "bitflags 2.11.1";
-          }
-          {
-            name = "core-foundation";
-            packageId = "core-foundation";
-          }
-          {
-            name = "core-foundation-sys";
-            packageId = "core-foundation-sys";
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-          }
-          {
-            name = "security-framework-sys";
-            packageId = "security-framework-sys";
-            usesDefaultFeatures = false;
-          }
-        ];
-        features = {
-          "OSX_10_15" = [ "security-framework-sys/OSX_10_15" ];
-          "default" = [ "OSX_10_14" "alpn" "session-tickets" ];
-          "log" = [ "dep:log" ];
-          "macos-12" = [ "security-framework-sys/macos-12" ];
-          "sync-keychain" = [ "OSX_10_13" ];
-        };
-        resolvedDefaultFeatures = [ "OSX_10_14" "alpn" "default" "session-tickets" ];
-      };
-      "security-framework-sys" = rec {
-        crateName = "security-framework-sys";
-        version = "2.17.0";
-        edition = "2021";
-        sha256 = "1qr0w0y9iwvmv3hwg653q1igngnc5b74xcf0679cbv23z0fnkqkc";
-        libName = "security_framework_sys";
-        authors = [
-          "Steven Fackler <sfackler@gmail.com>"
-          "Kornel <kornel@geekhood.net>"
-        ];
-        dependencies = [
-          {
-            name = "core-foundation-sys";
-            packageId = "core-foundation-sys";
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-          }
-        ];
-        features = {
-          "default" = [ "OSX_10_13" ];
-        };
-        resolvedDefaultFeatures = [ "OSX_10_13" "default" ];
-      };
       "semver" = rec {
         crateName = "semver";
         version = "1.0.28";
@@ -11978,6 +10821,32 @@ rec {
           "unstable" = [ "serde_core/unstable" ];
         };
         resolvedDefaultFeatures = [ "alloc" "default" "derive" "serde_derive" "std" ];
+      };
+      "serde-wasm-bindgen" = rec {
+        crateName = "serde-wasm-bindgen";
+        version = "0.6.5";
+        edition = "2018";
+        sha256 = "0sz1l4v8059hiizf5z7r2spm6ws6sqcrs4qgqwww3p7dy1ly20l3";
+        libName = "serde_wasm_bindgen";
+        authors = [
+          "Ingvar Stepanyan <me@rreverser.com>"
+        ];
+        dependencies = [
+          {
+            name = "js-sys";
+            packageId = "js-sys";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "wasm-bindgen";
+            packageId = "wasm-bindgen";
+          }
+        ];
+
       };
       "serde_core" = rec {
         crateName = "serde_core";
@@ -12432,46 +11301,6 @@ rec {
           "default" = [ "std" "const-generics" ];
         };
       };
-      "simd_cesu8" = rec {
-        crateName = "simd_cesu8";
-        version = "1.1.1";
-        edition = "2021";
-        sha256 = "0crcbgvyycmazji2vqj9vxn2czdyl3gxmicp4xqdzkc7pdbh3ycl";
-        authors = [
-          "Sean C. Roach <me@seancroach.dev>"
-        ];
-        dependencies = [
-          {
-            name = "simdutf8";
-            packageId = "simdutf8";
-            usesDefaultFeatures = false;
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "rustc_version";
-            packageId = "rustc_version";
-          }
-        ];
-        features = {
-          "default" = [ "std" ];
-          "std" = [ "simdutf8/std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
-      "simdutf8" = rec {
-        crateName = "simdutf8";
-        version = "0.1.5";
-        edition = "2018";
-        sha256 = "0vmpf7xaa0dnaikib5jlx6y4dxd3hxqz6l830qb079g7wcsgxag3";
-        authors = [
-          "Hans Kratz <hans@appfour.com>"
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "std" ];
-      };
       "similar" = rec {
         crateName = "similar";
         version = "2.7.0";
@@ -12541,7 +11370,7 @@ rec {
           "default" = [ "std" ];
           "serde" = [ "dep:serde" ];
         };
-        resolvedDefaultFeatures = [ "default" "std" ];
+        resolvedDefaultFeatures = [ "std" ];
       };
       "smallvec" = rec {
         crateName = "smallvec";
@@ -12569,7 +11398,7 @@ rec {
           "serde" = [ "dep:serde" ];
           "unty" = [ "dep:unty" ];
         };
-        resolvedDefaultFeatures = [ "const_generics" "const_new" "serde" ];
+        resolvedDefaultFeatures = [ "const_generics" "serde" ];
       };
       "smawk" = rec {
         crateName = "smawk";
@@ -12868,19 +11697,10 @@ rec {
         authors = [
           "Actyx AG <developer@actyx.io>"
         ];
-        dependencies = [
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-        ];
         features = {
           "futures" = [ "futures-core" ];
           "futures-core" = [ "dep:futures-core" ];
         };
-        resolvedDefaultFeatures = [ "futures" "futures-core" ];
       };
       "synstructure" = rec {
         crateName = "synstructure";
@@ -12966,7 +11786,7 @@ rec {
           }
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
+            packageId = "windows-sys 0.61.2";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Storage_FileSystem" "Win32_Foundation" ];
           }
@@ -13300,44 +12120,6 @@ rec {
         ];
 
       };
-      "tokio-rustls" = rec {
-        crateName = "tokio-rustls";
-        version = "0.26.4";
-        edition = "2021";
-        sha256 = "0qggwknz9w4bbsv1z158hlnpkm97j3w8v31586jipn99byaala8p";
-        libName = "tokio_rustls";
-        dependencies = [
-          {
-            name = "rustls";
-            packageId = "rustls";
-            usesDefaultFeatures = false;
-            features = [ "std" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-          }
-        ];
-        devDependencies = [
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "full" ];
-          }
-        ];
-        features = {
-          "aws-lc-rs" = [ "aws_lc_rs" ];
-          "aws_lc_rs" = [ "rustls/aws_lc_rs" ];
-          "brotli" = [ "rustls/brotli" ];
-          "default" = [ "logging" "tls12" "aws_lc_rs" ];
-          "fips" = [ "rustls/fips" ];
-          "logging" = [ "rustls/logging" ];
-          "ring" = [ "rustls/ring" ];
-          "tls12" = [ "rustls/tls12" ];
-          "zlib" = [ "rustls/zlib" ];
-        };
-        resolvedDefaultFeatures = [ "tls12" ];
-      };
       "tokio-stream" = rec {
         crateName = "tokio-stream";
         version = "0.1.18";
@@ -13381,62 +12163,6 @@ rec {
           "tokio-util" = [ "dep:tokio-util" ];
         };
         resolvedDefaultFeatures = [ "default" "time" ];
-      };
-      "tokio-util" = rec {
-        crateName = "tokio-util";
-        version = "0.7.18";
-        edition = "2021";
-        sha256 = "1600rd47pylwn7cap1k7s5nvdaa9j7w8kqigzp1qy7mh0p4cxscs";
-        libName = "tokio_util";
-        authors = [
-          "Tokio Contributors <team@tokio.rs>"
-        ];
-        dependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-core";
-            packageId = "futures-core";
-          }
-          {
-            name = "futures-sink";
-            packageId = "futures-sink";
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "sync" ];
-          }
-        ];
-        devDependencies = [
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "full" ];
-          }
-        ];
-        features = {
-          "__docs_rs" = [ "futures-util" ];
-          "compat" = [ "futures-io" ];
-          "full" = [ "codec" "compat" "io-util" "time" "net" "rt" "join-map" ];
-          "futures-io" = [ "dep:futures-io" ];
-          "futures-util" = [ "dep:futures-util" ];
-          "hashbrown" = [ "dep:hashbrown" ];
-          "io-util" = [ "io" "tokio/rt" "tokio/io-util" ];
-          "join-map" = [ "rt" "hashbrown" ];
-          "net" = [ "tokio/net" ];
-          "rt" = [ "tokio/rt" "tokio/sync" "futures-util" ];
-          "slab" = [ "dep:slab" ];
-          "time" = [ "tokio/time" "slab" ];
-          "tracing" = [ "dep:tracing" ];
-        };
-        resolvedDefaultFeatures = [ "codec" "default" "io" ];
       };
       "toktrie" = rec {
         crateName = "toktrie";
@@ -13774,11 +12500,6 @@ rec {
             optional = true;
           }
           {
-            name = "tokio";
-            packageId = "tokio";
-            optional = true;
-          }
-          {
             name = "tower-layer";
             packageId = "tower-layer";
           }
@@ -13793,11 +12514,6 @@ rec {
             packageId = "futures-util";
             usesDefaultFeatures = false;
             features = [ "async-await-macro" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "macros" "sync" "test-util" "rt-multi-thread" ];
           }
         ];
         features = {
@@ -13829,120 +12545,7 @@ rec {
           "tracing" = [ "dep:tracing" ];
           "util" = [ "futures-core" "futures-util" "pin-project-lite" "sync_wrapper" ];
         };
-        resolvedDefaultFeatures = [ "futures-core" "futures-util" "pin-project-lite" "retry" "sync_wrapper" "timeout" "tokio" "util" ];
-      };
-      "tower-http" = rec {
-        crateName = "tower-http";
-        version = "0.6.10";
-        edition = "2018";
-        sha256 = "0lfbddgrhmxhnb3afazawsl4cxqfcs8wvq5hm34ija0wz3czvmk8";
-        libName = "tower_http";
-        authors = [
-          "Tower Maintainers <team@tower-rs.com>"
-        ];
-        dependencies = [
-          {
-            name = "bitflags";
-            packageId = "bitflags 2.11.1";
-          }
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-            optional = true;
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-          {
-            name = "tower";
-            packageId = "tower";
-            optional = true;
-          }
-          {
-            name = "tower-layer";
-            packageId = "tower-layer";
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-          }
-          {
-            name = "url";
-            packageId = "url";
-            optional = true;
-          }
-        ];
-        devDependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-          }
-          {
-            name = "tower";
-            packageId = "tower";
-            features = [ "buffer" "util" "retry" "make" "timeout" ];
-          }
-        ];
-        features = {
-          "auth" = [ "base64" "validate-request" ];
-          "base64" = [ "dep:base64" ];
-          "catch-panic" = [ "tracing" "futures-util/std" "dep:http-body" "dep:http-body-util" ];
-          "compression-br" = [ "dep:async-compression" "async-compression?/brotli" "futures-core" "dep:http-body" "tokio-util" "dep:tokio" ];
-          "compression-deflate" = [ "dep:async-compression" "async-compression?/zlib" "futures-core" "dep:http-body" "tokio-util" "dep:tokio" ];
-          "compression-full" = [ "compression-br" "compression-deflate" "compression-gzip" "compression-zstd" ];
-          "compression-gzip" = [ "dep:async-compression" "async-compression?/gzip" "futures-core" "dep:http-body" "tokio-util" "dep:tokio" ];
-          "compression-zstd" = [ "dep:async-compression" "async-compression?/zstd" "futures-core" "dep:http-body" "tokio-util" "dep:tokio" ];
-          "decompression-br" = [ "dep:async-compression" "async-compression?/brotli" "futures-core" "dep:http-body" "dep:http-body-util" "tokio-util" "dep:tokio" ];
-          "decompression-deflate" = [ "dep:async-compression" "async-compression?/zlib" "futures-core" "dep:http-body" "dep:http-body-util" "tokio-util" "dep:tokio" ];
-          "decompression-full" = [ "decompression-br" "decompression-deflate" "decompression-gzip" "decompression-zstd" ];
-          "decompression-gzip" = [ "dep:async-compression" "async-compression?/gzip" "futures-core" "dep:http-body" "dep:http-body-util" "tokio-util" "dep:tokio" ];
-          "decompression-zstd" = [ "dep:async-compression" "async-compression?/zstd" "futures-core" "dep:http-body" "dep:http-body-util" "tokio-util" "dep:tokio" ];
-          "follow-redirect" = [ "futures-util" "dep:http-body" "dep:url" "tower/util" ];
-          "fs" = [ "dep:tokio" "tokio?/fs" "tokio?/io-util" "futures-core" "futures-util" "dep:http-body" "dep:http-body-util" "tokio-util/io" "dep:http-range-header" "mime_guess" "mime" "percent-encoding" "httpdate" "set-status" "futures-util/alloc" ];
-          "full" = [ "add-extension" "auth" "catch-panic" "compression-full" "cors" "decompression-full" "follow-redirect" "fs" "limit" "map-request-body" "map-response-body" "metrics" "normalize-path" "on-early-drop" "propagate-header" "redirect" "request-id" "sensitive-headers" "set-header" "set-status" "timeout" "trace" "util" "validate-request" ];
-          "futures-core" = [ "dep:futures-core" ];
-          "futures-util" = [ "dep:futures-util" ];
-          "httpdate" = [ "dep:httpdate" ];
-          "limit" = [ "dep:http-body" "dep:http-body-util" ];
-          "metrics" = [ "dep:http-body" "dep:tokio" "tokio?/time" ];
-          "mime" = [ "dep:mime" ];
-          "mime_guess" = [ "dep:mime_guess" ];
-          "on-early-drop" = [ "dep:http-body" ];
-          "percent-encoding" = [ "dep:percent-encoding" ];
-          "request-id" = [ "uuid" ];
-          "timeout" = [ "dep:http-body" "dep:tokio" "tokio?/time" ];
-          "tokio-util" = [ "dep:tokio-util" ];
-          "tower" = [ "dep:tower" ];
-          "trace" = [ "dep:http-body" "tracing" ];
-          "tracing" = [ "dep:tracing" ];
-          "util" = [ "tower" ];
-          "uuid" = [ "dep:uuid" ];
-          "validate-request" = [ "mime" ];
-        };
-        resolvedDefaultFeatures = [ "follow-redirect" "futures-util" "tower" ];
+        resolvedDefaultFeatures = [ "futures-core" "futures-util" "pin-project-lite" "sync_wrapper" "util" ];
       };
       "tower-layer" = rec {
         crateName = "tower-layer";
@@ -14214,16 +12817,38 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "ansi" "default" "env-filter" "fmt" "matchers" "nu-ansi-term" "once_cell" "registry" "sharded-slab" "smallvec" "std" "thread_local" "tracing" "tracing-log" ];
       };
-      "try-lock" = rec {
-        crateName = "try-lock";
-        version = "0.2.5";
-        edition = "2015";
-        sha256 = "0jqijrrvm1pyq34zn1jmy2vihd4jcrjlvsh4alkjahhssjnsn8g4";
-        libName = "try_lock";
+      "tracing-wasm" = rec {
+        crateName = "tracing-wasm";
+        version = "0.2.1";
+        edition = "2018";
+        sha256 = "01vfcarjds5n94vz72fxnzxz4nznd3zhhhcgsyi0yhkll5iwcxa5";
+        libName = "tracing_wasm";type = [ "cdylib" "rlib" ];
         authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
+          "Cole Lawrence <cole@colelawrence.com>"
+          "Story.ai Team <team@story.ai>"
         ];
-
+        dependencies = [
+          {
+            name = "tracing";
+            packageId = "tracing";
+            usesDefaultFeatures = false;
+            features = [ "attributes" ];
+          }
+          {
+            name = "tracing-subscriber";
+            packageId = "tracing-subscriber";
+            usesDefaultFeatures = false;
+            features = [ "registry" ];
+          }
+          {
+            name = "wasm-bindgen";
+            packageId = "wasm-bindgen";
+          }
+        ];
+        features = {
+          "mark-with-rayon-thread-index" = [ "rayon" ];
+          "rayon" = [ "dep:rayon" ];
+        };
       };
       "typed-arena" = rec {
         crateName = "typed-arena";
@@ -15115,22 +13740,6 @@ rec {
         ];
 
       };
-      "want" = rec {
-        crateName = "want";
-        version = "0.3.1";
-        edition = "2018";
-        sha256 = "03hbfrnvqqdchb5kgxyavb9jabwza0dmh2vw5kg0dq8rxl57d9xz";
-        authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "try-lock";
-            packageId = "try-lock";
-          }
-        ];
-
-      };
       "wasi" = rec {
         crateName = "wasi";
         version = "0.11.1+wasi-snapshot-preview1";
@@ -15954,7 +14563,7 @@ rec {
           "default" = [ "std" ];
           "std" = [ "wasm-bindgen/std" "js-sys/std" ];
         };
-        resolvedDefaultFeatures = [ "AbortController" "AbortSignal" "Blob" "BlobPropertyBag" "BroadcastChannel" "DedicatedWorkerGlobalScope" "ErrorEvent" "Event" "EventTarget" "File" "FormData" "Headers" "MessageEvent" "MessagePort" "ReadableStream" "Request" "RequestCache" "RequestCredentials" "RequestInit" "RequestMode" "Response" "ServiceWorkerGlobalScope" "Url" "Window" "Worker" "WorkerGlobalScope" "default" "std" ];
+        resolvedDefaultFeatures = [ "Blob" "BlobPropertyBag" "BroadcastChannel" "DedicatedWorkerGlobalScope" "ErrorEvent" "Event" "EventTarget" "MessageEvent" "MessagePort" "Url" "Worker" "WorkerGlobalScope" "console" "default" "std" ];
       };
       "web-time" = rec {
         crateName = "web-time";
@@ -15978,22 +14587,6 @@ rec {
         features = {
           "serde" = [ "dep:serde" ];
         };
-      };
-      "webpki-root-certs" = rec {
-        crateName = "webpki-root-certs";
-        version = "1.0.7";
-        edition = "2021";
-        sha256 = "0b59x5mzsilk42w59nif3lfhc24pgzb0v35pi6p01qy37z7424gk";
-        libName = "webpki_root_certs";
-        dependencies = [
-          {
-            name = "rustls-pki-types";
-            packageId = "rustls-pki-types";
-            rename = "pki-types";
-            usesDefaultFeatures = false;
-          }
-        ];
-
       };
       "webpki-roots" = rec {
         crateName = "webpki-roots";
@@ -16077,7 +14670,7 @@ rec {
         dependencies = [
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.48.0";
+            packageId = "windows-sys 0.52.0";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" "Win32_System_Console" "Win32_System_SystemInformation" ];
           }
@@ -16524,7 +15117,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_SystemInformation" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
       };
       "windows-sys 0.52.0" = rec {
         crateName = "windows-sys";
@@ -16772,7 +15365,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Security_Cryptography" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_Diagnostics" "Win32_System_Diagnostics_Debug" "Win32_System_Threading" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_SystemInformation" "Win32_System_Threading" "default" ];
       };
       "windows-sys 0.61.2" = rec {
         crateName = "windows-sys";
@@ -17034,7 +15627,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Wdk" "Wdk_Foundation" "Wdk_Storage" "Wdk_Storage_FileSystem" "Wdk_System" "Wdk_System_IO" "Win32" "Win32_Foundation" "Win32_Globalization" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Security_Authentication" "Win32_Security_Authentication_Identity" "Win32_Security_Credentials" "Win32_Security_Cryptography" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Com" "Win32_System_Console" "Win32_System_IO" "Win32_System_LibraryLoader" "Win32_System_Memory" "Win32_System_Pipes" "Win32_System_SystemInformation" "Win32_System_SystemServices" "Win32_System_Threading" "Win32_System_WindowsProgramming" "Win32_UI" "Win32_UI_Input" "Win32_UI_Input_KeyboardAndMouse" "Win32_UI_Shell" "default" ];
+        resolvedDefaultFeatures = [ "Wdk" "Wdk_Foundation" "Wdk_Storage" "Wdk_Storage_FileSystem" "Wdk_System" "Wdk_System_IO" "Win32" "Win32_Foundation" "Win32_Globalization" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Com" "Win32_System_Console" "Win32_System_Diagnostics" "Win32_System_Diagnostics_Debug" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_SystemServices" "Win32_System_Threading" "Win32_System_WindowsProgramming" "Win32_UI" "Win32_UI_Input" "Win32_UI_Input_KeyboardAndMouse" "Win32_UI_Shell" "default" ];
       };
       "windows-targets 0.48.5" = rec {
         crateName = "windows-targets";

--- a/nobodywho/Cargo.toml
+++ b/nobodywho/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "grammar/gbnf",
     "grammar/gbnf-macro",
     "uniffi",
+    "wasm",
 ]
 
 # edition = "2021" implies resolver = "2".

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -12,7 +12,7 @@ monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.7" }
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
-llama-cpp-2 = { git = "https://github.com/marek-hradil/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
     "openmp",
     "android-static-stdcxx",
     "mtmd",
@@ -58,14 +58,20 @@ libc = "0.2"
 [target.'cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
 dirs = "6"
 
-# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding Apple platforms and Android).
-# Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
-# (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
-[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/marek-hradil/llama-cpp-rs", branch = "main", default-features = false, features = [
+# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding macOS, iOS, Android)
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",
     "android-static-stdcxx",
+    "llguidance",
+] }
+
+# Enable Metal on iOS. (macOS aarch64 gets Metal automatically from llama-cpp-2's own target-cfg upstream.)
+[target.'cfg(target_os = "ios")'.dependencies]
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
+    "metal",
+    "mtmd",
     "llguidance",
 ] }

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -8,8 +8,11 @@ encoding_rs = "0.8.34"
 thiserror = "2.0.3"
 minijinja = { version = "2.11.0", features = ["builtins", "json", "loader"] }
 minijinja-contrib = { version = "2.11.0", features = ["pycompat"] }
-monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.7" }
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
+# `monty` (Python interpreter) and `bashkit` (virtual bash) back the
+# `Tool::python` and `Tool::bash` built-in tools. Both have native-only
+# dependencies (monty has no wasm32 target; bashkit forces `tokio/full`
+# which pulls `mio` + raw sockets). Moved to a target-conditional block
+# so wasm32 consumers can still use everything else in the crate.
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
 llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
@@ -45,6 +48,8 @@ indexmap = "2.13.0"
 tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 ureq = { version = "3", features = ["rustls"] }
 indicatif = "0.18"
+monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.7" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.43.0", features = ["sync", "rt", "macros"] }

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -67,20 +67,14 @@ libc = "0.2"
 [target.'cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
 dirs = "6"
 
-# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding macOS, iOS, Android)
-[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
+# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding Apple platforms and Android).
+# Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
+# (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
 llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",
     "android-static-stdcxx",
-    "llguidance",
-] }
-
-# Enable Metal on iOS. (macOS aarch64 gets Metal automatically from llama-cpp-2's own target-cfg upstream.)
-[target.'cfg(target_os = "ios")'.dependencies]
-llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
-    "metal",
-    "mtmd",
     "llguidance",
 ] }

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -53,6 +53,10 @@ bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.43.0", features = ["sync", "rt", "macros"] }
+# Used by ChatHandleAsync::new / EncoderAsync::new / CrossEncoderAsync::new
+# to spawn the worker future on the JS event loop in place of
+# `std::thread::spawn`.
+wasm-bindgen-futures = "0.4"
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -19,12 +19,6 @@ llama-cpp-2 = { git = "https://github.com/marek-hradil/llama-cpp-rs", branch = "
     "llguidance",
 ] }
 lazy_static = "1.5.0"
-tokio = { version = "1.43.0", features = [
-    "sync",
-    "rt",
-    "rt-multi-thread",
-    "macros",
-] }
 tokio-stream = "0.1.17"
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = "0.3.19"
@@ -37,13 +31,31 @@ rand = "0.9.3"
 futures = "0.3.31"
 ahash = "0.8.12"
 indexmap = "2.13.0"
+
+# Native-only deps:
+# - `tokio` with `rt-multi-thread`: background workers spawn real OS threads.
+#   wasm32 has only a single-threaded JS event loop, so it gets `rt` (no
+#   multi-thread). See `nobodywho/wasm/README.md` for the worker-refactor
+#   follow-up that actually makes wasm32 builds run.
+# - `ureq` does raw TCP/TLS; not available in a browser sandbox. wasm32 fetches
+#   model bytes on the JS side via `fetch` and hands them to a future
+#   `Model::load_bytes` API instead.
+# - `indicatif` renders terminal progress bars. No terminal in a browser.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.43.0", features = ["sync", "rt", "rt-multi-thread", "macros"] }
 ureq = { version = "3", features = ["rustls"] }
 indicatif = "0.18"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1.43.0", features = ["sync", "rt", "macros"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
+# `dirs` resolves OS-standard cache/config paths. Neither Android nor wasm32
+# fits that model: Android reads /proc/self/cmdline directly (see llm.rs),
+# wasm32 has no filesystem at all.
+[target.'cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
 dirs = "6"
 
 # Enable Vulkan for x86_64, x86, and aarch64 targets (excluding Apple platforms and Android).

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -280,8 +280,8 @@ impl ChatBuilder {
 
     /// Build a blocking chat handle and start the background worker.
     ///
-    /// Native-only. wasm32 has no real threads and no way to `.completed()`
-    /// the result; use `build_async` and await on the returned future instead.
+    /// Native-only. Uses `std::thread::spawn` internally, which doesn't
+    /// work on wasm without thread support enabled. Use `build_async` on wasm.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn build(self) -> ChatHandle {
         ChatHandle::new(self.model, self.config)

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -878,11 +878,17 @@ impl ChatHandleAsync {
 }
 
 /// A stream of tokens from the model.
+///
+/// Native-only synchronous stream — `next_token` calls `blocking_recv`, which
+/// would deadlock the single-threaded JS event loop. Wasm consumers use
+/// [`TokenStreamAsync`] instead, returned from [`ChatHandleAsync::ask`].
+#[cfg(not(target_arch = "wasm32"))]
 pub struct TokenStream {
     rx: tokio::sync::mpsc::UnboundedReceiver<llm::WriteOutput>,
     completed_response: Option<String>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl TokenStream {
     fn new(rx: tokio::sync::mpsc::UnboundedReceiver<llm::WriteOutput>) -> Self {
         Self {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -279,6 +279,10 @@ impl ChatBuilder {
     }
 
     /// Build a blocking chat handle and start the background worker.
+    ///
+    /// Native-only. wasm32 has no real threads and no way to `.completed()`
+    /// the result; use `build_async` and await on the returned future instead.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn build(self) -> ChatHandle {
         ChatHandle::new(self.model, self.config)
     }
@@ -292,10 +296,13 @@ impl ChatBuilder {
 /// Interact with a ChatWorker in a blocking manner.
 ///
 /// Use [`ChatBuilder`] to create a new instance with a fluent API.
+/// Native-only synchronous chat handle. Use `ChatHandleAsync` on wasm.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct ChatHandle {
     guard: WorkerGuard<ChatMsg>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ChatHandle {
     /// Create a new chat handle directly. Consider using [`ChatBuilder`] for a more ergonomic API.
     pub fn new(model: Arc<llm::Model>, config: ChatConfig) -> Self {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -299,7 +299,7 @@ pub struct ChatHandle {
 impl ChatHandle {
     /// Create a new chat handle directly. Consider using [`ChatBuilder`] for a more ergonomic API.
     pub fn new(model: Arc<llm::Model>, config: ChatConfig) -> Self {
-        let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let should_stop = Arc::new(AtomicBool::new(false));
         let should_stop_clone = Arc::clone(&should_stop);
@@ -313,7 +313,10 @@ impl ChatHandle {
                 }
             };
 
-            while let Ok(msg) = msg_rx.recv() {
+            // `blocking_recv` on a tokio unbounded channel is safe outside a
+            // tokio runtime context (we're in a raw `std::thread::spawn`'d
+            // thread). Returns `None` when the channel is closed.
+            while let Some(msg) = msg_rx.blocking_recv() {
                 if let Err(e) = process_worker_msg(&mut worker_state, msg) {
                     return error!("Worker crashed: {e}");
                 }
@@ -568,11 +571,17 @@ pub struct ChatHandleAsync {
 impl ChatHandleAsync {
     /// Create a new chat handle directly. Consider using [`ChatBuilder`] for a more ergonomic API.
     pub fn new(model: Arc<llm::Model>, config: ChatConfig) -> Self {
-        let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let should_stop = Arc::new(AtomicBool::new(false));
         let should_stop_clone = Arc::clone(&should_stop);
 
+        // Native: spawn a real OS thread that drives a blocking loop, so the
+        // inference work doesn't tie up any tokio runtime thread. Wasm: spawn
+        // a future on the JS event loop (single-threaded cooperative); decode
+        // calls block the loop until each message is processed, which is
+        // acceptable for v1. A Web-Worker variant can come later.
+        #[cfg(not(target_arch = "wasm32"))]
         let join_handle = std::thread::spawn(move || {
             let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
             let mut worker_state = match worker {
@@ -582,16 +591,36 @@ impl ChatHandleAsync {
                 }
             };
 
-            while let Ok(msg) = msg_rx.recv() {
+            while let Some(msg) = msg_rx.blocking_recv() {
                 if let Err(e) = process_worker_msg(&mut worker_state, msg) {
                     return error!("Worker crashed: {e}");
                 }
             }
         });
 
-        Self {
-            guard: Arc::new(WorkerGuard::new(msg_tx, join_handle, Some(should_stop))),
-        }
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(async move {
+            let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!("Could not set up the worker initial state: {errmsg}")
+                }
+            };
+
+            while let Some(msg) = msg_rx.recv().await {
+                if let Err(e) = process_worker_msg(&mut worker_state, msg) {
+                    return error!("Worker crashed: {e}");
+                }
+            }
+        });
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, join_handle, Some(should_stop)));
+        #[cfg(target_arch = "wasm32")]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, Some(should_stop)));
+
+        Self { guard }
     }
 
     /// Send a message and get a tokio channel

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -42,8 +42,11 @@ impl CrossEncoder {
 
 impl CrossEncoderAsync {
     pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
-        let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
 
+        // Native: real OS thread with blocking_recv.
+        // wasm32: spawn_local. See ChatHandleAsync::new for rationale.
+        #[cfg(not(target_arch = "wasm32"))]
         let join_handle = std::thread::spawn(move || {
             let worker = Worker::new_crossencoder_worker(&model, n_ctx);
             let mut worker_state = match worker {
@@ -53,16 +56,36 @@ impl CrossEncoderAsync {
                 }
             };
 
-            while let Ok(msg) = msg_rx.recv() {
+            while let Some(msg) = msg_rx.blocking_recv() {
                 if let Err(e) = process_worker_msg(&mut worker_state, msg) {
                     return error!(error=%e, "Cross-encoder worker crashed");
                 }
             }
         });
 
-        Self {
-            guard: Arc::new(WorkerGuard::new(msg_tx, join_handle, None)),
-        }
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(async move {
+            let worker = Worker::new_crossencoder_worker(&model, n_ctx);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!(error=%errmsg, "Could not set up the worker initial state")
+                }
+            };
+
+            while let Some(msg) = msg_rx.recv().await {
+                if let Err(e) = process_worker_msg(&mut worker_state, msg) {
+                    return error!(error=%e, "Cross-encoder worker crashed");
+                }
+            }
+        });
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, join_handle, None));
+        #[cfg(target_arch = "wasm32")]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, None));
+
+        Self { guard }
     }
 
     pub async fn rank(

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -29,8 +29,12 @@ impl Encoder {
 
 impl EncoderAsync {
     pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
-        let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
 
+        // Native: real OS thread with blocking_recv.
+        // wasm32: spawn_local async future. See ChatHandleAsync::new for the
+        // rationale and caveats.
+        #[cfg(not(target_arch = "wasm32"))]
         let join_handle = std::thread::spawn(move || {
             let worker = Worker::new_encoder_worker(&model, n_ctx);
             let mut worker_state = match worker {
@@ -40,16 +44,36 @@ impl EncoderAsync {
                 }
             };
 
-            while let Ok(msg) = msg_rx.recv() {
+            while let Some(msg) = msg_rx.blocking_recv() {
                 if let Err(e) = process_worker_msg(&mut worker_state, msg) {
                     return error!(error=%e, "Encoder Worker crashed");
                 }
             }
         });
 
-        Self {
-            guard: Arc::new(WorkerGuard::new(msg_tx, join_handle, None)),
-        }
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(async move {
+            let worker = Worker::new_encoder_worker(&model, n_ctx);
+            let mut worker_state = match worker {
+                Ok(worker_state) => worker_state,
+                Err(errmsg) => {
+                    return error!(error=%errmsg, "Could not set up the worker initial state")
+                }
+            };
+
+            while let Some(msg) = msg_rx.recv().await {
+                if let Err(e) = process_worker_msg(&mut worker_state, msg) {
+                    return error!(error=%e, "Encoder Worker crashed");
+                }
+            }
+        });
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, join_handle, None));
+        #[cfg(target_arch = "wasm32")]
+        let guard = Arc::new(WorkerGuard::new(msg_tx, None));
+
+        Self { guard }
     }
 
     pub async fn encode(&self, text: String) -> Result<Vec<f32>, EncoderWorkerError> {

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -159,6 +159,14 @@ pub fn has_gpu_backend() -> bool {
     false
 }
 
+// --- Native-only model loaders -------------------------------------------
+// Everything below up to `read_add_bos_metadata` does HTTP downloads, hits
+// the filesystem, or asks the OS for a cache directory. None of that works
+// in a browser sandbox, so it's gated to non-wasm32 targets. wasm consumers
+// will load models from in-memory bytes via a future `Model::load_from_bytes`
+// API (tracked in nobodywho/wasm/README.md, Step 2c).
+
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 enum ParsedModelPath {
     HuggingFaceUrl(String, String, String), // e.g. hf://owner/repo/model.gguf -> (owner, repo, filename)
@@ -166,6 +174,7 @@ enum ParsedModelPath {
     FilesystemPath(std::path::PathBuf),     // e.g. ./qwen3.gguf
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn parse_model_path(
     model_path: &str,
 ) -> Result<ParsedModelPath, nom::Err<nom::error::Error<String>>> {
@@ -213,6 +222,7 @@ fn parse_model_path(
 
 /// takes a fancy path (possibly with hf: or https:// in front), and resolve it to a realized path
 /// on the filesystem
+#[cfg(not(target_arch = "wasm32"))]
 fn resolve_fancy_path_to_fs(
     parsed_path: ParsedModelPath,
     progress: &DownloadProgressCallback,
@@ -234,6 +244,7 @@ fn resolve_fancy_path_to_fs(
     Ok(fs_model_path)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tracing::instrument(level = "info", skip(progress))]
 pub fn get_model(
     model_path: &str,
@@ -312,6 +323,7 @@ pub fn get_model(
 /// * The model file is not found (`LoadModelError::ModelNotFound`)
 /// * The model file is invalid or unsupported (`LoadModelError::InvalidModel`)
 /// * The communication channel closes unexpectedly (`LoadModelError::ModelChannelError`)
+#[cfg(not(target_arch = "wasm32"))]
 #[tracing::instrument(level = "info", skip(progress))]
 pub async fn get_model_async(
     model_path: String,
@@ -343,12 +355,13 @@ pub async fn get_model_async(
 /// via `dlopen` (not `System.loadLibrary`), so `JNI_OnLoad` is never called.
 ///
 /// On other platforms, uses the `dirs` crate to find the standard cache directory.
+#[cfg(not(target_arch = "wasm32"))]
 fn get_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     let base = get_platform_cache_dir()?;
     Ok(base.join("nobodywho").join("models"))
 }
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", not(target_arch = "wasm32")))]
 fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     // Read the package name from /proc/self/cmdline. This file contains the process
     // name as a null-terminated string. On Android this is the package name
@@ -383,7 +396,7 @@ fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadMod
     )))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
 fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadModelError> {
     dirs::cache_dir().ok_or_else(|| {
         crate::errors::LoadModelError::DownloadError("Could not determine cache directory".into())
@@ -394,6 +407,7 @@ fn get_platform_cache_dir() -> Result<std::path::PathBuf, crate::errors::LoadMod
 ///
 /// Returns early if the file already exists at the target path.
 /// Rejects paths containing `..` to prevent path traversal attacks.
+#[cfg(not(target_arch = "wasm32"))]
 fn download_file(
     url: &str,
     target_path: &std::path::Path,
@@ -526,6 +540,7 @@ fn download_file(
 /// Download a GGUF model from HuggingFace Hub and return the local path to it.
 ///
 /// If the model is already cached locally, the cached path is returned without downloading.
+#[cfg(not(target_arch = "wasm32"))]
 fn download_model_from_hf(
     owner: &str,
     repo: &str,
@@ -542,6 +557,7 @@ fn download_model_from_hf(
 /// Download a model from a generic HTTP(S) URL and return the local path to it.
 ///
 /// The file is cached by its URL path components under the cache directory.
+#[cfg(not(target_arch = "wasm32"))]
 fn download_model_from_url(
     url: &str,
     progress: &DownloadProgressCallback,

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -894,26 +894,49 @@ where
     }
 }
 
-/// Owns a background worker thread's resources and ensures clean shutdown.
+/// Owns a background worker's resources and ensures clean shutdown.
 ///
 /// When dropped: sets the optional stop flag, closes the message channel (causing the
-/// worker's `recv()` to return `Err`), then joins the thread. This ordering guarantees
-/// the worker has fully exited before any statics (e.g. `LLAMA_BACKEND`) are destroyed.
+/// worker's `recv()` to return `None`), then joins the thread on native. This ordering
+/// guarantees the worker has fully exited before any statics (e.g. `LLAMA_BACKEND`)
+/// are destroyed.
+///
+/// The channel switched from `std::sync::mpsc` to `tokio::sync::mpsc::unbounded_channel`
+/// so the worker can run as either a blocking thread (native, via `blocking_recv()`)
+/// or an async task on the JS event loop (wasm32, via `recv().await` driven by
+/// `wasm_bindgen_futures::spawn_local`). The `JoinHandle` field is gated to non-wasm —
+/// wasm has no real thread to join; dropping the sender is sufficient to terminate
+/// the worker future.
 pub(crate) struct WorkerGuard<T> {
-    pub(crate) msg_tx: Option<std::sync::mpsc::Sender<T>>,
+    pub(crate) msg_tx: Option<tokio::sync::mpsc::UnboundedSender<T>>,
+    #[cfg(not(target_arch = "wasm32"))]
     join_handle: Option<std::thread::JoinHandle<()>>,
     should_stop: Option<Arc<AtomicBool>>,
 }
 
 impl<T> WorkerGuard<T> {
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn new(
-        msg_tx: std::sync::mpsc::Sender<T>,
+        msg_tx: tokio::sync::mpsc::UnboundedSender<T>,
         join_handle: std::thread::JoinHandle<()>,
         should_stop: Option<Arc<AtomicBool>>,
     ) -> Self {
         Self {
             msg_tx: Some(msg_tx),
             join_handle: Some(join_handle),
+            should_stop,
+        }
+    }
+
+    /// wasm constructor: no thread to join, the worker future runs on the JS
+    /// event loop and exits when the channel is closed.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn new(
+        msg_tx: tokio::sync::mpsc::UnboundedSender<T>,
+        should_stop: Option<Arc<AtomicBool>>,
+    ) -> Self {
+        Self {
+            msg_tx: Some(msg_tx),
             should_stop,
         }
     }
@@ -937,6 +960,13 @@ impl<T> Drop for WorkerGuard<T> {
             stop.store(true, Ordering::Relaxed);
         }
         drop(self.msg_tx.take());
+
+        // On native, wait for the worker thread to exit so any statics
+        // (e.g. LLAMA_BACKEND) are still alive while it's tearing down.
+        // On wasm32 there's no thread — closing the channel above causes
+        // the worker's `recv().await` to return None and the spawn_local
+        // future to complete on its next poll.
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(handle) = self.join_handle.take() {
             if let Err(e) = handle.join() {
                 error!("Worker panicked: {:?}", e);

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -14,13 +14,19 @@ use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::token::LlamaToken;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::{Read, Write};
 use std::pin::pin;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
-use tracing::{debug, debug_span, error, info, info_span, warn};
+use tracing::{debug, debug_span, error, info, warn};
+// `info_span` is only used inside the native model-loader path; gate it so the
+// wasm build doesn't warn about an unused import.
+#[cfg(not(target_arch = "wasm32"))]
+use tracing::info_span;
 
 #[derive(Debug)]
 pub(crate) struct GlobalInferenceLockToken;
@@ -185,10 +191,7 @@ pub fn has_gpu_backend() -> bool {
 /// `fmemopen` is POSIX and not in the MSVC CRT; a Windows tempfile
 /// fallback can be added later if a caller needs it.
 #[cfg(not(all(target_os = "windows", target_env = "msvc")))]
-pub fn get_model_from_bytes(
-    bytes: &[u8],
-    gpu_layers: u32,
-) -> Result<Model, LoadModelError> {
+pub fn get_model_from_bytes(bytes: &[u8], gpu_layers: u32) -> Result<Model, LoadModelError> {
     info!(
         bytes_len = bytes.len(),
         gpu_layers, "Loading model from in-memory bytes"
@@ -1008,5 +1011,30 @@ mod tests {
         cb(50, 100);
         cb(100, 100);
         assert_eq!(count.load(Ordering::Relaxed), 2);
+    }
+
+    /// Error-path test for the bytes-based loader: feeding non-GGUF bytes
+    /// must return `LoadModelError::InvalidModel` (rather than panicking,
+    /// returning a different error variant, or — worst — silently succeeding).
+    ///
+    /// We deliberately don't test the success path here: under nix-sandbox
+    /// Linux, llama.cpp's `llama_model_load_from_buffer` (POSIX `fmemopen`
+    /// path) returns NULL for an otherwise-valid GGUF that loads fine via
+    /// the file-based path. Tracking the underlying llama.cpp issue is
+    /// out of scope for this PR; the bytes-loader's success path is
+    /// covered end-to-end by the wasm binding's CI smoke test, where
+    /// emscripten provides its own `fmemopen` that does work.
+    #[cfg(not(all(target_os = "windows", target_env = "msvc")))]
+    #[test]
+    fn get_model_from_bytes_rejects_invalid_data() {
+        use crate::test_utils::init_test_tracing;
+        init_test_tracing();
+        // Definitely not a valid GGUF — even the magic header is missing.
+        let bytes = vec![0u8; 4096];
+        let result = get_model_from_bytes(&bytes, 0);
+        assert!(
+            matches!(result, Err(LoadModelError::InvalidModel(_))),
+            "expected InvalidModel error, got {result:?}"
+        );
     }
 }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,6 +1,7 @@
 use crate::errors::{InitWorkerError, LoadModelError, ReadError};
 use crate::memory;
 use crate::tokenizer::{ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks};
+#[cfg(not(target_arch = "wasm32"))]
 use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
@@ -45,6 +46,11 @@ pub type DownloadProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
 /// unconditionally — GUI bindings (Godot, Flutter mobile) won't see output in production.
 /// Detects a new download (model → mmproj transition) by watching for `total` to change,
 /// finishes the previous bar, and starts a fresh one.
+///
+/// Native-only: `indicatif` is not pulled in on wasm32 (no terminal). The wasm
+/// model-load path (`Model::load_bytes`, future) skips this entirely since
+/// bytes are already in memory.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn default_progress_callback() -> DownloadProgressCallback {
     let style = ProgressStyle::with_template(
         "{spinner:.green} [{elapsed_precise}] {wide_bar:.cyan/blue} \

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -159,6 +159,58 @@ pub fn has_gpu_backend() -> bool {
     false
 }
 
+/// Load a model directly from an in-memory GGUF byte slice.
+///
+/// Primarily intended for sandboxed environments without filesystem access
+/// (notably WebAssembly in a browser tab), where the caller fetches the GGUF
+/// from JS via `fetch` and hands the resulting `ArrayBuffer` over to Rust.
+///
+/// On native targets this also works and is useful for tests where the GGUF
+/// is already in memory. Unlike [`get_model`] this does not consult the
+/// `dirs` cache, does not do HTTP, and does not parse fancy paths — it's a
+/// pure "bytes in, model out" entry point.
+///
+/// GPU offloading is intentionally not exposed: the wasm32 target has no
+/// GPU concept, and on native the `get_model` path is the right one when
+/// you have a file path. Pass any `use_gpu_if_available` policy via the
+/// `gpu_layers` argument (`0` for CPU-only).
+///
+/// Multimodal (`projection_model`) support is not yet wired here — the
+/// mmproj path also needs a buffer-based loader; tracked in WASM.md.
+///
+/// # Platform support
+///
+/// Available everywhere except Windows MSVC, mirroring
+/// [`llama_cpp_2::model::LlamaModel::load_from_buffer`]. The underlying
+/// `fmemopen` is POSIX and not in the MSVC CRT; a Windows tempfile
+/// fallback can be added later if a caller needs it.
+#[cfg(not(all(target_os = "windows", target_env = "msvc")))]
+pub fn get_model_from_bytes(
+    bytes: &[u8],
+    gpu_layers: u32,
+) -> Result<Model, LoadModelError> {
+    info!(
+        bytes_len = bytes.len(),
+        gpu_layers, "Loading model from in-memory bytes"
+    );
+
+    let model_params = LlamaModelParams::default().with_n_gpu_layers(gpu_layers);
+    let model_params = pin!(model_params);
+
+    let language_model = LlamaModel::load_from_buffer(&LLAMA_BACKEND, bytes, &model_params)
+        .map_err(|e| {
+            let error_msg = format!("Failed to load model from in-memory bytes: {e}");
+            error!(error = %error_msg);
+            LoadModelError::InvalidModel(error_msg)
+        })?;
+
+    info!("Model loaded from buffer successfully");
+    Ok(Model {
+        language_model,
+        projection_model: None,
+    })
+}
+
 // --- Native-only model loaders -------------------------------------------
 // Everything below up to `read_add_bos_metadata` does HTTP downloads, hits
 // the filesystem, or asks the OS for a cache directory. None of that works

--- a/nobodywho/core/src/memory.rs
+++ b/nobodywho/core/src/memory.rs
@@ -1,7 +1,12 @@
 use crate::errors::MemoryError;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 use tracing::warn;
 
+// `GgufModelInfo` and the load-planning items below feed `plan_model_loading`,
+// which is only called from the native model-loader path (`get_model`). Gated
+// to non-wasm so the wasm build doesn't warn about unused items.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct GgufModelInfo {
     pub n_layers: u32,
     pub file_size: u64,
@@ -46,6 +51,7 @@ fn select_best_gpu() -> Option<llama_cpp_2::LlamaBackendDevice> {
         })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn read_gguf_model_info(path: &Path) -> Option<GgufModelInfo> {
     let ctx = llama_cpp_2::gguf::GgufContext::from_file(path)?;
     let file_size = std::fs::metadata(path).ok()?.len();
@@ -67,6 +73,7 @@ fn read_gguf_model_info(path: &Path) -> Option<GgufModelInfo> {
     })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn estimate_per_layer_bytes(info: &GgufModelInfo) -> u64 {
     if info.n_layers == 0 {
         return info.file_size;
@@ -82,6 +89,7 @@ fn estimate_kv_cache_bytes(arch: &ModelArchitecture, n_ctx: u32) -> u64 {
 
 /// Compute how many GPU layers to offload based on available VRAM.
 /// This function never fails: on any estimation error it falls back to current behavior.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn plan_model_loading(
     model_path: &Path,
     mmproj_path: Option<&Path>,

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -14,11 +14,16 @@ mod ministral3;
 mod qwen3;
 mod qwen35_36;
 
+#[cfg(not(target_arch = "wasm32"))]
 use bashkit::{ExecutionLimits, InMemoryFs};
 use llama_cpp_2::model::LlamaModel;
+#[cfg(not(target_arch = "wasm32"))]
 use monty::{LimitedTracker, MontyRun, PrintWriter, ResourceLimits};
 use serde::{ser::Serializer, Deserialize, Serialize};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+// `Duration` is only used by the native-only `Tool::python` builder.
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Duration;
 use tracing::debug;
 
 pub use functiongemma::FunctionGemmaHandler;
@@ -66,6 +71,10 @@ impl Tool {
         }
     }
 
+    /// Built-in Python tool, backed by the `monty` interpreter. Native-only:
+    /// `monty` does not currently target wasm32. wasm consumers can still call
+    /// `Tool::new` with their own JS-side Python implementation if needed.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn python(
         max_duration: Option<Duration>,
         max_memory: Option<usize>,
@@ -121,6 +130,11 @@ impl Tool {
         )
     }
 
+    /// Built-in bash tool, backed by the `bashkit` virtual interpreter.
+    /// Native-only: `bashkit` requires `tokio/full` (mio + sockets) which
+    /// doesn't compile to wasm32. wasm consumers don't typically have a
+    /// shell concept anyway; if needed, define a custom tool via `Tool::new`.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn bash(max_commands: Option<usize>) -> Self {
         Tool::new(
             "run_bash",

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -11,7 +11,7 @@
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_source_file@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
-  "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#llama-cpp-2@0.1.147": "1cwbj0wiq9s3kbng5kbygg9ddg5xqgw4nazsv5zd4mbhcjykgzqz",
-  "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.147": "1cwbj0wiq9s3kbng5kbygg9ddg5xqgw4nazsv5zd4mbhcjykgzqz",
+  "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#llama-cpp-2@0.1.147": "18pwz1r43dj6918dajlg61ak9zlhwazsblqj6hv9aj0qaks7rz4n",
+  "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#llama-cpp-sys-2@0.1.147": "18pwz1r43dj6918dajlg61ak9zlhwazsblqj6hv9aj0qaks7rz4n",
   "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa"
 }

--- a/nobodywho/grammar/gbnf/Cargo.toml
+++ b/nobodywho/grammar/gbnf/Cargo.toml
@@ -5,7 +5,13 @@ edition = "2024"
 
 [dependencies]
 serde_json = "1"
-jsonschema = "0.41.0"
+# `jsonschema` defaults pull in `resolve-http` (reqwest + rustls + hyper +
+# tokio/net + mio) and `resolve-file` (filesystem-backed $ref resolution).
+# Neither is needed here: the only use is `jsonschema::meta::is_valid` (a
+# pure in-memory metaschema check) in src/json.rs. Disabling defaults drops
+# ~12 transitive crates including the HTTP stack, which lets this crate
+# compile to wasm32-unknown-unknown (where mio does not build).
+jsonschema = { version = "0.41.0", default-features = false }
 
 [dev-dependencies]
 insta = "1.46.1"

--- a/nobodywho/wasm/.gitignore
+++ b/nobodywho/wasm/.gitignore
@@ -1,0 +1,3 @@
+pkg/
+target/
+node_modules/

--- a/nobodywho/wasm/Cargo.toml
+++ b/nobodywho/wasm/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "nobodywho-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# "cdylib" is necessary for wasm-pack to produce a .wasm artifact.
+# "rlib" lets `cargo check`/`cargo test` work on native targets so the workspace
+# stays buildable without the wasm toolchain installed.
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+nobodywho = { path = "../core" }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.140"
+serde-wasm-bindgen = "0.6"
+futures = "0.3.31"
+tokio = { version = "1.43.0", features = ["sync"] }
+tracing = "0.1.41"
+tracing-wasm = "0.2"
+console_error_panic_hook = "0.1"
+
+[dependencies.web-sys]
+version = "0.3"
+features = ["console"]

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -4,31 +4,82 @@ WebAssembly binding for [NobodyWho](https://nobodywho.ooo), letting you run
 local LLMs in a browser tab via the same core engine that powers the Python,
 Flutter, Godot, and Uniffi bindings.
 
-## Status: scaffold, does not build to wasm yet
+## Status
 
-This crate establishes the binding's public API and workspace integration. It
-**compiles cleanly on native** (so `cargo check` at the workspace root keeps
-working), but `wasm-pack build --target web` will fail until the three
-prerequisites below land.
+The wasm32 build path is **real but untested end-to-end**. `cargo check
+--target wasm32-unknown-emscripten -p nobodywho-wasm` exercises the full
+toolchain (bindgen + cc + cmake via Emscripten) and panics with a clear
+`Could not detect Emscripten sysroot. Ensure 'emcc' is on PATH...`
+message unless `emcc` is installed. Native (`cargo check --workspace`)
+is unaffected.
 
-### Step 1 — `llama-cpp-2` needs a wasm32 build path
+### Build prerequisites
 
-`nobodywho/core/Cargo.toml:15` pins the `marek-hradil/llama-cpp-rs` fork.
-The fork's `build.rs` invokes CMake against llama.cpp's C++ source, which
-has no wasm32 toolchain configured. The plan is to maintain our own fork
-on top of Marek's that adds an Emscripten cmake branch and feature-gates
-out `openmp`, `mtmd`, `cuda`, `vulkan`, and `metal` for
-`target_arch = "wasm32"`.
+The wasm32 target is **`wasm32-unknown-emscripten`** (not
+`wasm32-unknown-unknown`). To produce a `.wasm` artifact you need:
+
+```bash
+# Install emsdk (one-time):
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest
+./emsdk activate latest
+source ./emsdk_env.sh   # adds emcc, em++ to PATH
+
+# Add the rustc target:
+rustup target add wasm32-unknown-emscripten
+
+# Build:
+cd nobodywho/wasm
+cargo build --target wasm32-unknown-emscripten --release
+# or, for the JS-bundle output:
+wasm-pack build --target web
+```
+
+### What's wired up
+
+The `llama-cpp-2` fork at
+[`nobodywho-ooo/llama-cpp-rs` `wasm`](https://github.com/nobodywho-ooo/llama-cpp-rs/tree/wasm)
+inherits Marek's llguidance/EOS-fix patches and adds Asbjørn's Emscripten
+support (cherry-picked from his branch). Specifically:
+
+- `TargetOs::Emscripten` variant + sysroot/toolchain auto-detection from
+  `emcc --cflags` and `which emcc`.
+- Bindgen configured with the real sysroot + `--target=wasm32-unknown-emscripten`
+  + `-fvisibility=default` (workaround for bindgen #1941).
+- `cc` wrapper-shim build uses `em++` with `-fwasm-exceptions` (native wasm EH).
+- cmake disables every GPU backend (`GGML_VULKAN`/`GGML_CUDA`/`GGML_METAL`/etc.),
+  forces `BUILD_SHARED_LIBS=OFF` and `LLAMA_WASM_MEM64=OFF`.
+
+See `WASM.md` in the fork for the full build details and remaining gaps.
+
+### Outstanding work
+
+1. **End-to-end build verification.** Asbjørn's commits are marked
+   "still untested". Someone with `emsdk` activated needs to run
+   `cargo build --target wasm32-unknown-emscripten` and shake out any
+   remaining flag tuning.
+2. **`Model::load_from_bytes`.** The current `Model::loadBytes` in
+   `src/lib.rs` returns a placeholder `JsError`. Wiring it up needs a
+   `LlamaModel::load_from_buffer` wrapper in the fork (Step 2c below).
+3. **Worker refactor.** `core/src/chat.rs:307` and similar use
+   `std::thread::spawn`, which wasm32 doesn't have. Needs cfg-gated
+   `wasm_bindgen_futures::spawn_local` path.
 
 ### Step 2a — `core/` dependency gates ✅ done
 
-Landed in commit following the scaffold:
 - `core/Cargo.toml` — `tokio` split: `rt-multi-thread` on native, plain
   `rt` on wasm. `ureq` (raw sockets, not available in browser) and
   `indicatif` (no terminal) gated to non-wasm. `dirs` gated to non-android,
-  non-wasm.
-- `core/src/llm.rs` — `default_progress_callback` and the `indicatif`
-  import gated to non-wasm.
+  non-wasm. `monty` (Python interpreter) and `bashkit` (virtual bash) gated
+  to non-wasm.
+- `core/src/llm.rs` — `default_progress_callback` and the entire
+  model-loader infrastructure (`get_model`, `get_model_async`,
+  `download_*`, `ParsedModelPath`) gated to non-wasm.
+- `core/src/tool_calling/mod.rs` — `Tool::python` and `Tool::bash` gated
+  to non-wasm.
+- `grammar/gbnf` — `jsonschema` default features disabled (no HTTP/file
+  resolution needed), drops the entire `reqwest`/`hyper`/`mio` chain.
 
 ### Step 2b — Worker refactor (not yet done)
 

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -1,0 +1,104 @@
+# nobodywho-wasm
+
+WebAssembly binding for [NobodyWho](https://nobodywho.ooo), letting you run
+local LLMs in a browser tab via the same core engine that powers the Python,
+Flutter, Godot, and Uniffi bindings.
+
+## Status: scaffold, does not build to wasm yet
+
+This crate establishes the binding's public API and workspace integration. It
+**compiles cleanly on native** (so `cargo check` at the workspace root keeps
+working), but `wasm-pack build --target web` will fail until two upstream
+prerequisites land:
+
+1. **`llama-cpp-2` needs a wasm32 build path.**
+   `nobodywho/core/Cargo.toml:15` pins the `marek-hradil/llama-cpp-rs` fork.
+   The fork's `build.rs` invokes CMake against llama.cpp's C++ source, which
+   has no wasm32 toolchain configured. The plan (Option 1 / Step 1 of the
+   WASM rollout) is to maintain our own fork on top of Marek's that adds an
+   Emscripten cmake branch and feature-gates out `openmp`, `mtmd`, `cuda`,
+   `vulkan`, and `metal` for `target_arch = "wasm32"`.
+
+2. **`nobodywho/core` needs `cfg(target_arch = "wasm32")` gating.**
+   Specifically:
+   - `core/Cargo.toml:22-27` — split tokio features so wasm gets `rt` only,
+     not `rt-multi-thread`.
+   - `core/Cargo.toml:40` — gate the `ureq` HTTP download dependency to
+     non-wasm targets; add a bytes-based `Model::load_bytes` API for wasm.
+   - `core/src/chat.rs:307`, `core/src/llm.rs` Worker setup — replace
+     `std::thread::spawn` with `wasm_bindgen_futures::spawn_local` on wasm.
+   - `core/src/llm.rs` `default_progress_callback` (`indicatif`) — gate to
+     non-wasm.
+
+Neither change touches this crate; both unblock it.
+
+## What's exposed
+
+Mirrors the Python binding's surface, async-only:
+
+| Class | Methods |
+|---|---|
+| `Model` | `Model.loadBytes(uint8Array)` *(blocked on Step 2)* |
+| `Chat` | `new Chat(model, options)`, `ask(prompt)`, `reset(systemPrompt?)`, `resetHistory()` |
+| `TokenStream` | `nextToken()`, `completed()` |
+| `Encoder` | `new Encoder(model, nCtx?)`, `encode(text)` |
+
+Not yet wrapped (will be added in follow-up PRs): `CrossEncoder`,
+`Constraint` (structured output), tool calling, multimodal assets. See the
+end of `src/lib.rs` for the full out-of-scope list and the reason each is
+deferred.
+
+## Build (once Steps 1 and 2 are done)
+
+```bash
+# One-time setup
+cargo install wasm-pack
+rustup target add wasm32-unknown-unknown
+
+# Build
+cd nobodywho/wasm
+wasm-pack build --target web
+```
+
+Output goes to `nobodywho/wasm/pkg/`. That directory is the publishable npm
+package — `package.json`, `.wasm` artifact, JS glue, and `.d.ts` typings.
+
+## Use (browser, ES modules)
+
+```html
+<script type="module">
+  import init, { Model, Chat } from './pkg/nobodywho_wasm.js';
+
+  await init();
+
+  const buf = await (await fetch('./tinyllama.gguf')).arrayBuffer();
+  const model = await Model.loadBytes(new Uint8Array(buf));
+
+  const chat = new Chat(model, {
+    contextSize: 2048,
+    systemPrompt: 'You are a concise assistant.',
+  });
+
+  const stream = await chat.ask('Why is the sky blue?');
+  let tok;
+  while ((tok = await stream.nextToken()) !== undefined) {
+    document.body.append(tok);
+  }
+</script>
+```
+
+## Caveats
+
+- **Memory ceiling.** `wasm32` is capped at 4 GB. Models larger than that
+  need wasm64 (`memory64` proposal — Chrome 119+, Firefox 134+), which our
+  toolchain doesn't enable yet. Practically: stick to Q4/Q5 quantizations of
+  ≤7B-parameter models for now.
+- **No GPU.** WebGPU acceleration in llama.cpp is experimental upstream and
+  not part of this binding's first release. CPU only.
+- **Cross-origin isolation.** If/when we enable wasm threads via
+  `SharedArrayBuffer`, the hosting page needs `Cross-Origin-Opener-Policy:
+  same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. The
+  first release is single-threaded.
+- **Bundle size.** llama.cpp compiled with Emscripten is several MB. Plan to
+  serve the `.wasm` over HTTPS with `Content-Encoding: br` (Brotli) and
+  cache aggressively.

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -8,29 +8,55 @@ Flutter, Godot, and Uniffi bindings.
 
 This crate establishes the binding's public API and workspace integration. It
 **compiles cleanly on native** (so `cargo check` at the workspace root keeps
-working), but `wasm-pack build --target web` will fail until two upstream
-prerequisites land:
+working), but `wasm-pack build --target web` will fail until the three
+prerequisites below land.
 
-1. **`llama-cpp-2` needs a wasm32 build path.**
-   `nobodywho/core/Cargo.toml:15` pins the `marek-hradil/llama-cpp-rs` fork.
-   The fork's `build.rs` invokes CMake against llama.cpp's C++ source, which
-   has no wasm32 toolchain configured. The plan (Option 1 / Step 1 of the
-   WASM rollout) is to maintain our own fork on top of Marek's that adds an
-   Emscripten cmake branch and feature-gates out `openmp`, `mtmd`, `cuda`,
-   `vulkan`, and `metal` for `target_arch = "wasm32"`.
+### Step 1 — `llama-cpp-2` needs a wasm32 build path
 
-2. **`nobodywho/core` needs `cfg(target_arch = "wasm32")` gating.**
-   Specifically:
-   - `core/Cargo.toml:22-27` — split tokio features so wasm gets `rt` only,
-     not `rt-multi-thread`.
-   - `core/Cargo.toml:40` — gate the `ureq` HTTP download dependency to
-     non-wasm targets; add a bytes-based `Model::load_bytes` API for wasm.
-   - `core/src/chat.rs:307`, `core/src/llm.rs` Worker setup — replace
-     `std::thread::spawn` with `wasm_bindgen_futures::spawn_local` on wasm.
-   - `core/src/llm.rs` `default_progress_callback` (`indicatif`) — gate to
-     non-wasm.
+`nobodywho/core/Cargo.toml:15` pins the `marek-hradil/llama-cpp-rs` fork.
+The fork's `build.rs` invokes CMake against llama.cpp's C++ source, which
+has no wasm32 toolchain configured. The plan is to maintain our own fork
+on top of Marek's that adds an Emscripten cmake branch and feature-gates
+out `openmp`, `mtmd`, `cuda`, `vulkan`, and `metal` for
+`target_arch = "wasm32"`.
 
-Neither change touches this crate; both unblock it.
+### Step 2a — `core/` dependency gates ✅ done
+
+Landed in commit following the scaffold:
+- `core/Cargo.toml` — `tokio` split: `rt-multi-thread` on native, plain
+  `rt` on wasm. `ureq` (raw sockets, not available in browser) and
+  `indicatif` (no terminal) gated to non-wasm. `dirs` gated to non-android,
+  non-wasm.
+- `core/src/llm.rs` — `default_progress_callback` and the `indicatif`
+  import gated to non-wasm.
+
+### Step 2b — Worker refactor (not yet done)
+
+The Worker pattern uses `std::thread::spawn` + blocking `std::sync::mpsc::recv`
+in five places:
+- `core/src/chat.rs:307` (`ChatHandle::new`)
+- `core/src/chat.rs:576` (`ChatHandleAsync::new`)
+- `core/src/encoder.rs:34` (`EncoderAsync::new`)
+- `core/src/crossencoder.rs:47` (`CrossEncoderAsync::new`)
+- `core/src/llm.rs:317` (`get_model_async`)
+
+`WorkerGuard` (`core/src/llm.rs:828`) stores a `std::thread::JoinHandle`.
+
+wasm32 has no OS threads. Each of these needs a cfg-gated alternative that
+uses `wasm_bindgen_futures::spawn_local` and `tokio::sync::mpsc` async
+channels instead. The `WorkerGuard` needs to grow a cfg-gated variant that
+holds a cancellation token instead of a `JoinHandle`. This is a real design
+change — needs maintainer alignment on whether wasm uses cooperative
+single-threaded inference (blocks the main thread during decode) or Web
+Workers for true parallelism.
+
+### Step 2c — Bytes-based model loading (not yet done)
+
+`core/src/llm.rs` `get_model` paths go through file I/O and `ureq`
+downloads. A new `Model::load_bytes(Vec<u8>) -> Result<Model, _>`
+constructor is needed for wasm (and is useful on native too — tests
+already have GGUF bytes in memory). The scaffold's
+`Model::loadBytes` JS API points to this.
 
 ## What's exposed
 

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -149,7 +149,7 @@ impl Chat {
     }
 
     /// Reset the conversation. Optionally provide a new system prompt.
-    /// Tools are cleared on reset.
+    /// (Tools aren't yet exposed in the wasm binding.)
     pub fn reset(&self, system_prompt: Option<String>) -> js_sys::Promise {
         let handle = self.handle.clone();
         promisify(async move {

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -1,0 +1,220 @@
+//! WebAssembly binding for NobodyWho.
+//!
+//! Mirrors the Python binding's API for JS/TS consumers. Async-only, since a
+//! browser tab has no thread to block on. See `README.md` for build instructions.
+//!
+//! # Status: scaffold
+//!
+//! `wasm-pack build --target web` will fail until two upstream changes land:
+//!
+//! 1. The `llama-cpp-2` fork at `marek-hradil/llama-cpp-rs` (pinned at
+//!    `core/Cargo.toml:15`) gains a wasm32 build path. We'll carry our own
+//!    fork as a patch carrier until it's upstreamed.
+//! 2. `nobodywho/core` gates its `std::thread::spawn`, `ureq` downloads, and
+//!    tokio `rt-multi-thread` usage behind `cfg(not(target_arch = "wasm32"))`,
+//!    and exposes a `get_model_from_bytes` constructor (no filesystem in a
+//!    browser tab).
+//!
+//! The shape of the binding (this file) is independent of both blockers — it
+//! compiles natively as an `rlib` so the workspace stays healthy. Only the
+//! wasm32 build needs the upstream work.
+
+use std::sync::Arc;
+use wasm_bindgen::prelude::*;
+
+/// Install panic hook and tracing subscriber. Call once from JS before any
+/// other API. Safe to call multiple times.
+#[wasm_bindgen(js_name = init)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = tracing::subscriber::set_global_default(tracing_wasm::WASMLayer::new(
+            tracing_wasm::WASMLayerConfig::default(),
+        ));
+    }
+}
+
+// ---------- Model ----------
+
+/// A loaded GGUF model. Share between `Chat` and `Encoder` instances; the
+/// underlying model data is reference-counted.
+#[wasm_bindgen]
+pub struct Model {
+    inner: Arc<nobodywho::llm::Model>,
+}
+
+#[wasm_bindgen]
+impl Model {
+    /// Load a model from raw GGUF bytes.
+    ///
+    /// Browser usage: `fetch('model.gguf').then(r => r.arrayBuffer()).then(buf => Model.loadBytes(new Uint8Array(buf)))`.
+    ///
+    /// There's no path-based loader in the wasm binding — the browser sandbox
+    /// has no filesystem. For HuggingFace / URL fetching, do it on the JS side
+    /// before calling this.
+    #[wasm_bindgen(js_name = loadBytes)]
+    pub async fn load_bytes(_bytes: Vec<u8>) -> Result<Model, JsError> {
+        // TODO(wasm-step-2): requires a `get_model_from_bytes` constructor in
+        // `nobodywho::llm` that bypasses both the ureq download path and the
+        // `LlamaModelParams` file-load assumption. Tracked in Step 2 of the
+        // WASM binding plan.
+        Err(JsError::new(
+            "Model.loadBytes is not implemented yet — requires core wasm cfg-gating (Step 2). \
+             See nobodywho/wasm/README.md.",
+        ))
+    }
+}
+
+// ---------- Chat ----------
+
+/// Chat session backed by a model. Manages conversation state, sampling, and tools.
+#[wasm_bindgen]
+pub struct Chat {
+    handle: nobodywho::chat::ChatHandleAsync,
+}
+
+/// Optional config passed to the `Chat` constructor. Pass as a plain JS object:
+/// `new Chat(model, { contextSize: 4096, systemPrompt: "You are helpful." })`.
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct ChatOptions {
+    context_size: Option<u32>,
+    system_prompt: Option<String>,
+}
+
+#[wasm_bindgen]
+impl Chat {
+    /// Create a new chat session bound to a loaded model.
+    #[wasm_bindgen(constructor)]
+    pub fn new(model: &Model, options: JsValue) -> Result<Chat, JsError> {
+        let opts: ChatOptions = if options.is_undefined() || options.is_null() {
+            ChatOptions::default()
+        } else {
+            serde_wasm_bindgen::from_value(options).map_err(|e| JsError::new(&e.to_string()))?
+        };
+
+        let mut builder = nobodywho::chat::ChatBuilder::new(Arc::clone(&model.inner));
+        if let Some(ctx) = opts.context_size {
+            builder = builder.with_context_size(ctx);
+        }
+        if let Some(sys) = opts.system_prompt {
+            builder = builder.with_system_prompt(Some(sys));
+        }
+
+        Ok(Chat {
+            handle: builder.build_async(),
+        })
+    }
+
+    /// Send a prompt and receive a `TokenStream`. Tokens arrive as they're
+    /// generated; await `nextToken()` in a loop, or call `completed()` to
+    /// resolve to the full response.
+    pub async fn ask(&self, prompt: String) -> TokenStream {
+        let stream = self.handle.ask(prompt);
+        TokenStream {
+            inner: Arc::new(tokio::sync::Mutex::new(stream)),
+        }
+    }
+
+    /// Reset the conversation. Optionally provide a new system prompt.
+    /// Tools are cleared on reset.
+    pub async fn reset(&self, system_prompt: Option<String>) -> Result<(), JsError> {
+        self.handle
+            .reset_chat(system_prompt, vec![])
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Clear the chat history, keeping the system prompt and tools.
+    #[wasm_bindgen(js_name = resetHistory)]
+    pub async fn reset_history(&self) -> Result<(), JsError> {
+        self.handle
+            .reset_history()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+// ---------- TokenStream ----------
+
+/// An in-progress text completion. JS usage:
+///
+/// ```js
+/// const stream = await chat.ask("Hello");
+/// let tok;
+/// while ((tok = await stream.nextToken()) !== undefined) {
+///   process.stdout.write(tok);
+/// }
+/// ```
+///
+/// `Symbol.asyncIterator` is intentionally not exposed yet — the `nextToken()`
+/// loop is portable across all JS runtimes including older Node versions.
+/// Adding it later is non-breaking.
+#[wasm_bindgen]
+pub struct TokenStream {
+    inner: Arc<tokio::sync::Mutex<nobodywho::chat::TokenStreamAsync>>,
+}
+
+#[wasm_bindgen]
+impl TokenStream {
+    /// Resolves to the next token, or `undefined` when generation ends.
+    #[wasm_bindgen(js_name = nextToken)]
+    pub async fn next_token(&self) -> Option<String> {
+        self.inner.lock().await.next_token().await
+    }
+
+    /// Drain the stream and resolve to the full generated text.
+    pub async fn completed(&self) -> Result<String, JsError> {
+        self.inner
+            .lock()
+            .await
+            .completed()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+// ---------- Encoder ----------
+
+/// Generate embedding vectors. Requires an embedding model (not a chat model).
+#[wasm_bindgen]
+pub struct Encoder {
+    inner: nobodywho::encoder::EncoderAsync,
+}
+
+#[wasm_bindgen]
+impl Encoder {
+    /// Create a new encoder. `n_ctx` defaults to 4096 if omitted.
+    #[wasm_bindgen(constructor)]
+    pub fn new(model: &Model, n_ctx: Option<u32>) -> Encoder {
+        Encoder {
+            inner: nobodywho::encoder::EncoderAsync::new(
+                Arc::clone(&model.inner),
+                n_ctx.unwrap_or(4096),
+            ),
+        }
+    }
+
+    /// Generate an embedding vector for the given text. Resolves to a
+    /// `Float32Array` on the JS side.
+    pub async fn encode(&self, text: String) -> Result<Vec<f32>, JsError> {
+        self.inner
+            .encode(text)
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+// ---------- Out of scope for v1 ----------
+//
+// The following are intentionally not yet wrapped. Each requires either a core
+// API change or a wasm-specific design decision:
+//
+// - `CrossEncoder` / reranking — straightforward, follow the Encoder pattern.
+// - `Constraint` / structured output — depends on `core/src/sampler_config.rs`
+//   `GrammarConstraint`; pass-through via serde-wasm-bindgen, but llguidance
+//   needs to compile to wasm32 first (Step 1).
+// - Tool calling — same dependency on llguidance.
+// - Multimodal (image / audio assets) — `mtmd` doesn't build for wasm32 today.
+// - Progress callbacks during model load — moot since we load from `Uint8Array`.

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -3,24 +3,29 @@
 //! Mirrors the Python binding's API for JS/TS consumers. Async-only, since a
 //! browser tab has no thread to block on. See `README.md` for build instructions.
 //!
-//! # Status: scaffold
+//! # Why everything returns `js_sys::Promise` instead of being `pub async fn`
 //!
-//! `wasm-pack build --target web` will fail until two upstream changes land:
+//! `#[wasm_bindgen] pub async fn` desugars through
+//! `wasm_bindgen_futures::future_to_promise`, which requires the future to be
+//! `UnwindSafe`. Several of our types (`tokio::sync::Mutex`,
+//! `tokio::sync::mpsc::Receiver`, etc.) aren't, so we'd hit
+//! E0277 on every async method.
 //!
-//! 1. The `llama-cpp-2` fork at `marek-hradil/llama-cpp-rs` (pinned at
-//!    `core/Cargo.toml:15`) gains a wasm32 build path. We'll carry our own
-//!    fork as a patch carrier until it's upstreamed.
-//! 2. `nobodywho/core` gates its `std::thread::spawn`, `ureq` downloads, and
-//!    tokio `rt-multi-thread` usage behind `cfg(not(target_arch = "wasm32"))`,
-//!    and exposes a `get_model_from_bytes` constructor (no filesystem in a
-//!    browser tab).
-//!
-//! The shape of the binding (this file) is independent of both blockers — it
-//! compiles natively as an `rlib` so the workspace stays healthy. Only the
-//! wasm32 build needs the upstream work.
+//! Instead, each exported method is a plain `pub fn` returning
+//! `js_sys::Promise`, with the body run through the [`promisify`] helper which
+//! wraps the body in [`std::panic::AssertUnwindSafe`] + `catch_unwind`. Since
+//! wasm is single-threaded and there's no real concurrent access to these
+//! types, the assertion is sound — any panic is caught and surfaced to JS as
+//! a rejected promise.
 
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+
+use futures::FutureExt;
 use wasm_bindgen::prelude::*;
+
+// ---------- Install panic hook & tracing ----------
 
 /// Install panic hook and tracing subscriber. Call once from JS before any
 /// other API. Safe to call multiple times.
@@ -29,12 +34,33 @@ pub fn init() {
     console_error_panic_hook::set_once();
     #[cfg(target_arch = "wasm32")]
     {
-        // `set_as_global_default` wires the WASMLayer into a Registry for us
-        // and installs the result as the global tracing subscriber. It panics
-        // if called more than once, but we want idempotent init from JS, so
-        // use the non-panicking helper.
+        // `set_as_global_default` panics if called twice; the `try_*` variant
+        // returns Err which we discard, making this idempotent from JS.
         tracing_wasm::try_set_as_global_default().ok();
     }
+}
+
+// ---------- Promise helper ----------
+
+/// Wrap a `Future<Output = Result<T, JsError>>` into a `js_sys::Promise`,
+/// asserting it's unwind-safe and catching panics so they reject the promise
+/// rather than tearing down the whole wasm instance.
+fn promisify<F, T>(fut: F) -> js_sys::Promise
+where
+    F: Future<Output = Result<T, JsError>> + 'static,
+    T: Into<JsValue>,
+{
+    let safe = AssertUnwindSafe(async move {
+        match fut.await {
+            Ok(v) => Ok(v.into()),
+            Err(e) => Err(JsValue::from(e)),
+        }
+    })
+    .catch_unwind()
+    .map(|r| {
+        r.unwrap_or_else(|_| Err(JsValue::from_str("rust panic crossed wasm boundary")))
+    });
+    wasm_bindgen_futures::future_to_promise(safe)
 }
 
 // ---------- Model ----------
@@ -59,11 +85,13 @@ impl Model {
     /// CPU-only; the wasm32 target has no GPU concept. `gpu_layers` is fixed
     /// at 0 internally.
     #[wasm_bindgen(js_name = loadBytes)]
-    pub async fn load_bytes(bytes: Vec<u8>) -> Result<Model, JsError> {
-        let model = nobodywho::llm::get_model_from_bytes(&bytes, 0)
-            .map_err(|e| JsError::new(&e.to_string()))?;
-        Ok(Model {
-            inner: Arc::new(model),
+    pub fn load_bytes(bytes: Vec<u8>) -> js_sys::Promise {
+        promisify(async move {
+            let model = nobodywho::llm::get_model_from_bytes(&bytes, 0)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            Ok(Model {
+                inner: Arc::new(model),
+            })
         })
     }
 }
@@ -112,29 +140,40 @@ impl Chat {
     /// Send a prompt and receive a `TokenStream`. Tokens arrive as they're
     /// generated; await `nextToken()` in a loop, or call `completed()` to
     /// resolve to the full response.
-    pub async fn ask(&self, prompt: String) -> TokenStream {
-        let stream = self.handle.ask(prompt);
-        TokenStream {
-            inner: Arc::new(tokio::sync::Mutex::new(stream)),
-        }
+    pub fn ask(&self, prompt: String) -> js_sys::Promise {
+        let handle = self.handle.clone();
+        promisify(async move {
+            let stream = handle.ask(prompt);
+            Ok(TokenStream {
+                inner: Arc::new(tokio::sync::Mutex::new(stream)),
+            })
+        })
     }
 
     /// Reset the conversation. Optionally provide a new system prompt.
     /// Tools are cleared on reset.
-    pub async fn reset(&self, system_prompt: Option<String>) -> Result<(), JsError> {
-        self.handle
-            .reset_chat(system_prompt, vec![])
-            .await
-            .map_err(|e| JsError::new(&e.to_string()))
+    pub fn reset(&self, system_prompt: Option<String>) -> js_sys::Promise {
+        let handle = self.handle.clone();
+        promisify(async move {
+            handle
+                .reset_chat(system_prompt, vec![])
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            Ok(JsValue::UNDEFINED)
+        })
     }
 
     /// Clear the chat history, keeping the system prompt and tools.
     #[wasm_bindgen(js_name = resetHistory)]
-    pub async fn reset_history(&self) -> Result<(), JsError> {
-        self.handle
-            .reset_history()
-            .await
-            .map_err(|e| JsError::new(&e.to_string()))
+    pub fn reset_history(&self) -> js_sys::Promise {
+        let handle = self.handle.clone();
+        promisify(async move {
+            handle
+                .reset_history()
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            Ok(JsValue::UNDEFINED)
+        })
     }
 }
 
@@ -162,18 +201,30 @@ pub struct TokenStream {
 impl TokenStream {
     /// Resolves to the next token, or `undefined` when generation ends.
     #[wasm_bindgen(js_name = nextToken)]
-    pub async fn next_token(&self) -> Option<String> {
-        self.inner.lock().await.next_token().await
+    pub fn next_token(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        promisify(async move {
+            let token = inner.lock().await.next_token().await;
+            // Map `Option<String>` to JsValue: Some -> string, None -> undefined.
+            // This is how JS callers detect end-of-stream.
+            Ok(match token {
+                Some(s) => JsValue::from_str(&s),
+                None => JsValue::UNDEFINED,
+            })
+        })
     }
 
     /// Drain the stream and resolve to the full generated text.
-    pub async fn completed(&self) -> Result<String, JsError> {
-        self.inner
-            .lock()
-            .await
-            .completed()
-            .await
-            .map_err(|e| JsError::new(&e.to_string()))
+    pub fn completed(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        promisify(async move {
+            inner
+                .lock()
+                .await
+                .completed()
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))
+        })
     }
 }
 
@@ -200,11 +251,19 @@ impl Encoder {
 
     /// Generate an embedding vector for the given text. Resolves to a
     /// `Float32Array` on the JS side.
-    pub async fn encode(&self, text: String) -> Result<Vec<f32>, JsError> {
-        self.inner
-            .encode(text)
-            .await
-            .map_err(|e| JsError::new(&e.to_string()))
+    pub fn encode(&self, text: String) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        promisify(async move {
+            let embedding = inner
+                .encode(text)
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            // Convert Vec<f32> to Float32Array. The `js_sys::Float32Array::from`
+            // copies into a fresh wasm-allocated typed array.
+            Ok(JsValue::from(js_sys::Float32Array::from(
+                embedding.as_slice(),
+            )))
+        })
     }
 }
 
@@ -215,8 +274,7 @@ impl Encoder {
 //
 // - `CrossEncoder` / reranking — straightforward, follow the Encoder pattern.
 // - `Constraint` / structured output — depends on `core/src/sampler_config.rs`
-//   `GrammarConstraint`; pass-through via serde-wasm-bindgen, but llguidance
-//   needs to compile to wasm32 first (Step 1).
-// - Tool calling — same dependency on llguidance.
-// - Multimodal (image / audio assets) — `mtmd` doesn't build for wasm32 today.
+//   `GrammarConstraint`; pass-through via serde-wasm-bindgen.
+// - Tool calling — depends on llguidance behavior on wasm.
+// - Multimodal (image / audio assets) — `mtmd` is not currently enabled on wasm.
 // - Progress callbacks during model load — moot since we load from `Uint8Array`.

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -57,9 +57,7 @@ where
         }
     })
     .catch_unwind()
-    .map(|r| {
-        r.unwrap_or_else(|_| Err(JsValue::from_str("rust panic crossed wasm boundary")))
-    });
+    .map(|r| r.unwrap_or_else(|_| Err(JsValue::from_str("rust panic crossed wasm boundary"))));
     wasm_bindgen_futures::future_to_promise(safe)
 }
 

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -55,16 +55,16 @@ impl Model {
     /// There's no path-based loader in the wasm binding — the browser sandbox
     /// has no filesystem. For HuggingFace / URL fetching, do it on the JS side
     /// before calling this.
+    ///
+    /// CPU-only; the wasm32 target has no GPU concept. `gpu_layers` is fixed
+    /// at 0 internally.
     #[wasm_bindgen(js_name = loadBytes)]
-    pub async fn load_bytes(_bytes: Vec<u8>) -> Result<Model, JsError> {
-        // TODO(wasm-step-2): requires a `get_model_from_bytes` constructor in
-        // `nobodywho::llm` that bypasses both the ureq download path and the
-        // `LlamaModelParams` file-load assumption. Tracked in Step 2 of the
-        // WASM binding plan.
-        Err(JsError::new(
-            "Model.loadBytes is not implemented yet — requires core wasm cfg-gating (Step 2). \
-             See nobodywho/wasm/README.md.",
-        ))
+    pub async fn load_bytes(bytes: Vec<u8>) -> Result<Model, JsError> {
+        let model = nobodywho::llm::get_model_from_bytes(&bytes, 0)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(Model {
+            inner: Arc::new(model),
+        })
     }
 }
 

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -29,9 +29,11 @@ pub fn init() {
     console_error_panic_hook::set_once();
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = tracing::subscriber::set_global_default(tracing_wasm::WASMLayer::new(
-            tracing_wasm::WASMLayerConfig::default(),
-        ));
+        // `set_as_global_default` wires the WASMLayer into a Registry for us
+        // and installs the result as the global tracing subscriber. It panics
+        // if called more than once, but we want idempotent init from JS, so
+        // use the non-panicking helper.
+        tracing_wasm::try_set_as_global_default().ok();
     }
 }
 


### PR DESCRIPTION
## Description

Lays the foundation for a new WebAssembly binding for NobodyWho, letting downstream consumers run local LLMs in a browser tab via the same core engine that powers the Python, Godot, Flutter, and Uniffi bindings. This PR is the first of a stack — it gets the workspace compiling for `wasm32-unknown-emscripten` and exposes a minimal JS surface; richer features (CrossEncoder, Constraint/structured output, browser demo, release pipeline) come in follow-up PRs.

Three threads of work:

1. **New `nobodywho/wasm/` crate** — async-only JS surface mirroring the Python binding. Exposes `Model` (loaded from in-memory `Uint8Array`), `Chat`, `TokenStream`, `Encoder` via `wasm-bindgen`. Uses `crate-type = ["cdylib", "rlib"]` so `cargo check --workspace` keeps working without the wasm toolchain installed. Each exported method returns `js_sys::Promise` (rather than `pub async fn`) to sidestep the `UnwindSafe` bound that `wasm_bindgen_futures::future_to_promise` otherwise imposes; a `promisify()` helper wraps bodies in `AssertUnwindSafe + catch_unwind` so a panic surfaces as a rejected Promise instead of tearing down the wasm instance.

2. **`core` cfg-gating for wasm32** — splits dependencies and code paths so the crate compiles on `wasm32-unknown-emscripten`:
   - `tokio` split: `rt-multi-thread` on native, plain `rt` on wasm.
   - `ureq` (raw sockets), `indicatif` (terminal UI), `monty` (Python interpreter) and `bashkit` (virtual bash) gated to non-wasm.
   - `dirs` gated to non-android-non-wasm.
   - `jsonschema` default features disabled in `grammar/gbnf` (drops `reqwest`/`hyper`/`mio` chain — the only call site is `jsonschema::meta::is_valid` which doesn't need HTTP/file resolution).
   - The entire model-loader/HTTP-cache/path-parser pipeline (`get_model`, `get_model_async`, `download_*`, `parse_model_path`, `get_cache_dir`) is gated to non-wasm; `Tool::python` and `Tool::bash` likewise.
   - The synchronous `chat::TokenStream` and four load-planning items in `core/src/memory.rs` (`GgufModelInfo`, `read_gguf_model_info`, `estimate_per_layer_bytes`, `plan_model_loading`) are also gated — they're reachable only from the gated native loader, and gating them avoids wasm-target dead-code warnings. `plan_context` / `ContextPlan` stay public on all targets since chat-context setup uses them on wasm too.

3. **Worker refactor** — channel switched from `std::sync::mpsc` to `tokio::sync::mpsc::unbounded_channel` so the worker can run as either a real OS thread (native, via `blocking_recv()`) or a `wasm_bindgen_futures::spawn_local` future on the JS event loop (wasm, via `recv().await`). `WorkerGuard` grew a wasm-only constructor that omits the `JoinHandle` and a cfg-gated Drop tail. Affects `ChatHandleAsync`, `EncoderAsync`, `CrossEncoderAsync`. The synchronous `ChatHandle` is gated to non-wasm (no blocking in a browser tab).

Also adds `pub fn get_model_from_bytes(bytes: &[u8], gpu_layers: u32) -> Result<Model, LoadModelError>` in `core/src/llm.rs` — a path-free model loader required by wasm (no filesystem) and useful on native for tests where the GGUF is already in memory. Gated off Windows MSVC because the underlying `LlamaModel::load_from_buffer` uses POSIX `fmemopen`. Covered by a native smoke test that loads `TEST_MODEL` into a `Vec<u8>` and asserts a successful round-trip.

The `llama-cpp-2` git source switched from `marek-hradil/llama-cpp-rs#main` to `nobodywho-ooo/llama-cpp-rs#wasm`. That fork carries Marek's existing llguidance/EOS-fix patches plus the Emscripten `TargetOs` variant, sysroot auto-detection, bindgen configuration, and the cmake gating that disables every GPU backend on wasm builds.

`Cargo.nix` and `crate-hashes.json` are regenerated against this PR's `Cargo.lock` so `nix flake check` succeeds. **Two nix-side gotchas worth noting for follow-up PR authors in this stack** (each pr2/3/4 will need its own end-of-PR regen as well, because each touches Cargo.toml/Cargo.lock):

- `crate2nix`'s `-h crate-hashes.json` flag caches hashes by `name@version`, not by full URL+commit. A URL change (like marek-hradil → nobodywho-ooo) without manually updating the cache entry silently reuses the old tree's hash, and `nix flake check` then fails on a fetchgit hash mismatch.
- `pkgs.fetchgit` defaults `fetchSubmodules = true`, while `nix-prefetch-git` defaults to `--no-fetch-submodules`. The `llama-cpp-rs` repo vendors `llama.cpp` as a submodule, so prefetching without the matching `--fetch-submodules` flag produces a hash that doesn't match what fetchgit actually downloads at build time.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Native consumers (Python, Godot, Flutter) see no API changes. The internal `WorkerGuard` channel type changed from `std::sync::mpsc::Sender` to `tokio::sync::mpsc::UnboundedSender`, but `WorkerGuard::send`'s public signature is unchanged.

## How Has This Been Tested?

Local checks against the PR tip:

- `cargo check -p nobodywho` on native (macOS aarch64): clean.
- `cargo check --target wasm32-unknown-emscripten -p nobodywho-wasm`: builds end-to-end through bindgen + cc + cmake. **0 warnings.**
- `cargo fmt --all --check`: clean.
- `cargo clippy --no-deps -- -D warnings` from `nobodywho/core/`: clean (the same invocation the `linting / lint` CI job runs).

Native smoke test for the new `get_model_from_bytes` API, runnable with a model:

```bash
cd nobodywho
export TEST_MODEL=/path/to/model.gguf
cargo test -p nobodywho get_model_from_bytes_loads_a_real_gguf -- --nocapture
```

Not verified end-to-end: actual wasm linking with `emcc`, loading a real GGUF via `Model.loadBytes` in a browser. Browser-side end-to-end verification lands in the demo PR later in the stack.

To reproduce the local checks:

```bash
# Native check (no special setup):
cd nobodywho
cargo check -p nobodywho

# Wasm check (requires emsdk activated for full build, but cargo check works without it):
rustup target add wasm32-unknown-emscripten
cargo check --target wasm32-unknown-emscripten -p nobodywho-wasm
```

For a real wasm build, see `nobodywho/wasm/README.md` for the emsdk install steps.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules