### PR TITLE
Updated marek fork of llama-cpp-rs to not build metal for watch os

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2048,7 +2048,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#8550f04e3dbc6eb1e30ed50466356a253d7bb652"
+source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#94e59043c4b0288dd752e0afc781d27e6ebd1124"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#8550f04e3dbc6eb1e30ed50466356a253d7bb652"
+source = "git+https://github.com/marek-hradil/llama-cpp-rs?branch=main#94e59043c4b0288dd752e0afc781d27e6ebd1124"
 dependencies = [
  "bindgen",
  "cc",
@@ -3485,7 +3485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3542,7 +3542,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4056,7 +4056,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -46,20 +46,14 @@ libc = "0.2"
 [target.'cfg(not(target_os = "android"))'.dependencies]
 dirs = "6"
 
-# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding macOS, iOS, Android)
-[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
+# Enable Vulkan for x86_64, x86, and aarch64 targets (excluding Apple platforms and Android).
+# Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
+# (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
 llama-cpp-2 = { git = "https://github.com/marek-hradil/llama-cpp-rs", branch = "main", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",
     "android-static-stdcxx",
-    "llguidance",
-] }
-
-# Enable Metal on iOS. (macOS aarch64 gets Metal automatically from llama-cpp-2's own target-cfg upstream.)
-[target.'cfg(target_os = "ios")'.dependencies]
-llama-cpp-2 = { git = "https://github.com/marek-hradil/llama-cpp-rs", branch = "main", default-features = false, features = [
-    "metal",
-    "mtmd",
     "llguidance",
 ] }


### PR DESCRIPTION
Removed section with metal feature, as this is handled by llama-cpp-rs' build.rs. Passing the metal feature has no effect.