### PR TITLE
fix: Model downloading in uniffi 

### DIFF
--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -28,6 +28,26 @@ final class NobodyWhoTests: XCTestCase {
         return value
     }
 
+    // MARK: - Download
+
+    func testDownloadModel() async throws {
+        let modelUrl = "hf://NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf"
+
+        // First download to discover the cache path, then delete to force a fresh download
+        let cachedPath = try await Model.downloadModel(modelPath: modelUrl)
+        try FileManager.default.removeItem(atPath: cachedPath)
+
+        var progressCalled = false
+        let localPath = try await Model.downloadModel(modelPath: modelUrl) { downloaded, total in
+            progressCalled = true
+            XCTAssertLessThanOrEqual(downloaded, total)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: localPath))
+        let attrs = try FileManager.default.attributesOfItem(atPath: localPath)
+        XCTAssertGreaterThan(attrs[.size] as? UInt64 ?? 0, 0)
+        XCTAssertTrue(progressCalled, "Progress callback should have been called")
+    }
+
     // MARK: - Chat (completion, streaming, tools)
 
     func testChat() async throws {

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -240,16 +240,19 @@ pub async fn download_model(
     init_logging();
     let headers_vec: Vec<(String, String)> = headers.unwrap_or_default().into_iter().collect();
     let progress = on_download_progress.map(wrap_progress);
-    tokio::task::spawn_blocking(move || {
-        nobodywho::llm::download_model(&model_path, headers_vec, progress)
+    // Use std::thread::spawn + tokio channel instead of tokio::task::spawn_blocking,
+    // because UniFFI's async bridge doesn't provide a Tokio runtime.
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    std::thread::spawn(move || {
+        let result = nobodywho::llm::download_model(&model_path, headers_vec, progress)
             .map(|p| p.to_string_lossy().into_owned())
             .map_err(|e| NobodyWhoError::Error {
                 message: nobodywho::render_miette(&e),
-            })
-    })
-    .await
-    .map_err(|e| NobodyWhoError::Error {
-        message: e.to_string(), // JoinError, not a miette diagnostic
+            });
+        let _ = tx.blocking_send(result);
+    });
+    rx.recv().await.ok_or_else(|| NobodyWhoError::Error {
+        message: "Download thread terminated unexpectedly".into(),
     })?
 }
 


### PR DESCRIPTION
The model downloading in uniffi uses the tokio runtime. This does not work as the ffi bridge in uniffi uses its own future executor, so this is now handled in the same way as in model.load which uses future::executor and tokio channels.

Also added a swift test to download a model to verify this check