### PR TITLE
feat(wasm): Path B build path — wasm32-unknown-unknown + first real inference

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#f41f97d584e0c740931d9e7718bf168473a6ab93"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#f41f97d584e0c740931d9e7718bf168473a6ab93"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#f41f97d584e0c740931d9e7718bf168473a6ab93"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#2b592da43f995c791926fd05d0104d17cc5bbecb"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#f41f97d584e0c740931d9e7718bf168473a6ab93"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#2b592da43f995c791926fd05d0104d17cc5bbecb"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#2b592da43f995c791926fd05d0104d17cc5bbecb"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#360e169e5a3f3ce42b6742ad5f9b3200bf14f448"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#2b592da43f995c791926fd05d0104d17cc5bbecb"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#360e169e5a3f3ce42b6742ad5f9b3200bf14f448"
 dependencies = [
  "bindgen",
  "cc",
@@ -4581,7 +4581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#168576fe4e69b9fc861b5183760dff6ed36c8cb2"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#1843e08b678ca8b0e2bdcdd74e78d243686ffe21"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#168576fe4e69b9fc861b5183760dff6ed36c8cb2"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#1843e08b678ca8b0e2bdcdd74e78d243686ffe21"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#360e169e5a3f3ce42b6742ad5f9b3200bf14f448"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#168576fe4e69b9fc861b5183760dff6ed36c8cb2"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#360e169e5a3f3ce42b6742ad5f9b3200bf14f448"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#168576fe4e69b9fc861b5183760dff6ed36c8cb2"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#1843e08b678ca8b0e2bdcdd74e78d243686ffe21"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#1843e08b678ca8b0e2bdcdd74e78d243686ffe21"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "bindgen",
  "cc",
@@ -4581,7 +4581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -7359,21 +7359,21 @@ rec {
             name = "llama-cpp-2";
             packageId = "llama-cpp-2";
             usesDefaultFeatures = false;
-            features = [ "openmp" "android-static-stdcxx" "mtmd" "llguidance" ];
+            features = [ "openmp" "android-static-stdcxx" "llguidance" ];
           }
           {
             name = "llama-cpp-2";
             packageId = "llama-cpp-2";
             usesDefaultFeatures = false;
             target = { target, features }: ((!("macos" == target."os" or null)) && (!("ios" == target."os" or null)) && (!("visionos" == target."os" or null)) && (!("watchos" == target."os" or null)) && (!("android" == target."os" or null)) && (("x86_64" == target."arch" or null) || ("x86" == target."arch" or null) || ("aarch64" == target."arch" or null)));
-            features = [ "openmp" "vulkan" "mtmd" "android-static-stdcxx" "llguidance" ];
+            features = [ "openmp" "vulkan" "android-static-stdcxx" "llguidance" ];
           }
           {
             name = "llama-cpp-2";
             packageId = "llama-cpp-2";
             usesDefaultFeatures = false;
             target = { target, features }: ("ios" == target."os" or null);
-            features = [ "metal" "mtmd" "llguidance" ];
+            features = [ "metal" "llguidance" ];
           }
           {
             name = "minijinja";
@@ -7452,7 +7452,11 @@ rec {
             target = { target, features }: ("wasm32" == target."arch" or null);
           }
         ];
-
+        features = {
+          "default" = [ "mtmd" ];
+          "mtmd" = [ "llama-cpp-2/mtmd" ];
+        };
+        resolvedDefaultFeatures = [ "default" "mtmd" ];
       };
       "nobodywho-flutter" = rec {
         crateName = "nobodywho-flutter";

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -3,6 +3,14 @@ name = "nobodywho"
 version = "2.2.0"
 edition = "2021"
 
+[features]
+default = ["mtmd"]
+# Multimodal (image / audio) input support, backed by llama.cpp's `mtmd`
+# C++ library. Default-on for native; the wasm binding opts out because
+# the underlying C++ pulls in libraries (miniaudio with pthread sched
+# APIs) that don't compile against wasi-libc.
+mtmd = ["llama-cpp-2/mtmd"]
+
 [dependencies]
 encoding_rs = "0.8.34"
 thiserror = "2.0.3"
@@ -18,7 +26,6 @@ chrono = "0.4.39"
 llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
     "openmp",
     "android-static-stdcxx",
-    "mtmd",
     "llguidance",
 ] }
 lazy_static = "1.5.0"
@@ -74,7 +81,16 @@ dirs = "6"
 llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
     "openmp",
     "vulkan",
-    "mtmd",
     "android-static-stdcxx",
+    "llguidance",
+] }
+
+# Enable Metal on iOS. macOS aarch64 gets Metal automatically from llama-cpp-rs upstream.
+# Kept explicit until the nobodywho-ooo/llama-cpp-rs#wasm fork picks up the
+# upstream watchOS Metal-skip patch (PR #527 on marek-hradil's main); once
+# the wasm fork rebases on that, this block can be dropped to match main.
+[target.'cfg(target_os = "ios")'.dependencies]
+llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
+    "metal",
     "llguidance",
 ] }

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -84,13 +84,3 @@ llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = 
     "android-static-stdcxx",
     "llguidance",
 ] }
-
-# Enable Metal on iOS. macOS aarch64 gets Metal automatically from llama-cpp-rs upstream.
-# Kept explicit until the nobodywho-ooo/llama-cpp-rs#wasm fork picks up the
-# upstream watchOS Metal-skip patch (PR #527 on marek-hradil's main); once
-# the wasm fork rebases on that, this block can be dropped to match main.
-[target.'cfg(target_os = "ios")'.dependencies]
-llama-cpp-2 = { git = "https://github.com/nobodywho-ooo/llama-cpp-rs", branch = "wasm", default-features = false, features = [
-    "metal",
-    "llguidance",
-] }

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -9,6 +9,18 @@ default = ["mtmd"]
 # C++ library. Default-on for native; the wasm binding opts out because
 # the underlying C++ pulls in libraries (miniaudio with pthread sched
 # APIs) that don't compile against wasi-libc.
+#
+# This feature is effectively a wasm-only opt-out — native consumers
+# should keep the default. On native, disabling it propagates to
+# llama-cpp-2, the mtmd Rust module disappears, and code in core that
+# refers to `MtmdBitmap` / `MtmdInputChunks` / etc. (in tokenizer.rs,
+# chat.rs, llm.rs) fails to compile. On wasm32, the fork of llama-cpp-2
+# keeps bindgen running against the mtmd headers even with the feature
+# off, so the Rust types stay in scope and only the C++ link is gated —
+# `mtmd_*` functions resolve to unresolved wasm imports that the JS
+# host stubs. That asymmetry is what lets the wasm crate `default-
+# features = false` cleanly while native still gets the full
+# multimodal API.
 mtmd = ["llama-cpp-2/mtmd"]
 
 [dependencies]

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -42,6 +42,7 @@ use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat};
 use ahash::AHasher;
 use indexmap::IndexMap;
 use llama_cpp_2::context::params::LlamaPoolingType;
+#[cfg(feature = "mtmd")]
 use llama_cpp_2::mtmd::MtmdBitmap;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
@@ -1194,6 +1195,7 @@ struct ChatContext {
     /// Here we keep the current tokens + media embeddings, which are in the KV cache.
     chunks: TokenizerChunks,
     /// Here we keep a list of the media bitmaps, which are needed for tokenization.
+    #[cfg(feature = "mtmd")]
     bitmaps: IndexMap<ChunkId, MtmdBitmap>,
 }
 
@@ -1201,10 +1203,12 @@ impl ChatContext {
     fn new() -> Self {
         Self {
             chunks: TokenizerChunks::new(),
+            #[cfg(feature = "mtmd")]
             bitmaps: IndexMap::new(),
         }
     }
 
+    #[cfg(feature = "mtmd")]
     pub fn add_bitmaps(
         &mut self,
         bitmaps: Vec<MtmdBitmap>,
@@ -1219,6 +1223,7 @@ impl ChatContext {
         Ok(bitmap_ids)
     }
 
+    #[cfg(feature = "mtmd")]
     pub fn garbage_collect_bitmaps(&mut self, messages: &[Message]) {
         // Garbage collection for the bitmaps.
         let referenced_bitmaps: HashSet<String> = messages
@@ -1237,12 +1242,14 @@ impl ChatContext {
         self.remove_bitmaps(unreferenced_bitmap_ids);
     }
 
+    #[cfg(feature = "mtmd")]
     fn create_bitmap_id(&self, bitmap: &MtmdBitmap) -> String {
         let mut hasher = AHasher::default();
         hasher.write(bitmap.data());
         hasher.finish().to_string()
     }
 
+    #[cfg(feature = "mtmd")]
     fn remove_bitmaps(&mut self, bitmap_ids: Vec<String>) {
         for id in bitmap_ids {
             if let Some(bitmap) = self.bitmaps.shift_remove(&id) {
@@ -1640,22 +1647,31 @@ impl Worker<'_, ChatWorker> {
             .map(|fmt| fmt.begin_token().to_string());
 
         let media_assets = prompt.extract_media_assets();
-        let bitmaps = if let Some(projection_model) = self.projection_model.as_ref() {
-            media_assets
-                .iter()
-                .map(|part| match part {
-                    PromptPart::Image(path) => projection_model.load_image(path),
-                    PromptPart::Audio(path) => projection_model.load_audio(path),
-                    PromptPart::Text(_) => unreachable!(),
-                })
-                .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?
-        } else {
-            vec![]
+
+        // Multimodal bitmap construction. Only enabled when the `mtmd` feature
+        // is on (i.e. native + Emscripten, not wasm32-unknown-unknown).
+        #[cfg(feature = "mtmd")]
+        let bitmap_ids = {
+            let bitmaps = if let Some(projection_model) = self.projection_model.as_ref() {
+                media_assets
+                    .iter()
+                    .map(|part| match part {
+                        PromptPart::Image(path) => projection_model.load_image(path),
+                        PromptPart::Audio(path) => projection_model.load_audio(path),
+                        PromptPart::Text(_) => unreachable!(),
+                    })
+                    .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?
+            } else {
+                vec![]
+            };
+            debug!("Detected bitmaps: {:?}", bitmaps);
+            self.extra.context.add_bitmaps(bitmaps)?
         };
+        // Without the mtmd feature: no projection model, no bitmaps, no media
+        // assets. Tokenizer just sees text.
+        #[cfg(not(feature = "mtmd"))]
+        let bitmap_ids: Vec<String> = Vec::new();
 
-        debug!("Detected bitmaps: {:?}", bitmaps);
-
-        let bitmap_ids = self.extra.context.add_bitmaps(bitmaps)?;
         let assets = bitmap_ids
             .iter()
             .zip(media_assets.iter())

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -129,6 +129,7 @@ pub enum ReadError {
     #[error("Projection model not initialized")]
     ProjectionModelNotInitialized,
 
+    #[cfg(feature = "mtmd")]
     #[error("Llama.cpp failed reading media embeddings: {0}")]
     FailedReadingMediaEmbeddings(#[from] llama_cpp_2::mtmd::MtmdEvalError),
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -696,6 +696,15 @@ where
 
         // Set up context parameters using available parallelism
         let ctx = {
+            // wasm32 has no concept of hardware threads (`available_parallelism`
+            // returns Err on wasm32-unknown-unknown). Single-thread the
+            // worker — llama.cpp will run inference sequentially on the
+            // wasm event loop, which matches how the wasm binding's
+            // chat/encoder/cross-encoder are structured anyway (spawn_local,
+            // no real threads).
+            #[cfg(target_arch = "wasm32")]
+            let n_threads: i32 = 1;
+            #[cfg(not(target_arch = "wasm32"))]
             let n_threads = std::thread::available_parallelism()?.get() as i32;
             let ctx_plan = memory::plan_context(
                 std::cmp::min(n_ctx, model.language_model.n_ctx_train()),

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -12,6 +12,7 @@ use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
+#[cfg(feature = "mtmd")]
 use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::token::LlamaToken;
 #[cfg(not(target_arch = "wasm32"))]
@@ -782,6 +783,7 @@ where
         Ok(self)
     }
 
+    #[cfg(feature = "mtmd")]
     #[tracing::instrument(level = "trace", skip(self))]
     fn read_media_embeddings(
         &mut self,

--- a/nobodywho/core/src/template.rs
+++ b/nobodywho/core/src/template.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+#[cfg(feature = "mtmd")]
 use llama_cpp_2::mtmd::MtmdBitmap;
 use minijinja::{Environment, Template, Value};
 use tracing::{debug, trace, warn};
@@ -32,6 +33,7 @@ static MINIJINJA_ENV: LazyLock<Environment> = LazyLock::new(|| {
 
 pub struct RenderedChat {
     pub text: String,
+    #[cfg(feature = "mtmd")]
     pub bitmaps: Vec<MtmdBitmap>,
 }
 
@@ -39,6 +41,7 @@ impl RenderedChat {
     pub fn from_text(text: String) -> Self {
         Self {
             text,
+            #[cfg(feature = "mtmd")]
             bitmaps: vec![],
         }
     }

--- a/nobodywho/core/src/tokenizer.rs
+++ b/nobodywho/core/src/tokenizer.rs
@@ -486,6 +486,14 @@ impl<'a> Tokenizer<'a> {
     }
 
     fn tokenize_text(&self, text: &str) -> Result<Vec<TokenizerChunk>, TokenizationError> {
+        // On wasm32, `mtmd_default_marker` resolves to an unresolved env
+        // import (we don't compile the mtmd C++). Inline the same literal
+        // llama.cpp returns for it. Text tokenization splits on this marker
+        // to interleave media chunks; on wasm there's no media so the
+        // split always produces one entry covering the whole input.
+        #[cfg(target_arch = "wasm32")]
+        let media_marker = String::from("<__media__>");
+        #[cfg(not(target_arch = "wasm32"))]
         let media_marker = llama_cpp_2::mtmd::mtmd_default_marker().to_string();
         let splits = text
             .split(media_marker.as_str())

--- a/nobodywho/core/src/tokenizer.rs
+++ b/nobodywho/core/src/tokenizer.rs
@@ -18,6 +18,25 @@ use tracing::{info, warn};
 
 use crate::{errors::MultimodalError, errors::TokenizationError};
 
+/// Get the media-marker string used to split text from media in rendered
+/// chat templates. Native reads this from llama.cpp's
+/// `mtmd_default_marker()`. The cfg gate routes all wasm32 targets to the
+/// inlined literal (`"<__media__>"`) — necessary for wasm32-unknown-unknown
+/// (which can't resolve the mtmd C++ symbol) and harmless for the other
+/// wasm32 OSes like Emscripten, since the literal is the same string the
+/// FFI call would return.
+#[inline]
+fn mtmd_marker_string() -> String {
+    #[cfg(target_arch = "wasm32")]
+    {
+        "<__media__>".to_string()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        llama_cpp_2::mtmd::mtmd_default_marker().to_string()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Prompt {
     parts: Vec<PromptPart>,
@@ -25,7 +44,7 @@ pub struct Prompt {
 
 impl Display for Prompt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let marker = llama_cpp_2::mtmd::mtmd_default_marker();
+        let marker = mtmd_marker_string();
         let result = self
             .parts
             .iter()
@@ -361,7 +380,7 @@ impl ProjectionModel {
             .map(|p| p.get() as i32)
             .unwrap_or(4);
 
-        let media_marker = llama_cpp_2::mtmd::mtmd_default_marker().to_string();
+        let media_marker = mtmd_marker_string();
 
         let mtmd_params = MtmdContextParams {
             use_gpu,
@@ -385,7 +404,7 @@ impl ProjectionModel {
     }
 
     pub fn tokenize(&self, bitmap: &MtmdBitmap) -> Result<TokenizerChunk, TokenizationError> {
-        let media_marker = llama_cpp_2::mtmd::mtmd_default_marker().to_string();
+        let media_marker = mtmd_marker_string();
         let mtmd_chunks = self
             .ctx
             .tokenize(
@@ -486,15 +505,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     fn tokenize_text(&self, text: &str) -> Result<Vec<TokenizerChunk>, TokenizationError> {
-        // On wasm32, `mtmd_default_marker` resolves to an unresolved env
-        // import (we don't compile the mtmd C++). Inline the same literal
-        // llama.cpp returns for it. Text tokenization splits on this marker
-        // to interleave media chunks; on wasm there's no media so the
-        // split always produces one entry covering the whole input.
-        #[cfg(target_arch = "wasm32")]
-        let media_marker = String::from("<__media__>");
-        #[cfg(not(target_arch = "wasm32"))]
-        let media_marker = llama_cpp_2::mtmd::mtmd_default_marker().to_string();
+        let media_marker = mtmd_marker_string();
         let splits = text
             .split(media_marker.as_str())
             .enumerate()

--- a/nobodywho/wasm/.gitignore
+++ b/nobodywho/wasm/.gitignore
@@ -2,3 +2,4 @@ pkg/
 target/
 node_modules/
 pkg-node/
+pkg-bundler/

--- a/nobodywho/wasm/.gitignore
+++ b/nobodywho/wasm/.gitignore
@@ -1,3 +1,4 @@
 pkg/
 target/
 node_modules/
+pkg-node/

--- a/nobodywho/wasm/Cargo.toml
+++ b/nobodywho/wasm/Cargo.toml
@@ -11,11 +11,13 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-# `default-features = false` drops the `mtmd` feature on core. mtmd (vision +
-# audio multimodal support) relies on llama.cpp's `tools/mtmd` library, which
-# pulls in `vendor/miniaudio` with pthread sched APIs wasi-libc doesn't ship.
-# The wasm binding doesn't currently expose multimodal assets either way.
-nobodywho = { path = "../core", default-features = false }
+# Default features include `mtmd` for now, so the existing
+# wasm32-unknown-emscripten build (which uses Emscripten's own pthread
+# emulation for miniaudio) keeps working. Once core's chat.rs and
+# tokenizer.rs finish their mtmd cfg-gating, switch this to
+# `default-features = false` to enable the wasm32-unknown-unknown
+# build path (which can't compile miniaudio against wasi-libc).
+nobodywho = { path = "../core" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/nobodywho/wasm/Cargo.toml
+++ b/nobodywho/wasm/Cargo.toml
@@ -11,7 +11,11 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-nobodywho = { path = "../core" }
+# `default-features = false` drops the `mtmd` feature on core. mtmd (vision +
+# audio multimodal support) relies on llama.cpp's `tools/mtmd` library, which
+# pulls in `vendor/miniaudio` with pthread sched APIs wasi-libc doesn't ship.
+# The wasm binding doesn't currently expose multimodal assets either way.
+nobodywho = { path = "../core", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -4,48 +4,87 @@ WebAssembly binding for [NobodyWho](https://nobodywho.ooo), letting you run
 local LLMs in a browser tab via the same core engine that powers the Python,
 Flutter, Godot, and Uniffi bindings.
 
-## Status
-
-**`cargo build --target wasm32-unknown-emscripten -p nobodywho-wasm`
-produces a working `nobodywho_wasm.wasm` artifact** (~113 MB debug,
-~10–20 MB release-stripped, including all of llama.cpp).
-
-The pipeline that runs end-to-end:
+## Status — Path B working end-to-end
 
 ```
-bindgen → cc::Build (em++) → cmake (llama.cpp via Emscripten) → wasm-bindgen
-        ↓                  ↓                                  ↓
-   FFI bindings.rs   wrapper static .a                  __wbindgen_* exports
-                                              ↓
-                                      emcc + wasm-ld
-                                              ↓
-                                   nobodywho_wasm.wasm
+cargo build --target wasm32-unknown-unknown -p nobodywho-wasm  ✅
+wasm-bindgen --target web ... --out-dir pkg/                   ✅
 ```
 
-Native (`cargo check --workspace`) is unaffected and builds bit-for-bit
+Produces a complete npm package shape in `pkg/`:
+
+```
+pkg/
+├── nobodywho_wasm.d.ts        9.1K  — TS typings for the public API
+├── nobodywho_wasm.js          37K   — JS loader / wasm-bindgen glue
+├── nobodywho_wasm_bg.wasm     21M   — compiled wasm (debug; ~5-7M release-stripped)
+└── nobodywho_wasm_bg.wasm.d.ts
+```
+
+The TS bindings expose `Model`, `Chat`, `TokenStream`, `Encoder` with
+full JSDoc and `Promise<any>` return types. JS consumers can
+`import init, { Model, Chat } from './pkg/nobodywho_wasm.js'`,
+`await init()`, then use the API.
+
+### Build pipeline
+```
+bindgen + cc::Build (wasi-sdk clang)
+  +
+cmake (llama.cpp targeting wasm32-wasip1 + wasi-libc, with the
+       fork's source-level patches: cpp-httplib excised, signal +
+       process-clocks emulation, __wasi__ cases, mtmd C++ skipped)
+                ↓
+        wasm-bindgen post-processor
+                ↓
+        pkg/ ready for npm publish
+```
+
+Native (`cargo check --workspace`) is unchanged and builds bit-for-bit
 the same as before the wasm branch.
+
+### Alternate target: wasm32-unknown-emscripten
+
+`cargo build --target wasm32-unknown-emscripten -p nobodywho-wasm` also
+works (produces a 113 MB debug .wasm). That artifact can't be processed
+by `wasm-bindgen-cli` (CLI doesn't understand Emscripten's section
+layout), so it's only useful for inspecting the Emscripten output or as
+a fallback for consumers who use Emscripten's own JS glue. The
+`wasm32-unknown-unknown` + wasm-bindgen path above is the recommended
+distribution.
 
 ### Build prerequisites
 
-The wasm32 target is **`wasm32-unknown-emscripten`** (not
-`wasm32-unknown-unknown`). To produce a `.wasm` artifact you need:
+1. **wasi-sdk** for the C/C++ side of llama.cpp:
+   ```bash
+   curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-arm64-macos.tar.gz | tar -xz -C ~
+   export WASI_SDK_PATH=~/wasi-sdk-33.0-arm64-macos
+   ```
+   (Or `/opt/wasi-sdk` if you prefer a system-wide install — the build
+   script probes that path automatically.)
+
+2. **Rust wasm target**:
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
+
+3. **wasm-bindgen-cli** (must match the `wasm-bindgen` crate version
+   you're building with — currently 0.2.121):
+   ```bash
+   cargo install wasm-bindgen-cli --version 0.2.121
+   ```
+
+### Build steps
 
 ```bash
-# Install emsdk (one-time):
-git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk
-./emsdk install latest
-./emsdk activate latest
-source ./emsdk_env.sh   # adds emcc, em++ to PATH
-
-# Add the rustc target:
-rustup target add wasm32-unknown-emscripten
-
-# Build:
 cd nobodywho/wasm
-cargo build --target wasm32-unknown-emscripten --release
-# or, for the JS-bundle output:
-wasm-pack build --target web
+WASI_SDK_PATH=~/wasi-sdk-33.0-arm64-macos \
+  cargo build --target wasm32-unknown-unknown --release
+
+wasm-bindgen --target web \
+  ../target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
+  --out-dir pkg/
+
+# pkg/ is the npm-publishable directory
 ```
 
 ### What's wired up

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -1,304 +1,208 @@
 # nobodywho-wasm
 
-WebAssembly binding for [NobodyWho](https://nobodywho.ooo), letting you run
-local LLMs in a browser tab via the same core engine that powers the Python,
-Flutter, Godot, and Uniffi bindings.
+WebAssembly binding for [NobodyWho](https://nobodywho.ooo) — runs local LLMs
+in a browser tab (or any wasm host) via llama.cpp compiled to wasm32.
 
-## Status — Path B working end-to-end
+## Status: working end-to-end
 
-```
-cargo build --target wasm32-unknown-unknown -p nobodywho-wasm  ✅
-wasm-bindgen --target web ... --out-dir pkg/                   ✅
-```
-
-Produces a complete npm package shape in `pkg/`:
+Real embedding inference verified under Node:
 
 ```
-pkg/
-├── nobodywho_wasm.d.ts        9.1K  — TS typings for the public API
-├── nobodywho_wasm.js          37K   — JS loader / wasm-bindgen glue
-├── nobodywho_wasm_bg.wasm     21M   — compiled wasm (debug; ~5-7M release-stripped)
-└── nobodywho_wasm_bg.wasm.d.ts
+$ node wasm/examples/run.mjs --encode /tmp/bge-small.gguf "Hello"
+  ✓ wasi.initialize ran _initialize
+  ✓ wasm wired up
+  ✓ init() ok
+Loading model from /tmp/bge-small.gguf…
+  model size: 35.1 MB
+  ✓ model loaded
+  ✓ encoder created
+Encoding: "Hello"
+  ✓ embedding generated: 384 dimensions
+  first 8: [-0.6244, -0.5940, 0.5545, -0.6085, -0.1348, 0.1800, 0.6621, 0.3490]
+Done.
 ```
 
-The TS bindings expose `Model`, `Chat`, `TokenStream`, `Encoder` with
-full JSDoc and `Promise<any>` return types. JS consumers can
-`import init, { Model, Chat } from './pkg/nobodywho_wasm.js'`,
-`await init()`, then use the API.
+The wasm binary contains all of llama.cpp (~9.5 MB release, ~21 MB debug)
+and exposes the binding's full surface to JS via wasm-bindgen.
 
-### Build pipeline
-```
-bindgen + cc::Build (wasi-sdk clang)
-  +
-cmake (llama.cpp targeting wasm32-wasip1 + wasi-libc, with the
-       fork's source-level patches: cpp-httplib excised, signal +
-       process-clocks emulation, __wasi__ cases, mtmd C++ skipped)
-                ↓
-        wasm-bindgen post-processor
-                ↓
-        pkg/ ready for npm publish
-```
-
-Native (`cargo check --workspace`) is unchanged and builds bit-for-bit
-the same as before the wasm branch.
-
-### Alternate target: wasm32-unknown-emscripten
-
-`cargo build --target wasm32-unknown-emscripten -p nobodywho-wasm` also
-works (produces a 113 MB debug .wasm). That artifact can't be processed
-by `wasm-bindgen-cli` (CLI doesn't understand Emscripten's section
-layout), so it's only useful for inspecting the Emscripten output or as
-a fallback for consumers who use Emscripten's own JS glue. The
-`wasm32-unknown-unknown` + wasm-bindgen path above is the recommended
-distribution.
-
-### Build prerequisites
-
-1. **wasi-sdk** for the C/C++ side of llama.cpp:
-   ```bash
-   curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-arm64-macos.tar.gz | tar -xz -C ~
-   export WASI_SDK_PATH=~/wasi-sdk-33.0-arm64-macos
-   ```
-   (Or `/opt/wasi-sdk` if you prefer a system-wide install — the build
-   script probes that path automatically.)
-
-2. **Rust wasm target**:
-   ```bash
-   rustup target add wasm32-unknown-unknown
-   ```
-
-3. **wasm-bindgen-cli** (must match the `wasm-bindgen` crate version
-   you're building with — currently 0.2.121):
-   ```bash
-   cargo install wasm-bindgen-cli --version 0.2.121
-   ```
-
-### Build steps
-
-```bash
-cd nobodywho/wasm
-WASI_SDK_PATH=~/wasi-sdk-33.0-arm64-macos \
-  cargo build --target wasm32-unknown-unknown --release
-
-wasm-bindgen --target web \
-  ../target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
-  --out-dir pkg/
-
-# pkg/ is the npm-publishable directory
-```
-
-### What's wired up
-
-The `llama-cpp-2` fork at
-[`nobodywho-ooo/llama-cpp-rs` `wasm`](https://github.com/nobodywho-ooo/llama-cpp-rs/tree/wasm)
-inherits Marek's llguidance/EOS-fix patches and adds Asbjørn's Emscripten
-support (cherry-picked from his branch). Specifically:
-
-- `TargetOs::Emscripten` variant + sysroot/toolchain auto-detection from
-  `emcc --cflags` and `which emcc`.
-- Bindgen configured with the real sysroot + `--target=wasm32-unknown-emscripten`
-  + `-fvisibility=default` (workaround for bindgen #1941).
-- `cc` wrapper-shim build uses `em++` with `-fwasm-exceptions` (native wasm EH).
-- cmake disables every GPU backend (`GGML_VULKAN`/`GGML_CUDA`/`GGML_METAL`/etc.),
-  forces `BUILD_SHARED_LIBS=OFF` and `LLAMA_WASM_MEM64=OFF`.
-
-See `WASM.md` in the fork for the full build details and remaining gaps.
-
-### Outstanding work — pick A or B
-
-#### Path A — drop wasm-bindgen, use Emscripten's JS glue (works today)
-
-Keep the existing `wasm32-unknown-emscripten` build. **Replace
-`#[wasm_bindgen]` with `#[no_mangle] extern "C"`** in `src/lib.rs`,
-marshaling types manually (string pointers via `Box::into_raw`, byte
-arrays as `(*mut u8, usize)`, async results as callback handles).
-Emscripten emits a JS loader via `MODULARIZE=1` that handles all libc
-imports automatically.
-
-Effort: ~1 day. Less type-safe than wasm-bindgen, but builds on the
-working pipeline and ships a usable npm package immediately.
-
-#### Path B — wasm32-unknown-unknown + wasi-sdk (C++ side done, Rust mtmd gating remains)
-
-The fork's `wasm` branch now has a full `wasm32-unknown-unknown` build
-path: `TargetOs::WasmUnknown` variant, wasi-sdk detection, parallel
-bindgen/cmake/cc config, and source-level patches to llama.cpp itself
-(cpp-httplib excision, `arg.cpp`/`console.cpp` removal, signal +
-process-clocks emulation, `fs_get_cache_directory` `__wasi__` case,
-`set_process_priority` no-op, mtmd's miniaudio skipped because it needs
-pthread sched APIs wasi-libc doesn't ship).
-
-**End-to-end C++ build works** for wasm32-unknown-unknown. The remaining
-blocker is in **`nobodywho/core` itself**: it imports
-`llama_cpp_2::mtmd::{MtmdInputChunks, MtmdBitmap, MtmdContext, ...}` and
-those types now don't exist on wasm32 (since the fork's mtmd Rust module
-is also gated off — the FFI symbols aren't there because the mtmd C++
-isn't compiled).
-
-`core/src/chat.rs` and `core/src/tokenizer.rs` use these types
-structurally (as struct fields, enum variants like `Asset::Image`,
-`TokenizerChunk::Image`/`Audio`, and `bitmaps: IndexMap<ChunkId,
-MtmdBitmap>` on the chat worker state). Gating them out for wasm is a
-mechanical-but-substantial refactor:
-
-```
-nobodywho/core/src/llm.rs       — gate MtmdInputChunks import + 1 field
-nobodywho/core/src/template.rs  — gate MtmdBitmap import + 1 field
-nobodywho/core/src/errors.rs    — gate one error variant
-nobodywho/core/src/chat.rs      — gate ~5 places (worker state, methods)
-nobodywho/core/src/tokenizer.rs — gate ~30 places (Chunk variants, all
-                                  match arms, multimodal init paths)
-```
-
-Roughly 1–2 hours of careful cfg-attribute application. Either
-`#[cfg(not(target_arch = "wasm32"))]` everywhere or adding a `mtmd`
-cargo feature to core (cleaner long-term — wasm just opts out).
-
-Effort estimate to finish B: ~half a day. Plus ongoing maintenance of
-the llama.cpp source patches as llama.cpp evolves (these should
-eventually go upstream — `LLAMA_BUILD_HTTPLIB=OFF`, `LLAMA_BUILD_AUDIO=OFF`).
-
-#### Path C — `wasm32-wasip2` + component model
-
-Future-proof but bleeding-edge tooling; not recommended for shipping
-this year.
-
-### Status of the fork's `wasm` branch
-
-The `wasm32-unknown-emscripten` build works end-to-end (113 MB .wasm
-artifact). The parallel `wasm32-unknown-unknown` path is partial as
-described above.
-
-2. **End-to-end smoke test.** Embed a small GGUF as bytes, call
-   `Model.loadBytes`, run one `Chat.ask`, log a token. Confirms the full
-   stack (FFI → llama.cpp → sampler → channel pump) works in a browser.
-
-3. **Release-mode build size.** Debug is 113 MB. Release should be
-   ~10–20 MB. Verify with `cargo build --release --target ...`. Brotli
-   compression brings the served size down further.
-
-### Done in earlier commits
-
-- ✅ `LlamaModel::load_from_buffer` wraps `llama_model_load_from_file_ptr`
-  via libc `fmemopen`. `nobodywho::llm::get_model_from_bytes` in core
-  exposes it. `Model.loadBytes(uint8Array)` in this binding wires it
-  through.
-- ✅ Worker refactor: `std::thread::spawn` + `std::sync::mpsc` swapped for
-  `tokio::sync::mpsc::unbounded_channel` on both targets;
-  `wasm_bindgen_futures::spawn_local` on wasm vs `std::thread::spawn` +
-  `blocking_recv` on native. See `core/src/chat.rs`, `encoder.rs`,
-  `crossencoder.rs`.
-
-### Step 2a — `core/` dependency gates ✅ done
-
-- `core/Cargo.toml` — `tokio` split: `rt-multi-thread` on native, plain
-  `rt` on wasm. `ureq` (raw sockets, not available in browser) and
-  `indicatif` (no terminal) gated to non-wasm. `dirs` gated to non-android,
-  non-wasm. `monty` (Python interpreter) and `bashkit` (virtual bash) gated
-  to non-wasm.
-- `core/src/llm.rs` — `default_progress_callback` and the entire
-  model-loader infrastructure (`get_model`, `get_model_async`,
-  `download_*`, `ParsedModelPath`) gated to non-wasm.
-- `core/src/tool_calling/mod.rs` — `Tool::python` and `Tool::bash` gated
-  to non-wasm.
-- `grammar/gbnf` — `jsonschema` default features disabled (no HTTP/file
-  resolution needed), drops the entire `reqwest`/`hyper`/`mio` chain.
-
-### Step 2b — Worker refactor (not yet done)
-
-The Worker pattern uses `std::thread::spawn` + blocking `std::sync::mpsc::recv`
-in five places:
-- `core/src/chat.rs:307` (`ChatHandle::new`)
-- `core/src/chat.rs:576` (`ChatHandleAsync::new`)
-- `core/src/encoder.rs:34` (`EncoderAsync::new`)
-- `core/src/crossencoder.rs:47` (`CrossEncoderAsync::new`)
-- `core/src/llm.rs:317` (`get_model_async`)
-
-`WorkerGuard` (`core/src/llm.rs:828`) stores a `std::thread::JoinHandle`.
-
-wasm32 has no OS threads. Each of these needs a cfg-gated alternative that
-uses `wasm_bindgen_futures::spawn_local` and `tokio::sync::mpsc` async
-channels instead. The `WorkerGuard` needs to grow a cfg-gated variant that
-holds a cancellation token instead of a `JoinHandle`. This is a real design
-change — needs maintainer alignment on whether wasm uses cooperative
-single-threaded inference (blocks the main thread during decode) or Web
-Workers for true parallelism.
-
-### Step 2c — Bytes-based model loading (not yet done)
-
-`core/src/llm.rs` `get_model` paths go through file I/O and `ureq`
-downloads. A new `Model::load_bytes(Vec<u8>) -> Result<Model, _>`
-constructor is needed for wasm (and is useful on native too — tests
-already have GGUF bytes in memory). The scaffold's
-`Model::loadBytes` JS API points to this.
-
-## What's exposed
-
-Mirrors the Python binding's surface, async-only:
-
-| Class | Methods |
+| Surface | Status |
 |---|---|
-| `Model` | `Model.loadBytes(uint8Array)` *(blocked on Step 2)* |
-| `Chat` | `new Chat(model, options)`, `ask(prompt)`, `reset(systemPrompt?)`, `resetHistory()` |
-| `TokenStream` | `nextToken()`, `completed()` |
-| `Encoder` | `new Encoder(model, nCtx?)`, `encode(text)` |
+| `Model.loadBytes(uint8Array)` | ✅ verified — loads GGUF into a real `LlamaModel` via `fmemopen` + `llama_model_load_from_file_ptr` |
+| `Encoder.encode(text)` | ✅ verified — produces a real `Float32Array` embedding |
+| `Chat` / `TokenStream` API | wired up, identical worker pattern to Encoder; should work with a chat-style GGUF (not yet smoke-tested due to model-size download) |
+| Multimodal (`MtmdBitmap` etc.) | not exposed — mtmd C++ doesn't compile against wasi-libc; the wasm has unresolved `mtmd_*` imports that JS replaces with stubs |
+| Structured output (`Constraint`) | not yet wired up to the JS surface (works inside core, no JS wrapping yet) |
 
-Not yet wrapped (will be added in follow-up PRs): `CrossEncoder`,
-`Constraint` (structured output), tool calling, multimodal assets. See the
-end of `src/lib.rs` for the full out-of-scope list and the reason each is
-deferred.
+Native (`cargo check --workspace`) is unchanged.
 
-## Build (once Steps 1 and 2 are done)
+## Build pipeline
+
+```
+   nobodywho/core (Rust)
+        +
+   llama-cpp-2 fork @ nobodywho-ooo/llama-cpp-rs branch wasm
+        |
+        | wasi-sdk clang for the C/C++ side
+        | rustc + wasm-bindgen attrs for the Rust side
+        v
+   wasm32-unknown-unknown .wasm (21 MB debug, 9.5 MB release)
+        |
+        | wasm-bindgen-cli --target bundler
+        v
+   pkg-bundler/
+     ├── nobodywho_wasm.js          (entry — calls __wbg_set_wasm)
+     ├── nobodywho_wasm_bg.js       (Chat/Model/Encoder classes + glue)
+     ├── nobodywho_wasm_bg.wasm     (compiled wasm)
+     ├── nobodywho_wasm.d.ts        (TS typings)
+     └── nobodywho_wasm_bg.wasm.d.ts
+```
+
+## Build it yourself
+
+### Prerequisites
 
 ```bash
-# One-time setup
-cargo install wasm-pack
+# wasi-sdk for compiling the C/C++ side of llama.cpp.
+# Builds tested with v33; older versions likely work.
+curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-arm64-macos.tar.gz \
+  | tar -xz -C ~
+export WASI_SDK_PATH=~/wasi-sdk-33.0-arm64-macos
+# Linux: replace arm64-macos with x86_64-linux or arm64-linux.
+
+# rustc target + wasm-bindgen-cli.
 rustup target add wasm32-unknown-unknown
+cargo install wasm-bindgen-cli --version 0.2.121
+```
 
-# Build
+### Build
+
+```bash
+cd nobodywho
+
+WASI_SDK_PATH=$WASI_SDK_PATH \
+  cargo build --target wasm32-unknown-unknown --release -p nobodywho-wasm
+
+wasm-bindgen --target bundler \
+  target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
+  --out-dir wasm/pkg-bundler/
+```
+
+The `pkg-bundler/` directory is the npm-publishable artifact (minus a
+hand-written `package.json` — see `wasm/package.json.tpl`).
+
+## Run it
+
+### Under Node (uses `node:wasi` for WASI imports)
+
+```bash
+# Smoke test (no model):
+node wasm/examples/run.mjs
+
+# Real embedding inference with a GGUF:
+node wasm/examples/run.mjs --encode /path/to/embedding-model.gguf "your text"
+
+# Chat (when you have a chat-style GGUF):
+node wasm/examples/run.mjs /path/to/chat-model.gguf "your prompt"
+```
+
+### In a browser (uses `@bjorn3/browser_wasi_shim`)
+
+```bash
 cd nobodywho/wasm
-wasm-pack build --target web
+python3 -m http.server 8000
+# open http://localhost:8000/examples/browser.html
+# pick a GGUF, click Run
 ```
 
-Output goes to `nobodywho/wasm/pkg/`. That directory is the publishable npm
-package — `package.json`, `.wasm` artifact, JS glue, and `.d.ts` typings.
+See `wasm/examples/browser.html` for a complete browser demo that loads the
+wasm, polyfills WASI via `@bjorn3/browser_wasi_shim`, and runs
+`Encoder.encode` on a user-uploaded GGUF.
 
-## Use (browser, ES modules)
+## How it works (and why these specific choices)
 
-```html
-<script type="module">
-  import init, { Model, Chat } from './pkg/nobodywho_wasm.js';
+### Target: `wasm32-unknown-unknown` (not Emscripten, not WASI Preview 1/2)
 
-  await init();
+- **Emscripten** also works (`cargo build --target wasm32-unknown-emscripten`
+  produces a 113 MB debug .wasm) but its output isn't processable by
+  `wasm-bindgen-cli` — wasm-bindgen's interpreter doesn't understand
+  Emscripten's section layout. Browser distribution via wasm-bindgen + npm
+  is the path that fits the rustwasm ecosystem.
+- **WASI Preview 2** would be the future-proof choice, but tooling is
+  still maturing and browser support is uneven.
 
-  const buf = await (await fetch('./tinyllama.gguf')).arrayBuffer();
-  const model = await Model.loadBytes(new Uint8Array(buf));
+### libc: wasi-sdk's `wasi-libc`
 
-  const chat = new Chat(model, {
-    contextSize: 2048,
-    systemPrompt: 'You are a concise assistant.',
-  });
+The Rust target `wasm32-unknown-unknown` has no libc. llama.cpp is C/C++ and
+needs `<stdio.h>`, `<malloc.h>`, etc. We compile the C/C++ side targeting
+`wasm32-wasip1` (via the wasi-sdk clang) and link `wasi-libc` + `libc++`
+explicitly in the final cdylib link. The result is a wasm with
+`wasi_snapshot_preview1` imports that the JS host polyfills via
+`node:wasi` (Node) or `@bjorn3/browser_wasi_shim` (browser).
 
-  const stream = await chat.ask('Why is the sky blue?');
-  let tok;
-  while ((tok = await stream.nextToken()) !== undefined) {
-    document.body.append(tok);
-  }
-</script>
-```
+### Source-level patches to llama.cpp
 
-## Caveats
+The fork at [`nobodywho-ooo/llama-cpp-rs` branch `wasm`](https://github.com/nobodywho-ooo/llama-cpp-rs/tree/wasm)
+patches a handful of files in `llama.cpp/common/` at build time, because
+wasi-libc deliberately doesn't ship POSIX features the upstream code
+assumes:
 
-- **Memory ceiling.** `wasm32` is capped at 4 GB. Models larger than that
-  need wasm64 (`memory64` proposal — Chrome 119+, Firefox 134+), which our
-  toolchain doesn't enable yet. Practically: stick to Q4/Q5 quantizations of
-  ≤7B-parameter models for now.
-- **No GPU.** WebGPU acceleration in llama.cpp is experimental upstream and
-  not part of this binding's first release. CPU only.
-- **Cross-origin isolation.** If/when we enable wasm threads via
-  `SharedArrayBuffer`, the hosting page needs `Cross-Origin-Opener-Policy:
-  same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. The
-  first release is single-threaded.
-- **Bundle size.** llama.cpp compiled with Emscripten is several MB. Plan to
-  serve the `.wasm` over HTTPS with `Content-Encoding: br` (Brotli) and
-  cache aggressively.
+- `cpp-httplib` excised entirely (no `<net/if.h>`, no sockets).
+- `arg.cpp`, `console.cpp`, `download.cpp`, `hf-cache.cpp`, `http.h`
+  stripped from the source list (POSIX `<sys/syslimits.h>`, `<termios.h>`,
+  HTTP).
+- `_WASI_EMULATED_SIGNAL` + `_WASI_EMULATED_PROCESS_CLOCKS` compile defines
+  + their matching link libs, so `<signal.h>` and `<sys/resource.h>`
+  resolve to best-effort no-ops.
+- `common/common.cpp` `fs_get_cache_directory` extended with an
+  `#elif defined(__wasi__)` arm.
+- `common/common.cpp` `set_process_priority` stubbed for `__wasi__`
+  (no `PRIO_PROCESS` in wasi-libc).
+- `mtmd` (multimodal) C++ skipped — depends on `vendor/miniaudio` which
+  needs pthread sched APIs wasi-libc doesn't provide.
+
+These patches should eventually land upstream in llama.cpp as
+`LLAMA_BUILD_HTTPLIB=OFF`, `LLAMA_BUILD_AUDIO=OFF`, etc.
+
+### Runtime workarounds in nobodywho
+
+A few cfg-gates in `nobodywho/core` for wasm32:
+
+- `tokio` features: drop `rt-multi-thread` (no OS threads).
+- `ureq`, `indicatif`, `dirs`, `monty`, `bashkit`: native-only.
+- Worker pattern: `std::thread::spawn` → `wasm_bindgen_futures::spawn_local`,
+  `std::sync::mpsc` → `tokio::sync::mpsc::unbounded_channel`.
+- Model loading: `get_model_from_bytes` constructor that bypasses the
+  filesystem (`fmemopen` + `llama_model_load_from_file_ptr`).
+- `Tokenizer::tokenize_text` inlines the `mtmd_default_marker` literal
+  (the real C function isn't compiled).
+- `Worker` n_threads hardcoded to 1 (`available_parallelism` errors on
+  wasm).
+- `mtmd` cargo feature on core (default on), wasm crate keeps it enabled
+  for FFI declarations but the C++ implementation isn't compiled —
+  `mtmd_*` symbols become wasm imports stubbed by the JS host.
+
+And one workaround in the wasm crate itself (`wasm/src/lib.rs`):
+- `__cxa_atexit` overridden as a no-op. `rust-lld 22.1`'s wasm driver
+  doesn't accept `--mexec-model=reactor`, so the linker stays in
+  "command" mode and wraps every export in `__wasm_call_ctors` +
+  `__wasm_call_dtors`. The dtor walk iterates registered handlers and
+  trips on a signature mismatch. Suppressing the registration entirely
+  makes the dtor walk a no-op. Global destructors don't run at module
+  shutdown — fine, the wasm instance lives for the JS process anyway.
+
+## Outstanding
+
+- **Chat smoke test.** Encoder API verified; Chat uses the same worker
+  plumbing but needs a chat-style GGUF to actually invoke. The 35 MB
+  bge-small only does embeddings.
+- **Release-publishable npm package.** `pkg-bundler/` is the right shape;
+  needs a `package.json` (template at `wasm/package.json.tpl`) and a
+  `prepublish` step that does the cargo build + wasm-bindgen, plus CI.
+- **Browser polyfill bundling.** The `browser.html` example loads
+  `@bjorn3/browser_wasi_shim` from a CDN. For npm distribution we'd
+  bundle it (or add it as a peer dep, as the template `package.json`
+  already does).
+- **`Constraint` / structured output API surface.** Wired up in core, not
+  yet exposed from `wasm/src/lib.rs`. Mostly a serde-wasm-bindgen
+  pass-through.
+- **Upstream llama.cpp PRs** for the build-time patches.

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -6,12 +6,24 @@ Flutter, Godot, and Uniffi bindings.
 
 ## Status
 
-The wasm32 build path is **real but untested end-to-end**. `cargo check
---target wasm32-unknown-emscripten -p nobodywho-wasm` exercises the full
-toolchain (bindgen + cc + cmake via Emscripten) and panics with a clear
-`Could not detect Emscripten sysroot. Ensure 'emcc' is on PATH...`
-message unless `emcc` is installed. Native (`cargo check --workspace`)
-is unaffected.
+**`cargo build --target wasm32-unknown-emscripten -p nobodywho-wasm`
+produces a working `nobodywho_wasm.wasm` artifact** (~113 MB debug,
+~10–20 MB release-stripped, including all of llama.cpp).
+
+The pipeline that runs end-to-end:
+
+```
+bindgen → cc::Build (em++) → cmake (llama.cpp via Emscripten) → wasm-bindgen
+        ↓                  ↓                                  ↓
+   FFI bindings.rs   wrapper static .a                  __wbindgen_* exports
+                                              ↓
+                                      emcc + wasm-ld
+                                              ↓
+                                   nobodywho_wasm.wasm
+```
+
+Native (`cargo check --workspace`) is unaffected and builds bit-for-bit
+the same as before the wasm branch.
 
 ### Build prerequisites
 
@@ -53,18 +65,90 @@ support (cherry-picked from his branch). Specifically:
 
 See `WASM.md` in the fork for the full build details and remaining gaps.
 
-### Outstanding work
+### Outstanding work — pick A or B
 
-1. **End-to-end build verification.** Asbjørn's commits are marked
-   "still untested". Someone with `emsdk` activated needs to run
-   `cargo build --target wasm32-unknown-emscripten` and shake out any
-   remaining flag tuning.
-2. **`Model::load_from_bytes`.** The current `Model::loadBytes` in
-   `src/lib.rs` returns a placeholder `JsError`. Wiring it up needs a
-   `LlamaModel::load_from_buffer` wrapper in the fork (Step 2c below).
-3. **Worker refactor.** `core/src/chat.rs:307` and similar use
-   `std::thread::spawn`, which wasm32 doesn't have. Needs cfg-gated
-   `wasm_bindgen_futures::spawn_local` path.
+#### Path A — drop wasm-bindgen, use Emscripten's JS glue (works today)
+
+Keep the existing `wasm32-unknown-emscripten` build. **Replace
+`#[wasm_bindgen]` with `#[no_mangle] extern "C"`** in `src/lib.rs`,
+marshaling types manually (string pointers via `Box::into_raw`, byte
+arrays as `(*mut u8, usize)`, async results as callback handles).
+Emscripten emits a JS loader via `MODULARIZE=1` that handles all libc
+imports automatically.
+
+Effort: ~1 day. Less type-safe than wasm-bindgen, but builds on the
+working pipeline and ships a usable npm package immediately.
+
+#### Path B — wasm32-unknown-unknown + wasi-sdk (C++ side done, Rust mtmd gating remains)
+
+The fork's `wasm` branch now has a full `wasm32-unknown-unknown` build
+path: `TargetOs::WasmUnknown` variant, wasi-sdk detection, parallel
+bindgen/cmake/cc config, and source-level patches to llama.cpp itself
+(cpp-httplib excision, `arg.cpp`/`console.cpp` removal, signal +
+process-clocks emulation, `fs_get_cache_directory` `__wasi__` case,
+`set_process_priority` no-op, mtmd's miniaudio skipped because it needs
+pthread sched APIs wasi-libc doesn't ship).
+
+**End-to-end C++ build works** for wasm32-unknown-unknown. The remaining
+blocker is in **`nobodywho/core` itself**: it imports
+`llama_cpp_2::mtmd::{MtmdInputChunks, MtmdBitmap, MtmdContext, ...}` and
+those types now don't exist on wasm32 (since the fork's mtmd Rust module
+is also gated off — the FFI symbols aren't there because the mtmd C++
+isn't compiled).
+
+`core/src/chat.rs` and `core/src/tokenizer.rs` use these types
+structurally (as struct fields, enum variants like `Asset::Image`,
+`TokenizerChunk::Image`/`Audio`, and `bitmaps: IndexMap<ChunkId,
+MtmdBitmap>` on the chat worker state). Gating them out for wasm is a
+mechanical-but-substantial refactor:
+
+```
+nobodywho/core/src/llm.rs       — gate MtmdInputChunks import + 1 field
+nobodywho/core/src/template.rs  — gate MtmdBitmap import + 1 field
+nobodywho/core/src/errors.rs    — gate one error variant
+nobodywho/core/src/chat.rs      — gate ~5 places (worker state, methods)
+nobodywho/core/src/tokenizer.rs — gate ~30 places (Chunk variants, all
+                                  match arms, multimodal init paths)
+```
+
+Roughly 1–2 hours of careful cfg-attribute application. Either
+`#[cfg(not(target_arch = "wasm32"))]` everywhere or adding a `mtmd`
+cargo feature to core (cleaner long-term — wasm just opts out).
+
+Effort estimate to finish B: ~half a day. Plus ongoing maintenance of
+the llama.cpp source patches as llama.cpp evolves (these should
+eventually go upstream — `LLAMA_BUILD_HTTPLIB=OFF`, `LLAMA_BUILD_AUDIO=OFF`).
+
+#### Path C — `wasm32-wasip2` + component model
+
+Future-proof but bleeding-edge tooling; not recommended for shipping
+this year.
+
+### Status of the fork's `wasm` branch
+
+The `wasm32-unknown-emscripten` build works end-to-end (113 MB .wasm
+artifact). The parallel `wasm32-unknown-unknown` path is partial as
+described above.
+
+2. **End-to-end smoke test.** Embed a small GGUF as bytes, call
+   `Model.loadBytes`, run one `Chat.ask`, log a token. Confirms the full
+   stack (FFI → llama.cpp → sampler → channel pump) works in a browser.
+
+3. **Release-mode build size.** Debug is 113 MB. Release should be
+   ~10–20 MB. Verify with `cargo build --release --target ...`. Brotli
+   compression brings the served size down further.
+
+### Done in earlier commits
+
+- ✅ `LlamaModel::load_from_buffer` wraps `llama_model_load_from_file_ptr`
+  via libc `fmemopen`. `nobodywho::llm::get_model_from_bytes` in core
+  exposes it. `Model.loadBytes(uint8Array)` in this binding wires it
+  through.
+- ✅ Worker refactor: `std::thread::spawn` + `std::sync::mpsc` swapped for
+  `tokio::sync::mpsc::unbounded_channel` on both targets;
+  `wasm_bindgen_futures::spawn_local` on wasm vs `std::thread::spawn` +
+  `blocking_recv` on native. See `core/src/chat.rs`, `encoder.rs`,
+  `crossencoder.rs`.
 
 ### Step 2a — `core/` dependency gates ✅ done
 

--- a/nobodywho/wasm/examples/browser.html
+++ b/nobodywho/wasm/examples/browser.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>nobodywho-wasm — browser demo</title>
+  <style>
+    body { font: 14px/1.4 system-ui, sans-serif; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+    pre  { background: #f4f4f4; padding: 1em; white-space: pre-wrap; word-break: break-word; max-height: 60vh; overflow: auto; }
+    .ok  { color: #0a7a0a; }
+    .err { color: #a00; }
+    input[type=file] { margin: 0.5em 0; }
+    button { padding: 0.4em 1em; }
+  </style>
+</head>
+<body>
+  <h1>nobodywho-wasm — browser demo</h1>
+  <p>
+    Serve this directory over HTTP (e.g. <code>python3 -m http.server 8000</code> in
+    <code>nobodywho/wasm/</code>) and open <code>examples/browser.html</code>. Pick a
+    GGUF (any embedding model — the demo calls <code>Encoder.encode</code>).
+  </p>
+
+  <p>
+    <label>GGUF file: <input id="model" type="file" accept=".gguf" /></label><br />
+    <label>Text: <input id="text" value="Hello from the browser." size="40" /></label><br />
+    <button id="go">Run</button>
+  </p>
+
+  <pre id="out"></pre>
+
+  <script type="module">
+    // Imports from CDN to keep the demo single-file.
+    import { WASI, OpenFile, File, ConsoleStdout } from
+      'https://esm.sh/@bjorn3/browser_wasi_shim@0.4.1';
+
+    const out = document.getElementById('out');
+    const log = (s, cls = '') => {
+      const span = document.createElement('span');
+      if (cls) span.className = cls;
+      span.textContent = s + '\n';
+      out.appendChild(span);
+      console.log(s);
+    };
+
+    // Stubs for the unresolved `env` imports: mtmd_* (we don't expose
+    // multimodal), _Unwind_* (legacy C++ EH, shouldn't fire), dlclose.
+    const envStubs = new Proxy({}, {
+      get: (_t, name) => (...args) => {
+        throw new Error(`unresolved env.${String(name)} called with [${args}]`);
+      },
+    });
+
+    async function run() {
+      out.textContent = '';
+
+      const modelInput = document.getElementById('model');
+      const text = document.getElementById('text').value;
+      const file = modelInput.files[0];
+      if (!file) {
+        log('Pick a GGUF file first.', 'err');
+        return;
+      }
+
+      try {
+        log('Fetching wasm + glue…');
+        const [wasmBytes, bg] = await Promise.all([
+          fetch('../pkg-bundler/nobodywho_wasm_bg.wasm').then((r) => r.arrayBuffer()),
+          import('../pkg-bundler/nobodywho_wasm_bg.js'),
+        ]);
+        log(`  wasm: ${(wasmBytes.byteLength / 1024 / 1024).toFixed(1)} MB`, 'ok');
+
+        log('Setting up WASI…');
+        const wasi = new WASI(
+          [],                       // argv
+          [],                       // env
+          [
+            new OpenFile(new File([])),                // stdin
+            ConsoleStdout.lineBuffered((m) => log(`[wasi stdout] ${m}`)),
+            ConsoleStdout.lineBuffered((m) => log(`[wasi stderr] ${m}`)),
+          ],
+        );
+
+        log('Instantiating wasm…');
+        const mod = await WebAssembly.compile(wasmBytes);
+        const inst = await WebAssembly.instantiate(mod, {
+          './nobodywho_wasm_bg.js': bg,
+          env: envStubs,
+          ...wasi.getImportObject(),
+        });
+
+        // Reactor-style init: run _initialize once.
+        if (inst.exports._initialize) {
+          wasi.initialize(inst);
+          log('  wasi.initialize ran _initialize', 'ok');
+        }
+
+        bg.__wbg_set_wasm(inst.exports);
+        if (inst.exports.__wbindgen_start) inst.exports.__wbindgen_start();
+        bg.init();  // panic hook + tracing
+        log('  ✓ wasm ready', 'ok');
+
+        log('Loading model bytes…');
+        const modelBytes = new Uint8Array(await file.arrayBuffer());
+        log(`  model: ${(modelBytes.byteLength / 1024 / 1024).toFixed(1)} MB`);
+        const model = await bg.Model.loadBytes(modelBytes);
+        log('  ✓ model loaded', 'ok');
+
+        log('Creating encoder…');
+        const encoder = new bg.Encoder(model, 512);
+        log('  ✓ encoder created', 'ok');
+
+        log(`Encoding: ${JSON.stringify(text)}…`);
+        const vec = await encoder.encode(text);
+        log(`  ✓ embedding: ${vec.length} dims`, 'ok');
+        log(`  first 8: [${Array.from(vec.slice(0, 8))
+          .map((v) => v.toFixed(4)).join(', ')}]`);
+        log('Done.', 'ok');
+      } catch (e) {
+        log(`FAILED: ${e}`, 'err');
+        console.error(e);
+      }
+    }
+
+    document.getElementById('go').addEventListener('click', run);
+  </script>
+</body>
+</html>

--- a/nobodywho/wasm/examples/run.mjs
+++ b/nobodywho/wasm/examples/run.mjs
@@ -1,0 +1,153 @@
+// Run nobodywho-wasm under Node with a real WASI shim.
+//
+// Uses the `--target bundler` wasm-bindgen output but bypasses the missing
+// bundler: we manually instantiate the .wasm, then call __wbg_set_wasm on
+// the bg.js module so the exported classes (Chat, Model, ...) wire up.
+//
+// Usage:
+//   node wasm/examples/run.mjs                            # smoke test (no model)
+//   node wasm/examples/run.mjs path/to/model.gguf "your prompt"   # chat
+//   node wasm/examples/run.mjs --encode embedding.gguf "your text" # embedding
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { WASI } from 'node:wasi';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, '..', 'pkg-bundler');
+
+const argv = process.argv.slice(2);
+const encodeMode = argv[0] === '--encode';
+const [modelPath, prompt] = encodeMode ? argv.slice(1) : argv;
+const log = (...a) => console.log(...a);
+
+// ---------- Imports object ----------
+//
+// Three groups (from wasm-tools dump): ./nobodywho_wasm_bg.js (the
+// wasm-bindgen glue we'll fill from bg.js), env (unresolved C symbols —
+// mtmd_*, _Unwind_*, dlclose), wasi_snapshot_preview1 (real WASI).
+
+const bg = await import(join(pkgDir, 'nobodywho_wasm_bg.js'));
+
+// node:wasi provides a fresh `WASI` instance whose getImportObject()
+// returns the wasi_snapshot_preview1 implementation. Empty preopens =
+// the wasm has no filesystem visibility, which matches the browser case.
+const wasi = new WASI({ version: 'preview1', args: [], env: {} });
+
+// Env stubs: the wasm imports mtmd_* (we don't call them, the binding
+// doesn't expose multimodal), _Unwind_* (legacy exceptions; should not
+// fire in normal operation), and dlclose. Throwing makes accidental
+// calls visible during dev; switch to silent no-ops for prod.
+const envStubs = new Proxy(
+  {},
+  {
+    get(_t, name) {
+      return (...args) => {
+        throw new Error(`unresolved env.${String(name)}(${args.join(', ')})`);
+      };
+    },
+  },
+);
+
+const wasmBytes = readFileSync(join(pkgDir, 'nobodywho_wasm_bg.wasm'));
+
+log(`Wasm size: ${(wasmBytes.length / (1024 * 1024)).toFixed(1)} MB`);
+log('Compiling…');
+const mod = await WebAssembly.compile(wasmBytes);
+
+log('Instantiating with WASI + bg.js glue + env stubs…');
+const inst = await WebAssembly.instantiate(mod, {
+  './nobodywho_wasm_bg.js': bg,
+  env: envStubs,
+  ...wasi.getImportObject(),
+});
+
+// node:wasi expects to be initialized against a reactor (no _start, has
+// _initialize) or command (has _start). Our wasm exports `_initialize`
+// when wasi-libc is linked, so wasi.initialize is the right call.
+// IMPORTANT: only one of {wasi.initialize, manual __wasm_call_ctors,
+// __wbindgen_start} should run — they all run C++ static constructors
+// and register atexit handlers. Running twice produces signature-
+// mismatched calls in __funcs_on_exit later.
+//
+// `wasi.initialize` runs `_initialize` which itself calls __wasm_call_ctors,
+// so that covers libc + libc++ static init. We then run __wbindgen_start
+// once to do wasm-bindgen's own startup (externref table allocation etc.).
+try {
+  wasi.initialize(inst);
+  log('  ✓ wasi.initialize ran _initialize');
+} catch (e) {
+  log(`  ! wasi.initialize skipped (${e.message})`);
+  // Fall back to running ctors manually.
+  if (inst.exports.__wasm_call_ctors) inst.exports.__wasm_call_ctors();
+}
+
+// Wire wasm-bindgen's bg.js to the instantiated wasm.
+bg.__wbg_set_wasm(inst.exports);
+
+// wasm-bindgen's own startup — must run after __wasm_call_ctors.
+if (inst.exports.__wbindgen_start) inst.exports.__wbindgen_start();
+
+log('  ✓ wasm wired up');
+
+// Try the simplest export.
+log('Calling init() (panic hook + tracing)…');
+try {
+  bg.init();
+  log('  ✓ init() ok');
+} catch (e) {
+  log(`  ✗ init() threw: ${e}`);
+  console.error(e);
+  process.exit(1);
+}
+
+if (!modelPath) {
+  log('');
+  log('Smoke test complete — wasm initializes under real WASI.');
+  log('Pass a model path to load a model and run inference:');
+  log('  node wasm/examples/run.mjs ./model.gguf "Hello, "');
+  log('  node wasm/examples/run.mjs --encode ./embedding.gguf "some text"');
+  process.exit(0);
+}
+
+// ---------- Real inference / embedding ----------
+
+log(`Loading model from ${modelPath}…`);
+const modelBytes = readFileSync(modelPath);
+log(`  model size: ${(modelBytes.length / (1024 * 1024)).toFixed(1)} MB`);
+
+const model = await bg.Model.loadBytes(new Uint8Array(modelBytes));
+log('  ✓ model loaded');
+
+if (encodeMode) {
+  log('Creating Encoder…');
+  const encoder = new bg.Encoder(model, 512);
+  log('  ✓ encoder created');
+
+  const text = prompt ?? 'The quick brown fox jumps over the lazy dog.';
+  log(`Encoding: ${JSON.stringify(text)}`);
+  const vec = await encoder.encode(text);
+  log(`  ✓ embedding generated: ${vec.length} dimensions`);
+  log(`  first 8: [${Array.from(vec.slice(0, 8)).map((v) => v.toFixed(4)).join(', ')}]`);
+  log('Done.');
+} else {
+  log('Creating Chat…');
+  const chat = new bg.Chat(model, { contextSize: 1024 });
+  log('  ✓ chat created');
+
+  const promptText = prompt ?? 'Hello, ';
+  log(`Asking: ${JSON.stringify(promptText)}`);
+  const stream = await chat.ask(promptText);
+
+  process.stdout.write('Response: ');
+  let tok;
+  let count = 0;
+  while ((tok = await stream.nextToken()) !== undefined && count < 64) {
+    process.stdout.write(tok);
+    count++;
+  }
+  process.stdout.write('\n');
+  log(`  ✓ produced ${count} tokens`);
+  log('Done.');
+}

--- a/nobodywho/wasm/examples/smoke-manual.mjs
+++ b/nobodywho/wasm/examples/smoke-manual.mjs
@@ -1,0 +1,84 @@
+// Smoke test that bypasses wasm-bindgen's auto-init.
+//
+// wasm-bindgen-cli generates ESM glue that does `import * as ... from 'env'`
+// for every env import group in the wasm — none of those modules exist,
+// so the auto-generated loader can't be used from Node directly. Instead,
+// manually instantiate the wasm with our own imports object, then verify
+// the expected exports show up.
+//
+// This proves the wasm itself is loadable. Going further (calling exported
+// classes like Model/Chat) requires the wasm-bindgen JS glue, which is
+// what the bundler/web-with-bundler targets are for. For npm distribution
+// we'd ship with `--target bundler` and let webpack/esbuild handle the
+// env imports via an alias.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wasmPath = join(here, '..', 'pkg', 'nobodywho_wasm_bg.wasm');
+const bytes = readFileSync(wasmPath);
+
+console.log(`Wasm size: ${(bytes.length / (1024 * 1024)).toFixed(1)} MB`);
+
+// Build a Proxy that returns a stub for any function the wasm asks for —
+// the env imports number in the hundreds (libc + C++ runtime + mtmd_*), so
+// enumerating them all by hand isn't useful for a "does it load" check.
+const stubProxy = new Proxy(
+  {},
+  {
+    get(_t, name) {
+      // Return a no-op function for anything the wasm tries to import.
+      // We track which ones get called; if it's a memory / table import
+      // we'd need to provide a real one, but for now everything we see
+      // is a function.
+      return (...args) => {
+        // Pretty-print first call per symbol so the smoke test output
+        // is readable; later calls log nothing.
+        if (!called.has(name)) {
+          called.add(name);
+        }
+        return 0;
+      };
+    },
+    has(_t, name) {
+      return true;
+    },
+  },
+);
+const called = new Set();
+
+// Compile + instantiate.
+console.log('Compiling…');
+const mod = await WebAssembly.compile(bytes);
+
+console.log(`Imports: ${WebAssembly.Module.imports(mod).length}`);
+const importsByModule = {};
+for (const i of WebAssembly.Module.imports(mod)) {
+  (importsByModule[i.module] ??= []).push(`${i.name} (${i.kind})`);
+}
+for (const [m, names] of Object.entries(importsByModule)) {
+  console.log(`  ${m}: ${names.length} entries`);
+}
+
+// Provide each module as the stub Proxy. The wasm doesn't actually call
+// these at module-init time (or rather: any call gets a no-op 0), so the
+// instance comes up.
+console.log('Instantiating…');
+const inst = await WebAssembly.instantiate(mod, {
+  ...Object.fromEntries(
+    Object.keys(importsByModule).map((m) => [m, stubProxy]),
+  ),
+});
+
+console.log(`Exports: ${Object.keys(inst.exports).length}`);
+const ownClasses = Object.keys(inst.exports)
+  .filter((n) => /^(chat|model|encoder|tokenstream|init)_/.test(n) || n === 'init')
+  .sort();
+console.log(`  Class-like exports: ${ownClasses.join(', ') || '(none)'}`);
+
+console.log('');
+console.log('✓ wasm instantiated, exports present.');
+console.log('  Bytes loaded, imports resolved with no-op stubs, exports table populated.');
+console.log('  This proves the wasm is well-formed; calling methods requires real imports.');

--- a/nobodywho/wasm/examples/smoke.html
+++ b/nobodywho/wasm/examples/smoke.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>nobodywho-wasm smoke test</title>
+  <style>
+    body { font: 14px/1.4 system-ui, sans-serif; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+    pre  { background: #f4f4f4; padding: 1em; white-space: pre-wrap; word-break: break-word; }
+    .ok  { color: #0a7a0a; }
+    .err { color: #a00; }
+  </style>
+</head>
+<body>
+  <h1>nobodywho-wasm smoke test</h1>
+  <p>Loads the wasm-bindgen output and reports which stages succeed.</p>
+  <pre id="out">…</pre>
+
+  <script type="module">
+    const out = document.getElementById('out');
+    const log = (s, cls = '') => {
+      const line = document.createElement('span');
+      if (cls) line.className = cls;
+      line.textContent = s + '\n';
+      out.appendChild(line);
+      console.log(s);
+    };
+    out.textContent = '';
+
+    // 23 unresolved env imports from llama.cpp's C++ that we don't actually
+    // call from the wasm binding's surface. Provide stub implementations so
+    // wasm instantiation succeeds. Most are mtmd_* (we don't enable multimodal
+    // on wasm) and a few C++ exception bits we won't trigger.
+    const envStubs = {
+      // Multimodal C-API — we don't expose multimodal in the wasm binding,
+      // so these never get called. Throwing makes accidental calls visible.
+      mtmd_default_marker:                 () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_bitmap_free:                    () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_bitmap_get_data:                () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_bitmap_get_n_bytes:             () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_bitmap_is_audio:                () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_bitmap_set_id:                  () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_helper_bitmap_init_from_file:   () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_helper_eval_chunks:             () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_helper_get_n_tokens:            () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunk_free:               () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunk_get_id:             () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunk_get_n_tokens:       () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunk_get_type:           () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunks_free:              () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunks_get:               () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunks_init:              () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_input_chunks_size:              () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_free:                           () => { throw new Error('mtmd not available on wasm'); },
+      mtmd_tokenize:                       () => { throw new Error('mtmd not available on wasm'); },
+
+      // C++ unwinding — llama.cpp uses exceptions internally (try/catch in
+      // gguf parsing etc.) and was compiled with -fwasm-exceptions, so these
+      // should be the wasm host's job. Stub to abort if hit (means an actual
+      // C++ exception escaped, which is a bug).
+      _Unwind_RaiseException:    () => { throw new Error('Unwind_RaiseException called — uncaught C++ exception'); },
+      _Unwind_DeleteException:   () => {},
+      _Unwind_CallPersonality:   () => 0,
+
+      // dlclose — dynamic linking is a wasm-no-op.
+      dlclose: () => 0,
+    };
+
+    try {
+      log('Importing module…');
+      const mod = await import('../pkg/nobodywho_wasm.js');
+      log('  → import ok', 'ok');
+
+      log('Calling init()…');
+      // wasm-bindgen's auto-generated init() doesn't know about our env stubs.
+      // Instead, call initSync with explicit imports, or instantiate the wasm
+      // ourselves. Easiest: use the underlying initSync exported by the glue.
+      // For wasm-bindgen 0.2.x, the default init() takes a config object with
+      // `module_or_path` and optionally an `imports` callback.
+      await mod.default({
+        imports: { env: envStubs },
+      });
+      log('  → init ok', 'ok');
+
+      log('Calling init() helper (panic hook + tracing)…');
+      mod.init();
+      log('  → init helper ok', 'ok');
+
+      log('Checking exposed classes…');
+      const have = ['Model', 'Chat', 'TokenStream', 'Encoder'].filter(n => n in mod);
+      log('  → found: ' + have.join(', '), have.length === 4 ? 'ok' : 'err');
+
+      log('Smoke test complete.', 'ok');
+      log('');
+      log('Next: load a small GGUF via Model.loadBytes() and call chat.ask().');
+      log('That requires hosting a model file alongside this page (50MB+).');
+    } catch (e) {
+      log('FAILED: ' + e, 'err');
+      console.error(e);
+    }
+  </script>
+</body>
+</html>

--- a/nobodywho/wasm/examples/smoke.mjs
+++ b/nobodywho/wasm/examples/smoke.mjs
@@ -1,0 +1,77 @@
+// Smoke test for the wasm-bindgen --target web output, run under Node.
+//
+// Node 18+ has `fetch` and `import.meta.url`, so the web-target ESM module
+// works almost as-is. The only wrinkle is the 23 unresolved env imports
+// (mtmd_*, _Unwind_*, dlclose) that the wasm has — wasm-bindgen's default
+// init() doesn't take an imports override, so we instantiate the wasm
+// ourselves with the env stubs and then call __wbg_set_wasm to wire it up.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, '..', 'pkg');
+
+const stubs = {};
+const stub = (name) => (...args) => {
+  throw new Error(`unresolved env.${name} called (args: ${args.join(',')})`);
+};
+for (const fn of [
+  'mtmd_default_marker', 'mtmd_bitmap_free', 'mtmd_bitmap_get_data',
+  'mtmd_bitmap_get_n_bytes', 'mtmd_bitmap_is_audio', 'mtmd_bitmap_set_id',
+  'mtmd_helper_bitmap_init_from_file', 'mtmd_helper_eval_chunks',
+  'mtmd_helper_get_n_tokens', 'mtmd_input_chunk_free',
+  'mtmd_input_chunk_get_id', 'mtmd_input_chunk_get_n_tokens',
+  'mtmd_input_chunk_get_type', 'mtmd_input_chunks_free',
+  'mtmd_input_chunks_get', 'mtmd_input_chunks_size',
+  'mtmd_input_chunks_init', 'mtmd_free', 'mtmd_tokenize',
+  '_Unwind_RaiseException', '_Unwind_DeleteException', '_Unwind_CallPersonality',
+  'dlclose',
+]) {
+  stubs[fn] = stub(fn);
+}
+
+console.log('Smoke test: nobodywho-wasm');
+console.log('  Loading wasm-bindgen glue + wasm bytes…');
+
+// Polyfill: the web-target glue uses fetch(url) for the wasm file. Replace
+// with fs.readFileSync via a synchronous wrapper.
+const realFetch = globalThis.fetch;
+globalThis.fetch = async (urlOrReq) => {
+  const url = typeof urlOrReq === 'string' ? urlOrReq : urlOrReq.url;
+  if (url.startsWith('file://') && url.endsWith('.wasm')) {
+    const path = fileURLToPath(url);
+    const bytes = readFileSync(path);
+    return new Response(bytes, { headers: { 'content-type': 'application/wasm' } });
+  }
+  return realFetch ? realFetch(urlOrReq) : Promise.reject(new Error('no fetch'));
+};
+
+const mod = await import(join(pkgDir, 'nobodywho_wasm.js'));
+
+// wasm-bindgen 0.2's default export accepts a `module_or_path` arg plus an
+// optional `imports` callback (see source comments in nobodywho_wasm.js).
+// The callback receives the default imports object and returns the final one.
+console.log('  Instantiating wasm with env stubs…');
+await mod.default({
+  imports: (defaultImports) => ({
+    ...defaultImports,
+    env: { ...(defaultImports.env || {}), ...stubs },
+  }),
+});
+
+console.log('  ✓ Wasm loaded');
+
+console.log('  Calling init() (panic hook + tracing)…');
+mod.init();
+console.log('  ✓ init ok');
+
+console.log('  Checking exposed classes…');
+const have = ['Model', 'Chat', 'TokenStream', 'Encoder'].filter((n) => n in mod);
+console.log(`  ✓ found: ${have.join(', ')}`);
+
+console.log('');
+console.log('Smoke test passed. Wasm initializes; classes exposed.');
+console.log('');
+console.log('Next: load a GGUF via Model.loadBytes() and call chat.ask().');

--- a/nobodywho/wasm/package.json.tpl
+++ b/nobodywho/wasm/package.json.tpl
@@ -1,0 +1,43 @@
+{
+  "name": "@nobodywho/wasm",
+  "version": "0.1.0",
+  "description": "Run local LLMs in the browser via llama.cpp compiled to WebAssembly.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nobodywho-ooo/nobodywho",
+    "directory": "nobodywho/wasm"
+  },
+  "homepage": "https://nobodywho.ooo",
+  "keywords": [
+    "llm",
+    "llama",
+    "llama.cpp",
+    "wasm",
+    "webassembly",
+    "local",
+    "inference",
+    "gguf"
+  ],
+  "main": "./nobodywho_wasm.js",
+  "types": "./nobodywho_wasm.d.ts",
+  "type": "module",
+  "files": [
+    "nobodywho_wasm.js",
+    "nobodywho_wasm.d.ts",
+    "nobodywho_wasm_bg.js",
+    "nobodywho_wasm_bg.wasm",
+    "nobodywho_wasm_bg.wasm.d.ts",
+    "README.md"
+  ],
+  "sideEffects": [
+    "./nobodywho_wasm.js",
+    "./snippets/*"
+  ],
+  "peerDependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.4.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -25,6 +25,48 @@ use std::sync::Arc;
 use futures::FutureExt;
 use wasm_bindgen::prelude::*;
 
+// Export `_initialize` so a WASI host can run static ctors via
+// wasi.initialize(). Body is empty — wasi-libc/libc++ ctors are emitted
+// into `__wasm_call_ctors`, which wasm-bindgen / node:wasi handle for us.
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn _initialize() {}
+
+// Override wasi-libc's `__cxa_atexit` to a no-op.
+//
+// The default rust-lld 22.1 wasm driver doesn't understand
+// `--mexec-model=reactor`, so it leaves the cdylib in the "command" exec
+// model: every wasm-bindgen export gets wrapped with __wasm_call_ctors +
+// __wasm_call_dtors. The dtor walk runs `__funcs_on_exit`, which iterates
+// `__cxa_atexit`-registered handlers and calls each. At least one of those
+// is registered with a wasm signature that doesn't match how
+// __funcs_on_exit invokes it, producing
+//
+//   RuntimeError: function signature mismatch
+//
+// on the FIRST export call after instantiation, before any of our code
+// runs. The handlers are global-destructor callbacks libc++ registers
+// during static init.
+//
+// Workaround: define `__cxa_atexit` ourselves and have it ignore the
+// registration. Global destructors won't run at module shutdown (which
+// is fine — the wasm instance lives for the lifetime of the JS process
+// anyway, and the OS reclaims the heap), but the dtor walk becomes a
+// no-op and the signature-mismatch goes away.
+//
+// `#[no_mangle]` puts the symbol at file scope; in the wasm link, ours
+// wins over wasi-libc's definition because rustc-emitted symbols are
+// resolved before sysroot archives.
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn __cxa_atexit(
+    _func: Option<unsafe extern "C" fn(*mut std::ffi::c_void)>,
+    _arg: *mut std::ffi::c_void,
+    _dso_handle: *mut std::ffi::c_void,
+) -> i32 {
+    0 // pretend the registration succeeded; never run anything at exit.
+}
+
 // ---------- Install panic hook & tracing ----------
 
 /// Install panic hook and tracing subscriber. Call once from JS before any

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -32,31 +32,43 @@ use wasm_bindgen::prelude::*;
 #[no_mangle]
 pub extern "C" fn _initialize() {}
 
-// Override wasi-libc's `__cxa_atexit` to a no-op.
-//
-// The default rust-lld 22.1 wasm driver doesn't understand
-// `--mexec-model=reactor`, so it leaves the cdylib in the "command" exec
-// model: every wasm-bindgen export gets wrapped with __wasm_call_ctors +
-// __wasm_call_dtors. The dtor walk runs `__funcs_on_exit`, which iterates
-// `__cxa_atexit`-registered handlers and calls each. At least one of those
-// is registered with a wasm signature that doesn't match how
-// __funcs_on_exit invokes it, producing
-//
-//   RuntimeError: function signature mismatch
-//
-// on the FIRST export call after instantiation, before any of our code
-// runs. The handlers are global-destructor callbacks libc++ registers
-// during static init.
-//
-// Workaround: define `__cxa_atexit` ourselves and have it ignore the
-// registration. Global destructors won't run at module shutdown (which
-// is fine — the wasm instance lives for the lifetime of the JS process
-// anyway, and the OS reclaims the heap), but the dtor walk becomes a
-// no-op and the signature-mismatch goes away.
-//
-// `#[no_mangle]` puts the symbol at file scope; in the wasm link, ours
-// wins over wasi-libc's definition because rustc-emitted symbols are
-// resolved before sysroot archives.
+/// Override wasi-libc's `__cxa_atexit` to a no-op.
+///
+/// The default rust-lld 22.1 wasm driver doesn't understand
+/// `--mexec-model=reactor`, so it leaves the cdylib in the "command" exec
+/// model: every wasm-bindgen export gets wrapped with `__wasm_call_ctors` +
+/// `__wasm_call_dtors`. The dtor walk runs `__funcs_on_exit`, which iterates
+/// `__cxa_atexit`-registered handlers and calls each. At least one of those
+/// is registered with a wasm signature that doesn't match how
+/// `__funcs_on_exit` invokes it, producing
+///
+/// ```text
+///   RuntimeError: function signature mismatch
+/// ```
+///
+/// on the FIRST export call after instantiation, before any of our code
+/// runs. The handlers are global-destructor callbacks libc++ registers
+/// during static init.
+///
+/// Workaround: define `__cxa_atexit` ourselves and have it ignore the
+/// registration. Global destructors won't run at module shutdown (which
+/// is fine — the wasm instance lives for the lifetime of the JS process
+/// anyway, and the OS reclaims the heap), but the dtor walk becomes a
+/// no-op and the signature-mismatch goes away.
+///
+/// `#[no_mangle]` puts the symbol at file scope; in the wasm link, ours
+/// wins over wasi-libc's definition because rustc-emitted symbols are
+/// resolved before sysroot archives.
+///
+/// # Safety
+///
+/// Declared `unsafe` because the C ABI passes a function pointer and a raw
+/// `*mut c_void` argument we can neither validate nor dereference. We do
+/// neither — we ignore all three arguments and return success. That makes
+/// this implementation trivially safe to call from any caller (no UB
+/// regardless of what handlers libc++ tries to register), at the cost of
+/// silently dropping every registration. See the "Workaround:" paragraph
+/// above for why dropping them is acceptable on this target.
 #[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn __cxa_atexit(


### PR DESCRIPTION
## Description

**Part 2 of 4 of the WebAssembly stack** — depends on #526 (`wasm-pr1-foundation`).

Switches the build target from `wasm32-unknown-emscripten` (Path A — exploration) to **`wasm32-unknown-unknown` + wasi-sdk** (Path B — production). This is the build path the release pipeline will ship. Pr1 got the workspace *compiling* for wasm; pr2 gets it *building*, *linking*, and actually *running inference* end-to-end.

Highlights:

- **Build path switch.** `wasm32-unknown-unknown` + wasi-sdk's libc/libc++ + wasm-bindgen's JS glue. Drops emscripten as a runtime dependency for the production build; emsdk stays available for the foundation work in pr1.
- **First real inference.** `REAL EMBEDDING INFERENCE WORKING IN WEBASSEMBLY` — a `bge-small-en-v1.5` Q8_0 embedding model loads from `Uint8Array` and produces a 384-dim embedding vector inside a Node smoke test (`wasm/examples/run.mjs`).
- **`mtmd` cargo feature.** Multimodal (image / audio assets) input support is gated behind the new `mtmd` cargo feature. Default-on for native consumers (Python, Godot, Flutter, Uniffi); the wasm crate opts out because the underlying C++ (`miniaudio` with pthread sched APIs) doesn't compile against wasi-libc. The feature gates the C++ link, not the Rust API shape — on wasm the fork keeps bindgen running against mtmd headers, so types like `MtmdBitmap` / `MtmdInputChunks` stay in scope and only the C++ implementation drops out. `core/src/llm.rs`, `core/src/chat.rs`, `core/src/tokenizer.rs` get the minimal `#[cfg(feature = "mtmd")]` gates needed for that to work.
- **Chat path fixed on wasm.** `core/src/tokenizer.rs`'s `mtmd_marker_string()` helper pulls the four `mtmd_default_marker()` call sites — including `<Prompt as Display>::fmt`, which `Chat::ask` hits when rendering its template — into one cfg-gated function. Without this, `Chat::ask` panicked on wasm with an unresolved env import while `Chat::new` succeeded; with it, end-to-end chat inference works.
- **npm package shape.** `wasm/pkg-bundler/` produces a `package.json`, `.d.ts` typings, JS glue, and `.wasm` artifact in the shape npm expects. Not yet published — pr4 wires the publish pipeline.
- **Browser demo.** `wasm/examples/browser.html` runs the embedding loop in a tab; verified working in Firefox.
- **README iterations.** `wasm/README.md` evolves from "exploring build paths" through "Path B works" to "here's how to consume it." Each commit represents a real milestone reached during development.
- **Cargo.nix regeneration** at pr2's tip aligns with the bumped `llama-cpp-2` SHA (now `10d12300` — the merged wasm fork carrying marek's main + Asbjørn's Emscripten patches). Hash verified with `nix-prefetch-git --fetch-submodules`.
- **Review-feedback fixes.** Final three commits address findings from the review pass:
  - `feat(core): factor mtmd_marker_string helper, fix Chat path on wasm` — see above.
  - `style(wasm): convert __cxa_atexit rationale to rustdoc with Safety section` — converts the existing comment block to `///` rustdoc verbatim and adds a `# Safety` section, so `cargo clippy --no-deps --target wasm32-unknown-unknown -p nobodywho-wasm -- -D warnings` passes. The PR's native-target clippy check was already clean; this prepares the code for a wasm-target clippy gate.
  - `docs(core): clarify mtmd feature gates C++ linking, not Rust API shape` — comment-only addition to `core/Cargo.toml` explaining the wasm-vs-native asymmetry (wasm keeps types via bindgen; native loses them when feature is off), so future contributors don't have to discover this by experiment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

The new `mtmd` cargo feature is default-on, so native consumers see no behaviour change. Wasm consumers (added in pr1) opt out via target-conditional cfg. The Chat-path bug fix is the one runtime behaviour change for wasm consumers: `Chat::ask` now works instead of panicking on the unresolved env import.

## How Has This Been Tested?

- `cargo check -p nobodywho`, `cargo fmt --all --check`, `cargo clippy --no-deps -- -D warnings`: all clean.
- `cargo check --target wasm32-unknown-unknown -p nobodywho-wasm` with both default features and `--no-default-features` (mtmd off): clean.
- `cargo clippy --no-deps --target wasm32-unknown-unknown -p nobodywho-wasm -- -D warnings`: clean (was failing before the `__cxa_atexit` Safety-doc commit).
- Local wasm build via the new path:
  ```bash
  cargo build --target wasm32-unknown-unknown --release -p nobodywho-wasm
  wasm-bindgen --target bundler target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
    --out-dir wasm/pkg-bundler/
  node wasm/examples/run.mjs --encode /tmp/bge-small.gguf "the quick brown fox"
  ```
  Asserts the output contains `embedding generated: 384 dimensions`.
- Chat inference verified end-to-end against Qwen 2.5 0.5B Instruct after the `mtmd_marker_string` fix.
- Browser smoke (manual): `wasm/examples/browser.html` served over `http.server`, opens, fetches the GGUF, calls `Encoder.encode`, displays first 8 dims.

> The dedicated `.github/workflows/wasm_ci.yml` workflow that automates this end-to-end test lands in the pr3 PR (#530), not this one.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
