### PR TITLE
fix: Add the `try` to swift Chat constructor

### DIFF
--- a/nobodywho/swift/src/Chat.swift
+++ b/nobodywho/swift/src/Chat.swift
@@ -8,7 +8,7 @@ import NobodyWhoGenerated
 ///     modelPath: "model.gguf",
 ///     systemPrompt: "You are a helpful assistant."
 /// )
-/// for await token in chat.ask("Hello!") {
+/// for try await token in chat.ask("Hello!") {
 ///     print(token, terminator: "")
 /// }
 /// ```
@@ -22,8 +22,8 @@ public class Chat {
         templateVariables: [String: Bool]? = nil,
         tools: [Tool]? = nil,
         sampler: SamplerConfig? = nil
-    ) {
-        self.inner = RustChat(
+    ) throws {
+        self.inner = try RustChat(
             model: model.inner,
             systemPrompt: systemPrompt,
             contextSize: contextSize,
@@ -52,7 +52,7 @@ public class Chat {
             projectionModelPath: projectionModelPath,
             onDownloadProgress: onDownloadProgress
         )
-        return Chat(
+        return try Chat(
             model: model,
             systemPrompt: systemPrompt,
             contextSize: contextSize,

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -34,7 +34,7 @@ final class NobodyWhoTests: XCTestCase {
         let modelPath = try requireEnv("TEST_MODEL")
         let model = try await Model.load(modelPath: modelPath)
         let noThinking = ["enable_thinking": false]
-        let chat = Chat(model: model, systemPrompt: "Reply with one word only.", templateVariables: noThinking)
+        let chat = try Chat(model: model, systemPrompt: "Reply with one word only.", templateVariables: noThinking)
 
         // Completion
         let response = try await chat.ask("Say hello").completed()
@@ -83,7 +83,7 @@ final class NobodyWhoTests: XCTestCase {
             .standardized.path
 
         let model = try await Model.load(modelPath: modelPath, projectionModelPath: mmprojPath)
-        let chat = Chat(model: model, systemPrompt: "Describe what you see briefly.")
+        let chat = try Chat(model: model, systemPrompt: "Describe what you see briefly.")
 
         let prompt = Prompt([
             Prompt.image(imagePath),


### PR DESCRIPTION
This is likely what is failing the pipelines currently. `Chat` now needs to be explicitely handled, cause it can fail.