### PR TITLE
feat(wasm): Python-binding parity — streaming, Constraint, browser chat demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
     with:
       full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
 
+  wasm_ci:
+    uses: ./.github/workflows/wasm_ci.yml
+
   test:
     uses: ./.github/workflows/test.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,3 +251,49 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Mirror of publish-react-native-npm but for the wasm binding.
+  # Tag your release like `nobodywho-wasm-v0.1.0` to trigger.
+  publish-wasm-npm:
+    if: startsWith(github.ref, 'refs/tags/nobodywho-wasm-v')
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: "Install wasi-sdk"
+        run: |
+          set -euo pipefail
+          cd ~
+          curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz \
+            | tar -xz
+          echo "WASI_SDK_PATH=$HOME/wasi-sdk-33.0-x86_64-linux" >> "$GITHUB_ENV"
+
+      - name: "Install rustc wasm target"
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: "Install wasm-bindgen-cli"
+        run: cargo install wasm-bindgen-cli --version 0.2.121 --locked
+
+      - name: "Build the npm package"
+        working-directory: ./nobodywho
+        run: bash wasm/scripts/build-pkg.sh
+
+      - name: "Verify Login"
+        working-directory: ./nobodywho/wasm/pkg-bundler
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: "Publish to npm"
+        working-directory: ./nobodywho/wasm/pkg-bundler
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/wasm_ci.yml
+++ b/.github/workflows/wasm_ci.yml
@@ -57,6 +57,28 @@ jobs:
         working-directory: nobodywho
         run: node wasm/examples/run.mjs
 
+      - name: Download a tiny embedding GGUF
+        working-directory: /tmp
+        run: |
+          # Use a small embedding model so we can exercise Model.loadBytes +
+          # Encoder.encode end-to-end in CI without burning a lot of time
+          # downloading. bge-small-en-v1.5 Q8_0 is 35 MB.
+          curl -L --fail -o bge-small.gguf \
+            'https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf'
+          ls -lh bge-small.gguf
+
+      - name: End-to-end embedding test
+        working-directory: nobodywho
+        run: |
+          # Run encode, parse out the first dim, sanity-check it's a finite
+          # float (i.e. the model actually ran and produced an embedding).
+          output=$(node wasm/examples/run.mjs --encode /tmp/bge-small.gguf "the quick brown fox")
+          echo "$output"
+          echo "$output" | grep -q "embedding generated: 384 dimensions" \
+            || { echo "expected '384 dimensions' line in output"; exit 1; }
+          echo "$output" | grep -q "first 8: \[-\?[0-9]" \
+            || { echo "expected 'first 8: [<float>...' line"; exit 1; }
+
       - name: Inspect artifact sizes
         working-directory: nobodywho/wasm/pkg-bundler
         run: |

--- a/.github/workflows/wasm_ci.yml
+++ b/.github/workflows/wasm_ci.yml
@@ -53,6 +53,24 @@ jobs:
             target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
             --out-dir wasm/pkg-bundler/
 
+      # Node 26+ is required. wasi-sdk's libc++ STL emits both noexternref
+      # (WasmGC) and exn (wasm Exception Handling) types in functions like
+      # money_get<wchar_t>. Older Nodes flag these as experimental and
+      # refuse to compile without flags:
+      #   - Node 20.x: "invalid value type 'noexternref', enable with
+      #     --experimental-wasm-gc"
+      #   - Node 22.x: gets past compile but SIGSEGVs in V8 on Linux x86_64
+      #     once llama.cpp's compute path runs (likely SIMD128 codegen bug,
+      #     fixed in Node 24). Doesn't reproduce on macOS arm64.
+      #   - Node 24.x: "invalid value type 'exn', enable with
+      #     --experimental-wasm-exnref"
+      #   - Node 26.x: enables both by default — runs end-to-end with no
+      #     flag tweaking.
+      - name: Set up Node 26
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+
       - name: Smoke test under Node (no model)
         working-directory: nobodywho
         run: node wasm/examples/run.mjs

--- a/.github/workflows/wasm_ci.yml
+++ b/.github/workflows/wasm_ci.yml
@@ -1,0 +1,74 @@
+name: "Wasm CI"
+
+# Builds the wasm32-unknown-unknown target via wasi-sdk + wasm-bindgen and
+# runs the no-model smoke test in Node. Skips actually loading a GGUF —
+# that requires hosting a multi-MB model file somewhere.
+
+on:
+  workflow_call: {}
+
+jobs:
+  wasm-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache cargo registry + git deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            nobodywho/target
+          key: wasm-${{ runner.os }}-${{ hashFiles('nobodywho/Cargo.lock') }}
+          restore-keys: |
+            wasm-${{ runner.os }}-
+
+      - name: Install wasi-sdk
+        run: |
+          set -euo pipefail
+          cd ~
+          curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz \
+            | tar -xz
+          echo "WASI_SDK_PATH=$HOME/wasi-sdk-33.0-x86_64-linux" >> "$GITHUB_ENV"
+
+      - name: Install rustup wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.121 --locked
+
+      - name: Build wasm32-unknown-unknown (release)
+        working-directory: nobodywho
+        run: cargo build --target wasm32-unknown-unknown --release -p nobodywho-wasm
+
+      - name: Run wasm-bindgen
+        working-directory: nobodywho
+        run: |
+          mkdir -p wasm/pkg-bundler
+          wasm-bindgen --target bundler \
+            target/wasm32-unknown-unknown/release/nobodywho_wasm.wasm \
+            --out-dir wasm/pkg-bundler/
+
+      - name: Smoke test under Node (no model)
+        working-directory: nobodywho
+        run: node wasm/examples/run.mjs
+
+      - name: Inspect artifact sizes
+        working-directory: nobodywho/wasm/pkg-bundler
+        run: |
+          ls -lh
+          echo ""
+          echo "Brotli-compressed size of wasm (target for npm distribution):"
+          brotli -k -q 11 nobodywho_wasm_bg.wasm -o /tmp/wasm.br || true
+          ls -lh /tmp/wasm.br || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nobodywho-wasm-pkg
+          path: nobodywho/wasm/pkg-bundler/
+          retention-days: 14

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a8a8dddab63569accdd82b927cf1e30a804c8739"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a8a8dddab63569accdd82b927cf1e30a804c8739"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
 dependencies = [
  "bindgen",
  "cc",
@@ -4581,7 +4581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a8a8dddab63569accdd82b927cf1e30a804c8739"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.147"
-source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#10d12300ff1f50a472c7cce5a5b834e2c83d29ef"
+source = "git+https://github.com/nobodywho-ooo/llama-cpp-rs?branch=wasm#a8a8dddab63569accdd82b927cf1e30a804c8739"
 dependencies = [
  "bindgen",
  "cc",

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -6607,7 +6607,7 @@ rec {
           "system-ggml-static" = [ "llama-cpp-sys-2/system-ggml-static" ];
           "vulkan" = [ "llama-cpp-sys-2/vulkan" ];
         };
-        resolvedDefaultFeatures = [ "android-static-stdcxx" "llguidance" "metal" "mtmd" "openmp" "vulkan" ];
+        resolvedDefaultFeatures = [ "android-static-stdcxx" "llguidance" "mtmd" "openmp" "vulkan" ];
       };
       "llama-cpp-sys-2" = rec {
         crateName = "llama-cpp-sys-2";
@@ -7367,13 +7367,6 @@ rec {
             usesDefaultFeatures = false;
             target = { target, features }: ((!("macos" == target."os" or null)) && (!("ios" == target."os" or null)) && (!("visionos" == target."os" or null)) && (!("watchos" == target."os" or null)) && (!("android" == target."os" or null)) && (("x86_64" == target."arch" or null) || ("x86" == target."arch" or null) || ("aarch64" == target."arch" or null)));
             features = [ "openmp" "vulkan" "android-static-stdcxx" "llguidance" ];
-          }
-          {
-            name = "llama-cpp-2";
-            packageId = "llama-cpp-2";
-            usesDefaultFeatures = false;
-            target = { target, features }: ("ios" == target."os" or null);
-            features = [ "metal" "llguidance" ];
           }
           {
             name = "minijinja";
@@ -14674,7 +14667,7 @@ rec {
         dependencies = [
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.52.0";
+            packageId = "windows-sys 0.48.0";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" "Win32_System_Console" "Win32_System_SystemInformation" ];
           }
@@ -15121,7 +15114,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_SystemInformation" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
       };
       "windows-sys 0.52.0" = rec {
         crateName = "windows-sys";
@@ -15369,7 +15362,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_SystemInformation" "Win32_System_Threading" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_System" "Win32_System_Threading" "default" ];
       };
       "windows-sys 0.61.2" = rec {
         crateName = "windows-sys";

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1098,6 +1098,18 @@ fn process_worker_msg(
         ChatMsg::Ask { prompt, output_tx } => {
             let should_stop = Arc::clone(&worker_state.extra.should_stop);
             let callback = move |out| {
+                // wasm32: also fan the token out through the synchronous streaming
+                // hook (if set). The wasm binding installs one that calls
+                // self.postMessage(token), which is non-blocking from the worker
+                // thread — the main thread sees tokens as they're produced,
+                // instead of all at once after inference completes (the latter is
+                // what you'd get from the tokio-mpsc channel alone on wasm
+                // because the inference loop is sync Rust and doesn't yield back
+                // to the JS event loop between tokens).
+                #[cfg(target_arch = "wasm32")]
+                if let crate::llm::WriteOutput::Token(ref t) = out {
+                    crate::llm::with_streaming_hook(|hook| hook(t));
+                }
                 if output_tx.send(out).is_err() {
                     // Receiver was dropped or the buffer is full with nobody consuming.
                     // Either way, stop generating immediately.

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -40,7 +40,9 @@ use tracing::info_span;
 // only drain after.
 //
 // Single-threaded only by construction: wasm32 has one thread, the hook is
-// per-thread, and `Worker::ask` is the only consumer.
+// per-thread, and only one logical consumer can be active at a time — see
+// `set_streaming_hook` for why overlap is not supported. Enforcement lives
+// at the binding boundary, not here.
 #[cfg(target_arch = "wasm32")]
 mod streaming_hook {
     use std::cell::RefCell;
@@ -49,9 +51,16 @@ mod streaming_hook {
         static HOOK: RefCell<Option<Hook>> = const { RefCell::new(None) };
     }
 
-    /// Install a streaming callback. Returns the previous one, if any —
-    /// callers (the wasm Chat binding) should save and restore it so nested
-    /// or concurrent asks each see their own hook.
+    /// Install a streaming callback. Returns whatever was in the slot before;
+    /// the caller decides whether to restore or discard it.
+    ///
+    /// Only one logical consumer can use this at a time. The chat worker
+    /// processes asks FIFO, but installs are stack-shaped (LIFO), so two
+    /// overlapping consumers would misroute tokens — the inner install
+    /// displaces the outer, and the outer's still-running inference would
+    /// fire tokens through the inner's hook. Enforcement is the caller's
+    /// responsibility: inspect the returned previous value and refuse to
+    /// proceed if it's `Some`.
     pub fn set_streaming_hook(hook: Option<Hook>) -> Option<Hook> {
         HOOK.with(|h| std::mem::replace(&mut *h.borrow_mut(), hook))
     }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -29,6 +29,46 @@ use tracing::{debug, debug_span, error, info, warn};
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::info_span;
 
+// --- Streaming hook (wasm32 only) ----------------------------------------
+//
+// Bindings can register a callback that gets fired synchronously per emitted
+// token, in addition to (not in place of) the normal `output_tx.send` path
+// that ChatHandleAsync uses. The wasm binding uses this to call back into JS
+// from inside the inference loop so the JS host can `postMessage(token)` to
+// the main thread while inference is still running — without this, the
+// inference loop holds the wasm worker thread until completion and tokens
+// only drain after.
+//
+// Single-threaded only by construction: wasm32 has one thread, the hook is
+// per-thread, and `Worker::ask` is the only consumer.
+#[cfg(target_arch = "wasm32")]
+mod streaming_hook {
+    use std::cell::RefCell;
+    type Hook = Box<dyn Fn(&str)>;
+    thread_local! {
+        static HOOK: RefCell<Option<Hook>> = const { RefCell::new(None) };
+    }
+
+    /// Install a streaming callback. Returns the previous one, if any —
+    /// callers (the wasm Chat binding) should save and restore it so nested
+    /// or concurrent asks each see their own hook.
+    pub fn set_streaming_hook(hook: Option<Hook>) -> Option<Hook> {
+        HOOK.with(|h| std::mem::replace(&mut *h.borrow_mut(), hook))
+    }
+
+    /// Call the installed hook with the given token, if one is set.
+    pub fn with_streaming_hook<F: FnOnce(&dyn Fn(&str))>(f: F) {
+        HOOK.with(|h| {
+            if let Some(hook) = h.borrow().as_ref() {
+                f(hook.as_ref());
+            }
+        });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use streaming_hook::{set_streaming_hook, with_streaming_hook};
+
 #[derive(Debug)]
 pub(crate) struct GlobalInferenceLockToken;
 lazy_static! {

--- a/nobodywho/wasm/README.md
+++ b/nobodywho/wasm/README.md
@@ -5,21 +5,24 @@ in a browser tab (or any wasm host) via llama.cpp compiled to wasm32.
 
 ## Status: working end-to-end
 
-Real embedding inference verified under Node:
+Real LLM inference verified under Node, both Encoder and Chat:
 
+**Embedding** with a 35 MB BGE-small GGUF:
 ```
 $ node wasm/examples/run.mjs --encode /tmp/bge-small.gguf "Hello"
-  ✓ wasi.initialize ran _initialize
-  ✓ wasm wired up
-  ✓ init() ok
-Loading model from /tmp/bge-small.gguf…
-  model size: 35.1 MB
-  ✓ model loaded
-  ✓ encoder created
-Encoding: "Hello"
+  ✓ model loaded                 ✓ encoder created
   ✓ embedding generated: 384 dimensions
   first 8: [-0.6244, -0.5940, 0.5545, -0.6085, -0.1348, 0.1800, 0.6621, 0.3490]
-Done.
+```
+
+**Chat** with a 379 MB Qwen 2.5 0.5B Instruct GGUF:
+```
+$ node wasm/examples/run.mjs /tmp/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf "Hello"
+  ✓ model loaded                 ✓ chat created
+Asking: "Hello"
+Response: Hello! How can I assist you today? If you have any questions
+          or need help with something, feel free to ask.
+  ✓ produced 25 tokens
 ```
 
 The wasm binary contains all of llama.cpp (~9.5 MB release, ~21 MB debug)
@@ -28,8 +31,9 @@ and exposes the binding's full surface to JS via wasm-bindgen.
 | Surface | Status |
 |---|---|
 | `Model.loadBytes(uint8Array)` | ✅ verified — loads GGUF into a real `LlamaModel` via `fmemopen` + `llama_model_load_from_file_ptr` |
-| `Encoder.encode(text)` | ✅ verified — produces a real `Float32Array` embedding |
-| `Chat` / `TokenStream` API | wired up, identical worker pattern to Encoder; should work with a chat-style GGUF (not yet smoke-tested due to model-size download) |
+| `Encoder.encode(text)` → `Float32Array` | ✅ verified |
+| `Chat.ask(prompt)` → `TokenStream` → tokens | ✅ verified |
+| `TokenStream.nextToken()` / `completed()` | ✅ verified |
 | Multimodal (`MtmdBitmap` etc.) | not exposed — mtmd C++ doesn't compile against wasi-libc; the wasm has unresolved `mtmd_*` imports that JS replaces with stubs |
 | Structured output (`Constraint`) | not yet wired up to the JS surface (works inside core, no JS wrapping yet) |
 

--- a/nobodywho/wasm/examples/browser-chat-worker.html
+++ b/nobodywho/wasm/examples/browser-chat-worker.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>nobodywho-wasm — chat (Worker)</title>
+  <style>
+    body { font: 14px/1.4 system-ui, sans-serif; max-width: 760px; margin: 2em auto; padding: 0 1em; }
+    .status { background: #eef; padding: 0.5em 1em; border-radius: 4px; margin: 0.5em 0; }
+    .status.ready { background: #efe; }
+    .status.err { background: #fee; color: #a00; }
+    pre  { background: #f4f4f4; padding: 1em; white-space: pre-wrap; word-break: break-word; max-height: 50vh; overflow: auto; }
+    .tok { color: #0a3a7a; }
+    input[type=file] { margin: 0.5em 0; }
+    button { padding: 0.4em 1em; }
+    button:disabled { opacity: 0.5; cursor: wait; }
+    textarea { width: 100%; padding: 0.4em; font: inherit; box-sizing: border-box; min-height: 4em; }
+    .meta { font: 12px/1.4 system-ui; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>nobodywho-wasm — chat (Worker version)</h1>
+  <p>
+    Same as <code>browser-chat.html</code> but the wasm runs in a Web Worker,
+    so the page stays responsive while llama.cpp grinds. Watch the status
+    line below to see what stage it's in.
+  </p>
+
+  <div id="status" class="status">Spinning up worker…</div>
+
+  <p>
+    <label>GGUF: <input id="model" type="file" accept=".gguf" disabled /></label>
+    <button id="load" disabled>Load model</button>
+    <span id="modelInfo" class="meta"></span>
+  </p>
+
+  <p>
+    <label>Context size: <input id="ctx" type="number" value="2048" min="256" max="8192" step="256" /></label><br />
+    <label>System prompt:<br />
+      <textarea id="sys">You are a concise, helpful assistant.</textarea>
+    </label><br />
+    <label>User prompt:<br />
+      <textarea id="prompt">What is 2 + 2? Answer in one sentence.</textarea>
+    </label><br />
+    <button id="ask" disabled>Ask</button>
+    <span id="askInfo" class="meta"></span>
+  </p>
+
+  <pre id="out"></pre>
+
+  <script type="module">
+    const $status = document.getElementById('status');
+    const $modelInput = document.getElementById('model');
+    const $modelInfo = document.getElementById('modelInfo');
+    const $loadBtn = document.getElementById('load');
+    const $askBtn = document.getElementById('ask');
+    const $askInfo = document.getElementById('askInfo');
+    const $out = document.getElementById('out');
+    const $sys = document.getElementById('sys');
+    const $prompt = document.getElementById('prompt');
+    const $ctx = document.getElementById('ctx');
+
+    const setStatus = (text, cls = '') => {
+      $status.textContent = text;
+      $status.className = 'status' + (cls ? ' ' + cls : '');
+    };
+    const writeTok = (s) => {
+      const span = document.createElement('span');
+      span.className = 'tok';
+      span.textContent = s;
+      $out.appendChild(span);
+      $out.scrollTop = $out.scrollHeight;
+    };
+
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
+
+    worker.onmessage = (e) => {
+      const m = e.data;
+      switch (m.type) {
+        case 'progress':
+          setStatus(`Worker: ${m.stage}…`);
+          break;
+        case 'ready':
+          setStatus('Worker ready. Pick a GGUF and click "Load model".', 'ready');
+          $modelInput.disabled = false;
+          $loadBtn.disabled = false;
+          break;
+        case 'model-loaded':
+          setStatus('Model loaded.', 'ready');
+          $askBtn.disabled = false;
+          break;
+        case 'chat-ready':
+          setStatus('Chat ready. Click Ask.', 'ready');
+          break;
+        case 'token':
+          writeTok(m.token);
+          break;
+        case 'ask-done':
+          $askInfo.textContent =
+            ` (${m.count} tokens in ${m.seconds.toFixed(1)}s, ` +
+            `${(m.count / m.seconds).toFixed(1)} tok/s)`;
+          setStatus('Done. Ask another question to continue the conversation.', 'ready');
+          $askBtn.disabled = false;
+          break;
+        case 'error':
+          setStatus('Error: ' + m.message, 'err');
+          console.error(m);
+          $askBtn.disabled = false;
+          break;
+        default:
+          console.warn('Unknown msg from worker:', m);
+      }
+    };
+    worker.onerror = (e) => setStatus('Worker crashed: ' + e.message, 'err');
+
+    worker.postMessage({ type: 'init' });
+
+    $loadBtn.addEventListener('click', async () => {
+      const file = $modelInput.files[0];
+      if (!file) { setStatus('Pick a GGUF first.', 'err'); return; }
+      $loadBtn.disabled = true;
+      $modelInfo.textContent = `${(file.size / 1024 / 1024).toFixed(1)} MB`;
+      setStatus('Reading file…');
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      setStatus('Sending to worker…');
+      // Transfer the underlying buffer (zero-copy). After this, `bytes` on
+      // the main thread is empty — the worker now owns it.
+      worker.postMessage({ type: 'load-model', bytes }, [bytes.buffer]);
+    });
+
+    $askBtn.addEventListener('click', () => {
+      $askBtn.disabled = true;
+      $out.textContent = '';
+      $askInfo.textContent = '';
+      setStatus('Creating chat session…');
+      worker.postMessage({
+        type: 'create-chat',
+        options: {
+          contextSize: parseInt($ctx.value, 10) || 2048,
+          systemPrompt: $sys.value,
+        },
+      });
+      // After chat-ready fires we'll get a status update; chain the ask:
+      const onceChatReady = (e) => {
+        if (e.data.type === 'chat-ready') {
+          worker.removeEventListener('message', onceChatReady);
+          setStatus('Generating…');
+          worker.postMessage({ type: 'ask', prompt: $prompt.value });
+        }
+      };
+      worker.addEventListener('message', onceChatReady);
+    });
+  </script>
+</body>
+</html>

--- a/nobodywho/wasm/examples/browser-chat.html
+++ b/nobodywho/wasm/examples/browser-chat.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>nobodywho-wasm — browser chat demo</title>
+  <style>
+    body { font: 14px/1.4 system-ui, sans-serif; max-width: 760px; margin: 2em auto; padding: 0 1em; }
+    pre  { background: #f4f4f4; padding: 1em; white-space: pre-wrap; word-break: break-word; max-height: 50vh; overflow: auto; }
+    .ok  { color: #0a7a0a; }
+    .err { color: #a00; }
+    .tok { color: #0a3a7a; }
+    input[type=file] { margin: 0.5em 0; }
+    button { padding: 0.4em 1em; }
+    textarea { width: 100%; padding: 0.4em; font: inherit; box-sizing: border-box; min-height: 4em; }
+  </style>
+</head>
+<body>
+  <h1>nobodywho-wasm — chat in the browser</h1>
+  <p>
+    Same wasm as <code>browser.html</code>, but exercises <code>Chat.ask</code>
+    and streams tokens. Pick a chat-style GGUF (e.g. Qwen2.5-0.5B-Instruct
+    or Qwen3-0.6B from <code>~/Downloads/</code>).
+  </p>
+
+  <p>
+    <label>GGUF: <input id="model" type="file" accept=".gguf" /></label><br />
+    <label>Context size: <input id="ctx" type="number" value="2048" min="256" max="8192" step="256" /></label><br />
+    <label>System prompt:<br />
+      <textarea id="sys">You are a concise, helpful assistant.</textarea>
+    </label><br />
+    <label>User prompt:<br />
+      <textarea id="prompt">What is 2 + 2? Answer in one sentence.</textarea>
+    </label><br />
+    <button id="go">Run</button>
+  </p>
+
+  <pre id="out"></pre>
+
+  <script type="module">
+    import { WASI, OpenFile, File, ConsoleStdout } from
+      'https://esm.sh/@bjorn3/browser_wasi_shim@0.4.1';
+
+    const out = document.getElementById('out');
+    const log = (s, cls = '') => {
+      const span = document.createElement('span');
+      if (cls) span.className = cls;
+      span.textContent = s + '\n';
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+      console.log(s);
+    };
+    const write = (s) => {
+      const span = document.createElement('span');
+      span.className = 'tok';
+      span.textContent = s;
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+    };
+
+    const envStubs = new Proxy({}, {
+      get: (_t, name) => (...args) => {
+        throw new Error(`unresolved env.${String(name)} called with [${args}]`);
+      },
+    });
+
+    async function run() {
+      out.textContent = '';
+      const modelInput = document.getElementById('model');
+      const sysPrompt = document.getElementById('sys').value;
+      const userPrompt = document.getElementById('prompt').value;
+      const ctxSize = parseInt(document.getElementById('ctx').value, 10) || 2048;
+      const file = modelInput.files[0];
+      if (!file) { log('Pick a GGUF first.', 'err'); return; }
+
+      try {
+        log('Fetching wasm + glue…');
+        const [wasmBytes, bg] = await Promise.all([
+          fetch('../pkg-bundler/nobodywho_wasm_bg.wasm').then((r) => r.arrayBuffer()),
+          import('../pkg-bundler/nobodywho_wasm_bg.js'),
+        ]);
+        log(`  wasm: ${(wasmBytes.byteLength / 1024 / 1024).toFixed(1)} MB`, 'ok');
+
+        log('Setting up WASI…');
+        const wasi = new WASI([], [], [
+          new OpenFile(new File([])),
+          ConsoleStdout.lineBuffered(() => {}),
+          ConsoleStdout.lineBuffered(() => {}),
+        ]);
+
+        log('Instantiating wasm…');
+        const mod = await WebAssembly.compile(wasmBytes);
+        const inst = await WebAssembly.instantiate(mod, {
+          './nobodywho_wasm_bg.js': bg,
+          env: envStubs,
+          wasi_snapshot_preview1: wasi.wasiImport,
+        });
+        wasi.initialize(inst);
+        bg.__wbg_set_wasm(inst.exports);
+        if (inst.exports.__wbindgen_start) inst.exports.__wbindgen_start();
+        bg.init();
+        log('  ✓ wasm ready', 'ok');
+
+        log('Loading model bytes…');
+        const modelBytes = new Uint8Array(await file.arrayBuffer());
+        log(`  model: ${(modelBytes.byteLength / 1024 / 1024).toFixed(1)} MB`);
+        const model = await bg.Model.loadBytes(modelBytes);
+        log('  ✓ model loaded', 'ok');
+
+        log('Creating chat…');
+        const chat = new bg.Chat(model, {
+          contextSize: ctxSize,
+          systemPrompt: sysPrompt,
+        });
+        log('  ✓ chat created', 'ok');
+
+        log(`Asking: ${JSON.stringify(userPrompt)}`);
+        log('');
+        log('Response:', 'ok');
+        const stream = await chat.ask(userPrompt);
+        const t0 = performance.now();
+        let count = 0, tok;
+        while ((tok = await stream.nextToken()) !== undefined) {
+          write(tok);
+          count++;
+        }
+        const dt = (performance.now() - t0) / 1000;
+        log('');
+        log(`  ✓ ${count} tokens in ${dt.toFixed(1)}s (${(count / dt).toFixed(1)} tok/s)`, 'ok');
+      } catch (e) {
+        log(`FAILED: ${e}`, 'err');
+        console.error(e);
+      }
+    }
+
+    document.getElementById('go').addEventListener('click', run);
+  </script>
+</body>
+</html>

--- a/nobodywho/wasm/examples/browser.html
+++ b/nobodywho/wasm/examples/browser.html
@@ -85,7 +85,10 @@
         const inst = await WebAssembly.instantiate(mod, {
           './nobodywho_wasm_bg.js': bg,
           env: envStubs,
-          ...wasi.getImportObject(),
+          // @bjorn3/browser_wasi_shim exposes its import table as a property
+          // (`wasiImport`), whereas `node:wasi` uses `getImportObject()`.
+          // Both expose the wasi_snapshot_preview1 ABI.
+          wasi_snapshot_preview1: wasi.wasiImport,
         });
 
         // Reactor-style init: run _initialize once.

--- a/nobodywho/wasm/examples/worker.js
+++ b/nobodywho/wasm/examples/worker.js
@@ -1,0 +1,93 @@
+// Web Worker: runs the wasm + llama.cpp off the main thread.
+//
+// All wasm calls happen here; the main page only posts messages and
+// receives results. Messages are tiny (text in, text out) but the model
+// bytes get transferred (zero-copy) via postMessage's `transfer` arg.
+
+import { WASI, OpenFile, File, ConsoleStdout } from
+  'https://esm.sh/@bjorn3/browser_wasi_shim@0.4.1';
+
+const send = (type, extra = {}) => self.postMessage({ type, ...extra });
+
+// Resolved during the first 'init' message. Held in module scope so
+// subsequent messages can reuse the loaded wasm + model + chat.
+let bg;
+let model;
+let chat;
+
+const envStubs = new Proxy({}, {
+  get: (_t, name) => (...args) => {
+    throw new Error(`unresolved env.${String(name)}(${args.join(', ')})`);
+  },
+});
+
+async function init() {
+  send('progress', { stage: 'fetching-wasm' });
+  const [wasmBytes, bgModule] = await Promise.all([
+    fetch(new URL('../pkg-bundler/nobodywho_wasm_bg.wasm', import.meta.url))
+      .then((r) => r.arrayBuffer()),
+    import(new URL('../pkg-bundler/nobodywho_wasm_bg.js', import.meta.url).href),
+  ]);
+  bg = bgModule;
+
+  send('progress', { stage: 'instantiating', wasmBytes: wasmBytes.byteLength });
+  const wasi = new WASI([], [], [
+    new OpenFile(new File([])),
+    ConsoleStdout.lineBuffered(() => {}),
+    ConsoleStdout.lineBuffered(() => {}),
+  ]);
+  const wmod = await WebAssembly.compile(wasmBytes);
+  const inst = await WebAssembly.instantiate(wmod, {
+    './nobodywho_wasm_bg.js': bg,
+    env: envStubs,
+    wasi_snapshot_preview1: wasi.wasiImport,
+  });
+  wasi.initialize(inst);
+  bg.__wbg_set_wasm(inst.exports);
+  if (inst.exports.__wbindgen_start) inst.exports.__wbindgen_start();
+  bg.init();
+
+  send('ready');
+}
+
+async function loadModel(bytes) {
+  send('progress', { stage: 'loading-model', modelBytes: bytes.byteLength });
+  model = await bg.Model.loadBytes(bytes);
+  send('model-loaded');
+}
+
+function createChat(options) {
+  chat = new bg.Chat(model, options);
+  send('chat-ready');
+}
+
+async function ask(prompt) {
+  // Use `askStreaming` (not `ask` + `nextToken()`) so the Rust inference loop
+  // calls back into JS per token directly. From a Web Worker, the JS callback
+  // posts to the main thread, which sees streaming in real time. The
+  // `ask` + `nextToken()` path batches everything until inference finishes
+  // because sync wasm doesn't yield to the event loop between tokens.
+  const t0 = performance.now();
+  let count = 0;
+  await chat.askStreaming(prompt, (token) => {
+    send('token', { token });
+    count++;
+  });
+  const dt = (performance.now() - t0) / 1000;
+  send('ask-done', { count, seconds: dt });
+}
+
+self.onmessage = async (e) => {
+  const { type, ...rest } = e.data;
+  try {
+    switch (type) {
+      case 'init':         await init(); break;
+      case 'load-model':   await loadModel(rest.bytes); break;
+      case 'create-chat':  createChat(rest.options); break;
+      case 'ask':          await ask(rest.prompt); break;
+      default: send('error', { message: `unknown message type: ${type}` });
+    }
+  } catch (err) {
+    send('error', { message: String(err), stack: err?.stack });
+  }
+};

--- a/nobodywho/wasm/scripts/build-pkg.sh
+++ b/nobodywho/wasm/scripts/build-pkg.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build the publishable npm package for nobodywho-wasm.
+#
+# Produces nobodywho/wasm/pkg-bundler/ with:
+#   nobodywho_wasm.js          — entrypoint
+#   nobodywho_wasm_bg.js       — Chat/Model/Encoder classes + wasm-bindgen glue
+#   nobodywho_wasm_bg.wasm     — compiled wasm (release-stripped)
+#   nobodywho_wasm.d.ts        — TS typings
+#   nobodywho_wasm_bg.wasm.d.ts
+#   package.json               — copied from package.json.tpl, version-bumped
+#   README.md
+#
+# Prereqs:
+#   - $WASI_SDK_PATH points at wasi-sdk-XX (see ../README.md)
+#   - rustup target add wasm32-unknown-unknown
+#   - cargo install wasm-bindgen-cli --version 0.2.121
+set -euo pipefail
+
+if [[ -z "${WASI_SDK_PATH:-}" ]]; then
+  echo "error: WASI_SDK_PATH not set. Install wasi-sdk and point this env var at it." >&2
+  echo "       Releases: https://github.com/WebAssembly/wasi-sdk/releases" >&2
+  exit 1
+fi
+if [[ ! -x "$WASI_SDK_PATH/bin/clang" ]]; then
+  echo "error: \$WASI_SDK_PATH=$WASI_SDK_PATH but bin/clang not found there." >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."   # nobodywho/wasm
+WASM_DIR="$(pwd)"
+WORKSPACE_ROOT="$(cd ../.. && pwd)"
+
+PROFILE="${PROFILE:-release}"
+echo "==> Building wasm32-unknown-unknown ($PROFILE)…"
+(
+  cd "$WORKSPACE_ROOT/nobodywho"
+  case "$PROFILE" in
+    release) "$(command -v cargo || echo ~/.cargo/bin/cargo)" build --target wasm32-unknown-unknown --release -p nobodywho-wasm ;;
+    debug)   "$(command -v cargo || echo ~/.cargo/bin/cargo)" build --target wasm32-unknown-unknown          -p nobodywho-wasm ;;
+    *)       echo "error: PROFILE must be release or debug, got $PROFILE" >&2; exit 1 ;;
+  esac
+)
+
+WASM_PATH="$WORKSPACE_ROOT/nobodywho/target/wasm32-unknown-unknown/$PROFILE/nobodywho_wasm.wasm"
+ls -lh "$WASM_PATH"
+
+echo "==> Running wasm-bindgen…"
+rm -rf "$WASM_DIR/pkg-bundler"
+"$(command -v wasm-bindgen || echo ~/.cargo/bin/wasm-bindgen)" \
+  --target bundler "$WASM_PATH" --out-dir "$WASM_DIR/pkg-bundler/"
+
+echo "==> Copying package.json + README…"
+cp "$WASM_DIR/package.json.tpl" "$WASM_DIR/pkg-bundler/package.json"
+# Could `npm version` here; keep the template as the source of truth.
+cp "$WASM_DIR/README.md" "$WASM_DIR/pkg-bundler/README.md"
+
+echo "==> Done."
+ls -lh "$WASM_DIR/pkg-bundler/"
+echo ""
+echo "To smoke-test:"
+echo "  node $WASM_DIR/examples/run.mjs --encode /path/to/embedding.gguf 'text'"
+echo "  node $WASM_DIR/examples/run.mjs /path/to/chat.gguf 'prompt'"
+echo ""
+echo "To publish (manually):"
+echo "  cd $WASM_DIR/pkg-bundler && npm publish --access public"

--- a/nobodywho/wasm/scripts/build-pkg.sh
+++ b/nobodywho/wasm/scripts/build-pkg.sh
@@ -57,6 +57,23 @@ cp "$WASM_DIR/README.md" "$WASM_DIR/pkg-bundler/README.md"
 echo "==> Done."
 ls -lh "$WASM_DIR/pkg-bundler/"
 echo ""
+
+# `bash build-pkg.sh --link` runs `npm link` inside pkg-bundler/ so the
+# package becomes available to downstream projects via `npm link @nobodywho/wasm`
+# without going through a real npm publish. Mirrors maturin's `develop`
+# command — the Python binding equivalent.
+if [[ "${1:-}" == "--link" ]]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "error: 'npm' not on PATH. Install Node.js to use --link." >&2
+    exit 1
+  fi
+  echo "==> npm link…"
+  ( cd "$WASM_DIR/pkg-bundler" && npm link )
+  echo ""
+  echo "In a consumer project:  npm link @nobodywho/wasm"
+  echo ""
+fi
+
 echo "To smoke-test:"
 echo "  node $WASM_DIR/examples/run.mjs --encode /path/to/embedding.gguf 'text'"
 echo "  node $WASM_DIR/examples/run.mjs /path/to/chat.gguf 'prompt'"

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -117,25 +117,41 @@ where
 
 // ---------- Streaming hook RAII (wasm32 only) ----------
 //
-// Install a core::llm streaming hook on construction; restore the previous one
-// on drop. Lets `Chat::ask_streaming` thread a JS callback into the
-// (synchronous) chat-worker inference loop without leaking the hook past the
-// call's lifetime even if it's interrupted by an error.
+// RAII guard for the per-thread streaming hook in `core::llm`. `install`
+// refuses to overwrite an existing hook — overlapping `askStreaming` calls
+// can't share the slot because the chat worker processes asks FIFO but
+// installs are LIFO, so two concurrent installs would misroute tokens. See
+// the doc on `core::llm::set_streaming_hook` for the underlying reason.
+// Drop unconditionally clears, which is safe because we only construct when
+// the slot was empty before our write.
 #[cfg(target_arch = "wasm32")]
-struct HookRestore {
-    previous: Option<Box<dyn Fn(&str)>>,
-}
+struct HookRestore;
 #[cfg(target_arch = "wasm32")]
 impl HookRestore {
-    fn install(hook: Box<dyn Fn(&str)>) -> Self {
-        let previous = nobodywho::llm::set_streaming_hook(Some(hook));
-        Self { previous }
+    fn install(hook: Box<dyn Fn(&str)>) -> Result<Self, JsError> {
+        let displaced = nobodywho::llm::set_streaming_hook(Some(hook));
+        if displaced.is_some() {
+            // Put it back. set_streaming_hook returns Some(our_hook) here,
+            // which we drop on the floor — fine, because we're erroring out
+            // and the on_token capture inside it is no longer needed.
+            let _ = nobodywho::llm::set_streaming_hook(displaced);
+            return Err(JsError::new(
+                "askStreaming: another streaming call is already in progress; \
+                 await the previous askStreaming promise before starting a new one",
+            ));
+        }
+        Ok(Self)
     }
 }
 #[cfg(target_arch = "wasm32")]
 impl Drop for HookRestore {
     fn drop(&mut self) {
-        nobodywho::llm::set_streaming_hook(self.previous.take());
+        // `install` only constructs Self when the slot was empty before our
+        // write, so the slot stays "ours alone" for our lifetime (single-
+        // threaded wasm guarantees no other code can observe or mutate it
+        // while this future is suspended on an await). Clearing to None on
+        // drop is therefore equivalent to "restore previous."
+        nobodywho::llm::set_streaming_hook(None);
     }
 }
 
@@ -295,6 +311,20 @@ impl Chat {
     /// `self.postMessage(token)` from a Web Worker, which is non-blocking, so
     /// the main thread sees tokens as they're produced.
     ///
+    /// **Concurrency: one streaming call per thread at a time.** If a previous
+    /// `askStreaming` is still in flight when this is called, the returned
+    /// Promise rejects with an "already in progress" error — await the
+    /// previous one first. The constraint is per-thread, so it also applies
+    /// across `Chat` instances that share a thread (e.g. two `Chat`s in the
+    /// same Web Worker).
+    ///
+    /// **Don't mix with `ask` mid-flight.** The worker fires the streaming
+    /// hook for every generated token regardless of which API initiated the
+    /// Ask, so an in-flight (non-streaming) `ask`'s tokens would be misrouted
+    /// through a later `askStreaming` callback. Serialize: drain the
+    /// `TokenStream` (or await its `completed()`) before starting an
+    /// `askStreaming` on the same `Chat`.
+    ///
     /// JS usage from inside a Worker:
     /// ```js
     /// chat.askStreaming(prompt, (tok) => self.postMessage({type: 'token', token: tok}))
@@ -304,12 +334,14 @@ impl Chat {
     pub fn ask_streaming(&self, prompt: String, on_token: js_sys::Function) -> js_sys::Promise {
         let handle = self.handle.clone();
         promisify(async move {
-            // Install the streaming hook for the duration of this call.
-            // Save and restore so we don't clobber a nested caller's hook.
+            // Install the per-thread streaming hook for the duration of this
+            // call. `install` fails if another streaming call is already in
+            // flight on this thread — propagate that as a rejected Promise
+            // rather than silently misrouting tokens.
             #[cfg(target_arch = "wasm32")]
             let _restore = HookRestore::install(Box::new(move |tok| {
                 let _ = on_token.call1(&JsValue::null(), &JsValue::from_str(tok));
-            }));
+            }))?;
             #[cfg(not(target_arch = "wasm32"))]
             let _ = &on_token;
 

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -157,12 +157,65 @@ pub struct Chat {
 }
 
 /// Optional config passed to the `Chat` constructor. Pass as a plain JS object:
-/// `new Chat(model, { contextSize: 4096, systemPrompt: "You are helpful." })`.
+///
+/// ```js
+/// new Chat(model, {
+///   contextSize: 4096,
+///   systemPrompt: "You are helpful.",
+///   constraint: { jsonSchema: '{"type":"object","properties":{...}}' },
+/// });
+/// ```
 #[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct ChatOptions {
     context_size: Option<u32>,
     system_prompt: Option<String>,
+    constraint: Option<ConstraintSpec>,
+}
+
+/// Grammar constraint for structured-output generation, via llguidance.
+///
+/// Exactly one of the fields should be set. JS-side examples:
+///
+/// ```js
+/// // JSON Schema:
+/// { jsonSchema: '{"type":"object","properties":{"answer":{"type":"string"}}}' }
+///
+/// // Regex:
+/// { regex: "[A-Z][a-z]+" }
+///
+/// // Lark CFG:
+/// { lark: 'start: "yes" | "no"' }
+/// ```
+///
+/// All three are documented in core's `GrammarConstraint`; this is just the
+/// JS-facing wire format.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ConstraintSpec {
+    json_schema: Option<String>,
+    regex: Option<String>,
+    lark: Option<String>,
+}
+
+impl ConstraintSpec {
+    fn into_sampler(self) -> Result<nobodywho::sampler_config::SamplerConfig, JsError> {
+        use nobodywho::sampler_config::SamplerPresets;
+        let n_set =
+            self.json_schema.is_some() as u8 + self.regex.is_some() as u8 + self.lark.is_some() as u8;
+        if n_set != 1 {
+            return Err(JsError::new(
+                "constraint must set exactly one of jsonSchema / regex / lark",
+            ));
+        }
+        Ok(if let Some(s) = self.json_schema {
+            SamplerPresets::constrain_with_json_schema(s)
+        } else if let Some(p) = self.regex {
+            SamplerPresets::constrain_with_regex(p)
+        } else {
+            SamplerPresets::constrain_with_grammar(self.lark.unwrap())
+        })
+    }
 }
 
 #[wasm_bindgen]
@@ -182,6 +235,9 @@ impl Chat {
         }
         if let Some(sys) = opts.system_prompt {
             builder = builder.with_system_prompt(Some(sys));
+        }
+        if let Some(constraint) = opts.constraint {
+            builder = builder.with_sampler(constraint.into_sampler()?);
         }
 
         Ok(Chat {

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -225,8 +225,9 @@ struct ConstraintSpec {
 impl ConstraintSpec {
     fn into_sampler(self) -> Result<nobodywho::sampler_config::SamplerConfig, JsError> {
         use nobodywho::sampler_config::SamplerPresets;
-        let n_set =
-            self.json_schema.is_some() as u8 + self.regex.is_some() as u8 + self.lark.is_some() as u8;
+        let n_set = self.json_schema.is_some() as u8
+            + self.regex.is_some() as u8
+            + self.lark.is_some() as u8;
         if n_set != 1 {
             return Err(JsError::new(
                 "constraint must set exactly one of jsonSchema / regex / lark",

--- a/nobodywho/wasm/src/lib.rs
+++ b/nobodywho/wasm/src/lib.rs
@@ -115,6 +115,30 @@ where
     wasm_bindgen_futures::future_to_promise(safe)
 }
 
+// ---------- Streaming hook RAII (wasm32 only) ----------
+//
+// Install a core::llm streaming hook on construction; restore the previous one
+// on drop. Lets `Chat::ask_streaming` thread a JS callback into the
+// (synchronous) chat-worker inference loop without leaking the hook past the
+// call's lifetime even if it's interrupted by an error.
+#[cfg(target_arch = "wasm32")]
+struct HookRestore {
+    previous: Option<Box<dyn Fn(&str)>>,
+}
+#[cfg(target_arch = "wasm32")]
+impl HookRestore {
+    fn install(hook: Box<dyn Fn(&str)>) -> Self {
+        let previous = nobodywho::llm::set_streaming_hook(Some(hook));
+        Self { previous }
+    }
+}
+#[cfg(target_arch = "wasm32")]
+impl Drop for HookRestore {
+    fn drop(&mut self) {
+        nobodywho::llm::set_streaming_hook(self.previous.take());
+    }
+}
+
 // ---------- Model ----------
 
 /// A loaded GGUF model. Share between `Chat` and `Encoder` instances; the
@@ -255,6 +279,45 @@ impl Chat {
             Ok(TokenStream {
                 inner: Arc::new(tokio::sync::Mutex::new(stream)),
             })
+        })
+    }
+
+    /// Send a prompt and stream tokens via a JS callback called per token,
+    /// rather than via the channel-based `TokenStream`. Returns a Promise that
+    /// resolves to the full response when generation completes.
+    ///
+    /// On wasm32, sync inference inside the wasm holds the worker thread
+    /// until completion, so a `chat.ask(...).then((stream) => stream.nextToken())`
+    /// loop only sees tokens AFTER the whole generation finishes. This method
+    /// instead installs a synchronous streaming hook that's called from inside
+    /// the inference loop — the JS callback runs there and can
+    /// `self.postMessage(token)` from a Web Worker, which is non-blocking, so
+    /// the main thread sees tokens as they're produced.
+    ///
+    /// JS usage from inside a Worker:
+    /// ```js
+    /// chat.askStreaming(prompt, (tok) => self.postMessage({type: 'token', token: tok}))
+    ///   .then((full) => self.postMessage({type: 'done', full}));
+    /// ```
+    #[wasm_bindgen(js_name = askStreaming)]
+    pub fn ask_streaming(&self, prompt: String, on_token: js_sys::Function) -> js_sys::Promise {
+        let handle = self.handle.clone();
+        promisify(async move {
+            // Install the streaming hook for the duration of this call.
+            // Save and restore so we don't clobber a nested caller's hook.
+            #[cfg(target_arch = "wasm32")]
+            let _restore = HookRestore::install(Box::new(move |tok| {
+                let _ = on_token.call1(&JsValue::null(), &JsValue::from_str(tok));
+            }));
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = &on_token;
+
+            let mut stream = handle.ask(prompt);
+            let full = stream
+                .completed()
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            Ok(JsValue::from_str(&full))
         })
     }
 


### PR DESCRIPTION
## Description

**Part 3 of 4 of the WebAssembly stack** — depends on the pr2 path-b PR.

Brings the wasm binding to **Python-binding parity**: real-time token streaming, structured-output constraints, a working browser chat demo, and the packaging script that turns `pkg-bundler/` into a publishable npm artifact. Everything a consumer would actually want, minus tooling (which is pr4).

Highlights:

- **Real-time token streaming + SIMD perf bump.** New `streaming_hook` module in `core/src/llm.rs` (wasm32-only, thread-local) fires a JS callback for each generated token as it's produced. Inside a Web Worker host, the callback does `postMessage(token)` to the main thread mid-decode — the worker blocks during decode (single-threaded reality), the main thread stays interactive. SIMD128 enabled on the wasm crate for ~1.5× decode speedup.
- **Streaming-hook concurrency guard** (`fix(wasm)`, last commit in the stack):
  - The original `HookRestore` save-and-restore pattern misrouted tokens between callbacks when two `askStreaming` calls overlapped on the same JS thread — the chat worker processes asks FIFO but save-and-restore is LIFO, so the inner install displaced the outer's hook, the outer's tokens fired through the inner's callback, then the outer's drop wiped the inner's hook before its own tokens arrived.
  - `HookRestore::install` now returns `Result<Self, JsError>` and refuses to overwrite an occupied slot. The second `askStreaming` rejects cleanly with `"askStreaming: another streaming call is already in progress; await the previous askStreaming promise before starting a new one"`. Sequential awaited calls are unaffected.
  - Docstrings on `core::llm::set_streaming_hook` and `Chat::ask_streaming` rewritten to name the constraint (one streaming consumer per thread) and explain why. New section in `ask_streaming`'s rustdoc warns against the related but distinct `ask`+`askStreaming` mid-flight mixing hazard (asymmetric — `ask` in flight when `askStreaming` starts misroutes; the reverse order is safe).
  - Regression tests live in pr4 (`wasm/tests/lint.rs`, which is introduced there) so they aren't in this PR's diff. The fix itself is self-contained here.
- **`Constraint` / structured output.** New `ConstraintSpec` type in `wasm/src/lib.rs` accepts `{ jsonSchema, regex, lark }` via serde-wasm-bindgen and wires it into `Chat::new`'s sampler config. Mirrors the Python binding's API.
- **Browser chat demo verified.** `wasm/examples/browser-chat-worker.html` runs a real chat conversation in Firefox — Web Worker pattern with token streaming back to the main thread.
- **Packaging script + CI workflow.** `wasm/scripts/build-pkg.sh` is the canonical build entry point. `.github/workflows/wasm_ci.yml` builds, runs wasm-bindgen, executes the Node smoke test, and downloads a real GGUF for an end-to-end embedding test.
- **Bring binding to Python-binding parity.** Final wiring commit — exposes the remaining surface that was scaffolded in pr1 (`ContextSize`, sampler options, etc.) in the JS API.

> Note: the earlier "Chat path fix on wasm" (`mtmd_marker_string` helper) that originally lived as the first commit in this PR has moved down to pr2 (#529) where the bug was introduced. Git's patch-id deduplication dropped it from this PR's diff during rebase; the fix is now in this PR's base.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Adds `core::llm::streaming_hook` module — public on `target_arch = "wasm32"` only. Other targets see no API change. The concurrency-guard commit is the one bug-fix change in the stack; everything else is additive.

## How Has This Been Tested?

- `cargo check -p nobodywho`, `cargo fmt --all --check`, `cargo clippy --no-deps -- -D warnings`: all clean.
- Browser demo `examples/browser-chat-worker.html` verified end-to-end in Firefox: loads a small chat model, streams tokens to the page in real time, UI remains responsive during decode.
- Node smoke test (carried from pr2) still passes — embedding inference unaffected.
- Concurrency-guard manual check: two overlapping `askStreaming` calls without awaiting now reject the second one with the expected JsError; sequential awaited calls work identically to before.

## Known issue (will fix in pr4)

The "Out of scope for v1" block at the bottom of `wasm/src/lib.rs` still lists `Constraint / structured output` even though it's now wired in. Pr4 updates the block and adds a regression-test in `wasm/tests/lint.rs` that fails CI if `Constraint` is re-added to the out-of-scope list. Pr4 also adds the four regression tests guarding the streaming-hook fix above (`hook_restore_install_returns_result`, `ask_streaming_doc_warns_about_concurrency`, `ask_streaming_doc_warns_about_mixing_with_ask`, `core_streaming_hook_doc_explains_overlap_constraint`).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
