### PR TITLE
Detect model type and check on worker construction

### DIFF
--- a/docs/docs-swift/embeddings-and-rag.md
+++ b/docs/docs-swift/embeddings-and-rag.md
@@ -27,7 +27,7 @@ You can also create an encoder from an already-loaded model:
 
 ```swift
 let model = try await Model.load(modelPath: "/path/to/embeddings.gguf", useGpu: true)
-let encoder = Encoder(model: model, contextSize: 512)
+let encoder = try Encoder(model: model, contextSize: 512)
 ```
 
 ## Cross-Encoder for reranking

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1260,12 +1260,10 @@ impl Worker<'_, ChatWorker> {
         config: ChatConfig,
         should_stop: Arc<AtomicBool>,
     ) -> Result<Worker<'_, ChatWorker>, InitWorkerError> {
-        if !model.is_generative_model() {
-            let architecture = model
-                .language_model
-                .meta_val_str("general.architecture")
-                .unwrap_or_else(|_| "unknown".into());
-            return Err(InitWorkerError::NotAnLLM { architecture });
+        if model.model_kind() != llm::ModelKind::Generative {
+            return Err(InitWorkerError::NotAnLLM {
+                architecture: model.architecture(),
+            });
         }
 
         let template = select_template(&model.language_model, !config.tools.is_empty())?;

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -16,9 +16,10 @@ pub struct CrossEncoderAsync {
 }
 
 impl CrossEncoder {
-    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
-        let async_handle = CrossEncoderAsync::new(model, n_ctx);
-        Self { async_handle }
+    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Result<Self, InitWorkerError> {
+        Ok(Self {
+            async_handle: CrossEncoderAsync::new(model, n_ctx)?,
+        })
     }
 
     pub fn rank(
@@ -41,7 +42,13 @@ impl CrossEncoder {
 }
 
 impl CrossEncoderAsync {
-    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
+    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Result<Self, InitWorkerError> {
+        if model.model_kind() != llm::ModelKind::Reranker {
+            return Err(InitWorkerError::NotAReranker {
+                architecture: model.architecture(),
+            });
+        }
+
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
 
         let join_handle = std::thread::spawn(move || {
@@ -60,9 +67,9 @@ impl CrossEncoderAsync {
             }
         });
 
-        Self {
+        Ok(Self {
             guard: Arc::new(WorkerGuard::new(msg_tx, join_handle, None)),
-        }
+        })
     }
 
     pub async fn rank(
@@ -201,7 +208,7 @@ mod tests {
     async fn test_crossencoder_async() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
-        let handle: CrossEncoderAsync = CrossEncoderAsync::new(model, 4096);
+        let handle: CrossEncoderAsync = CrossEncoderAsync::new(model, 4096)?;
 
         let query = "What is the capital of France?".to_string();
         let mut documents = vec![
@@ -239,10 +246,20 @@ mod tests {
     }
 
     #[test]
+    fn test_crossencoder_rejects_generative_model() {
+        test_utils::init_test_tracing();
+        let chat_model = test_utils::load_test_model();
+        match CrossEncoder::new(chat_model, 1024) {
+            Err(crate::errors::InitWorkerError::NotAReranker { .. }) => {}
+            other => panic!("expected NotAReranker, got {:?}", other.map(|_| "ok")),
+        }
+    }
+
+    #[test]
     fn test_crossencoder_sync() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
-        let encoder = CrossEncoder::new(model, 4096);
+        let encoder = CrossEncoder::new(model, 4096)?;
 
         let query = "What is the capital of France?".to_string();
         let documents = vec![

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -16,9 +16,10 @@ pub struct EncoderAsync {
 }
 
 impl Encoder {
-    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
-        let async_handle = EncoderAsync::new(model, n_ctx);
-        Self { async_handle }
+    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Result<Self, InitWorkerError> {
+        Ok(Self {
+            async_handle: EncoderAsync::new(model, n_ctx)?,
+        })
     }
 
     pub fn encode(&self, text: String) -> Result<Vec<f32>, EncoderWorkerError> {
@@ -27,7 +28,13 @@ impl Encoder {
 }
 
 impl EncoderAsync {
-    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Self {
+    pub fn new(model: Arc<llm::Model>, n_ctx: u32) -> Result<Self, InitWorkerError> {
+        if model.model_kind() != llm::ModelKind::Embedding {
+            return Err(InitWorkerError::NotAnEmbedder {
+                architecture: model.architecture(),
+            });
+        }
+
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
 
         let join_handle = std::thread::spawn(move || {
@@ -46,9 +53,9 @@ impl EncoderAsync {
             }
         });
 
-        Self {
+        Ok(Self {
             guard: Arc::new(WorkerGuard::new(msg_tx, join_handle, None)),
-        }
+        })
     }
 
     pub async fn encode(&self, text: String) -> Result<Vec<f32>, EncoderWorkerError> {
@@ -137,7 +144,7 @@ mod tests {
     fn test_encoder_sync() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
-        let encoder = Encoder::new(model, 1024);
+        let encoder = Encoder::new(model, 1024)?;
 
         let copenhagen_embedding =
             encoder.encode("Copenhagen is the capital of Denmark.".to_string())?;
@@ -220,10 +227,20 @@ mod tests {
     }
 
     #[test]
+    fn test_encoder_rejects_generative_model() {
+        test_utils::init_test_tracing();
+        let chat_model = test_utils::load_test_model();
+        match Encoder::new(chat_model, 1024) {
+            Err(crate::errors::InitWorkerError::NotAnEmbedder { .. }) => {}
+            other => panic!("expected NotAnEmbedder, got {:?}", other.map(|_| "ok")),
+        }
+    }
+
+    #[test]
     fn test_deterministic_encoder() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
-        let encoder = Encoder::new(model, 1024);
+        let encoder = Encoder::new(model, 1024)?;
 
         let input = "I don't want to be different";
 

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -270,6 +270,26 @@ pub enum InitWorkerError {
     )]
     NotAnLLM { architecture: String },
 
+    #[error("Model is not a reranker: {architecture}")]
+    #[diagnostic(
+        code(nobodywho::not_a_reranker),
+        help(
+            "CrossEncoder requires a model with a Rank pooling head (e.g. BGE-reranker).\n\
+             '{architecture}' has no Rank head — logit-based rerankers (like Qwen3Reranker) are not yet supported."
+        )
+    )]
+    NotAReranker { architecture: String },
+
+    #[error("Model is not an embedder: {architecture}")]
+    #[diagnostic(
+        code(nobodywho::not_an_embedder),
+        help(
+            "Encoder requires an embedding model (e.g. BGE, nomic-bert) with a CLS, Mean, or Last pooling head.\n\
+             '{architecture}' does not produce embeddings."
+        )
+    )]
+    NotAnEmbedder { architecture: String },
+
     #[error("Could not determine number of threads available: {0}")]
     ThreadCount(#[from] std::io::Error),
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -140,30 +140,39 @@ impl Model {
     /// Classify the model based on its GGUF metadata.
     ///
     /// # Detection logic
-    /// 1. `<arch>.attention.causal` is `true` (or absent — autoregressive decoders typically
-    ///    omit it, defaulting to `true`) → [`ModelKind::Generative`].
-    ///    Autoregressive generation is biconditional with causal attention (each token must
-    ///    only see previous tokens), so this is both necessary and sufficient for `Chat`.
-    /// 2. Otherwise (`causal=false` — encoder-style) check `<arch>.pooling_type`:
-    ///    - `CLS` / `Mean` / `Last` → [`ModelKind::Embedding`].
-    ///    - `Rank` or `Unspecified` → [`ModelKind::Reranker`] (BGE-reranker-v2-m3 ships
-    ///      without explicit pooling metadata but has `cls.*` classifier tensors).
+    /// 1. `<arch>.pooling_type` is the strongest signal — an explicit pooling head or
+    ///    mode marker is unambiguous:
+    ///    - `Cls` / `Mean` / `Last` → [`ModelKind::Embedding`].
+    ///    - `Rank` → [`ModelKind::Reranker`].
+    /// 2. No pooling metadata → fall back to `<arch>.attention.causal`:
+    ///    - `true` (or absent — most chat decoders omit it) → [`ModelKind::Generative`].
+    ///      Autoregressive generation is biconditional with causal attention.
+    ///    - `false` → [`ModelKind::Reranker`] (BGE-reranker-v2-m3 ships without explicit
+    ///      pooling metadata but has `cls.*` classifier tensors and `causal=false`).
+    ///
+    /// Pooling beats causal because models like EmbeddingGemma are causal autoregressive
+    /// decoders adapted into embedders by adding a Mean pooling head — `causal` alone
+    /// would misclassify them as `Generative`.
     ///
     /// # What this catches
     /// - Loading a chat decoder into `CrossEncoder` (would otherwise crash in llama.cpp).
     /// - Loading a BGE-style reranker into `Chat` or `Encoder`.
-    /// - Loading an embedder into `Chat`.
+    /// - Loading an embedder into `Chat` (including EmbeddingGemma-style adapted decoders).
+    /// - Loading a logit-based reranker tagged with `pooling_type=Rank` into `Chat`.
     ///
     /// # Known holes
     /// - **Logit-based rerankers** (Qwen3-Reranker, etc.) are autoregressive decoders
-    ///   fine-tuned to emit a Yes/No token. GGUF-wise they're indistinguishable from a
-    ///   chat model → classified as `Generative`. Loading one into `CrossEncoder` returns
-    ///   `NotAReranker` with a help message pointing at this limitation.
+    ///   fine-tuned to emit a Yes/No token. Recent GGUF conversions tag them with
+    ///   `pooling_type=Rank` as a mode hint and are classified correctly. Older or
+    ///   hand-converted GGUFs without that marker remain indistinguishable from a chat
+    ///   model → classified as `Generative`. Loading such a model into `CrossEncoder`
+    ///   returns `NotAReranker` with a help message pointing at this limitation.
     /// - **Non-autoregressive generative models** (diffusion LMs like Dream, LLaDA) set
     ///   `causal=false` and have no pooling → classified as `Reranker`. nobodywho doesn't
     ///   support running these on any API path, so misuse fails at runtime instead.
     /// - **MLM-only BERT** (no pooling head, no rank head — rare in practice) would bucket
-    ///   as `Reranker`; CrossEncoder use would likely crash at inference time.
+    ///   as `Reranker` via the causal fallback; CrossEncoder use would likely crash at
+    ///   inference time.
     /// - **Encoder embedder shipped without `pooling_type`** would bucket as `Reranker`;
     ///   embedding extraction wouldn't work anyway without pooling metadata.
     ///
@@ -174,6 +183,25 @@ impl Model {
             return ModelKind::Generative;
         };
 
+        let pooling = self
+            .language_model
+            .meta_val_str(&format!("{arch}.pooling_type"))
+            .ok()
+            .and_then(|val| val.parse::<i32>().ok())
+            .map(LlamaPoolingType::from);
+
+        // Explicit pooling head/marker wins — strongest signal we have from GGUF.
+        if matches!(
+            pooling,
+            Some(LlamaPoolingType::Cls | LlamaPoolingType::Mean | LlamaPoolingType::Last)
+        ) {
+            return ModelKind::Embedding;
+        }
+        if matches!(pooling, Some(LlamaPoolingType::Rank)) {
+            return ModelKind::Reranker;
+        }
+
+        // No pooling hint — fall back to causal attention heuristic.
         let causal = self
             .language_model
             .meta_val_str(&format!("{arch}.attention.causal"))
@@ -182,20 +210,9 @@ impl Model {
             .unwrap_or(true);
 
         if causal {
-            return ModelKind::Generative;
-        }
-
-        let pooling = self
-            .language_model
-            .meta_val_str(&format!("{arch}.pooling_type"))
-            .ok()
-            .and_then(|val| val.parse::<i32>().ok())
-            .map(LlamaPoolingType::from)
-            .unwrap_or(LlamaPoolingType::Unspecified);
-
-        match pooling {
-            LlamaPoolingType::Unspecified | LlamaPoolingType::Rank => ModelKind::Reranker,
-            _ => ModelKind::Embedding,
+            ModelKind::Generative
+        } else {
+            ModelKind::Reranker
         }
     }
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -114,25 +114,94 @@ pub struct Model {
     pub(crate) projection_model: Option<ProjectionModel>,
 }
 
+/// What a model can be used for, inferred from its GGUF metadata.
+///
+/// This is an operational taxonomy ("which nobodywho API can use this model"), not a
+/// general-purpose classifier of every kind of language model in the wild.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelKind {
+    /// Autoregressive decoder compatible with `Chat` (Llama, Qwen, Gemma, …).
+    Generative,
+    /// Encoder-only embedder (BGE, nomic-bert, …) — pools token representations into a vector.
+    Embedding,
+    /// Cross-encoder reranker with a classifier head (BGE-reranker, …).
+    Reranker,
+}
+
 impl Model {
-    /// Returns true if this model can generate text (i.e. is an autoregressive decoder).
-    ///
-    /// Generative models never pool token representations, so `<arch>.pooling_type` is absent
-    /// from their GGUF metadata (giving `Unspecified`). Encoder-only models (BERT, nomic-bert,
-    /// etc.) always have this key set to CLS, Mean, or similar — a reliable,
-    /// architecture-agnostic signal that the model cannot generate text.
-    pub fn is_generative_model(&self) -> bool {
-        let Ok(arch) = self.language_model.meta_val_str("general.architecture") else {
-            return true;
-        };
-        let key = format!("{arch}.pooling_type");
+    /// Returns the GGUF architecture string (e.g. `"qwen3"`, `"bert"`), or `"unknown"` if
+    /// the model has no `general.architecture` metadata.
+    pub fn architecture(&self) -> String {
         self.language_model
-            .meta_val_str(&key)
+            .meta_val_str("general.architecture")
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+
+    /// Classify the model based on its GGUF metadata.
+    ///
+    /// # Detection logic
+    /// 1. `<arch>.attention.causal` is `true` (or absent — autoregressive decoders typically
+    ///    omit it, defaulting to `true`) → [`ModelKind::Generative`].
+    ///    Autoregressive generation is biconditional with causal attention (each token must
+    ///    only see previous tokens), so this is both necessary and sufficient for `Chat`.
+    /// 2. Otherwise (`causal=false` — encoder-style) check `<arch>.pooling_type`:
+    ///    - `CLS` / `Mean` / `Last` → [`ModelKind::Embedding`].
+    ///    - `Rank` or `Unspecified` → [`ModelKind::Reranker`] (BGE-reranker-v2-m3 ships
+    ///      without explicit pooling metadata but has `cls.*` classifier tensors).
+    ///
+    /// # What this catches
+    /// - Loading a chat decoder into `CrossEncoder` (would otherwise crash in llama.cpp).
+    /// - Loading a BGE-style reranker into `Chat` or `Encoder`.
+    /// - Loading an embedder into `Chat`.
+    ///
+    /// # Known holes
+    /// - **Logit-based rerankers** (Qwen3-Reranker, etc.) are autoregressive decoders
+    ///   fine-tuned to emit a Yes/No token. GGUF-wise they're indistinguishable from a
+    ///   chat model → classified as `Generative`. Loading one into `CrossEncoder` returns
+    ///   `NotAReranker` with a help message pointing at this limitation.
+    /// - **Non-autoregressive generative models** (diffusion LMs like Dream, LLaDA) set
+    ///   `causal=false` and have no pooling → classified as `Reranker`. nobodywho doesn't
+    ///   support running these on any API path, so misuse fails at runtime instead.
+    /// - **MLM-only BERT** (no pooling head, no rank head — rare in practice) would bucket
+    ///   as `Reranker`; CrossEncoder use would likely crash at inference time.
+    /// - **Encoder embedder shipped without `pooling_type`** would bucket as `Reranker`;
+    ///   embedding extraction wouldn't work anyway without pooling metadata.
+    ///
+    /// A fully robust classifier would require tensor-name inspection (look for `cls.*`
+    /// weights), which `llama-cpp-2` does not expose today.
+    pub fn model_kind(&self) -> ModelKind {
+        let Ok(arch) = self.language_model.meta_val_str("general.architecture") else {
+            return ModelKind::Generative;
+        };
+
+        let causal = self
+            .language_model
+            .meta_val_str(&format!("{arch}.attention.causal"))
+            .ok()
+            .map(|v| v.trim() == "true")
+            .unwrap_or(true);
+
+        if causal {
+            return ModelKind::Generative;
+        }
+
+        let pooling = self
+            .language_model
+            .meta_val_str(&format!("{arch}.pooling_type"))
             .ok()
             .and_then(|val| val.parse::<i32>().ok())
             .map(LlamaPoolingType::from)
-            .unwrap_or(LlamaPoolingType::Unspecified)
-            == LlamaPoolingType::Unspecified
+            .unwrap_or(LlamaPoolingType::Unspecified);
+
+        match pooling {
+            LlamaPoolingType::Unspecified | LlamaPoolingType::Rank => ModelKind::Reranker,
+            _ => ModelKind::Embedding,
+        }
+    }
+
+    /// Returns true if this model is compatible with `Chat` (autoregressive decoder).
+    pub fn is_generative_model(&self) -> bool {
+        self.model_kind() == ModelKind::Generative
     }
 }
 
@@ -945,7 +1014,20 @@ impl<T> Drop for WorkerGuard<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_model_kind_classification() {
+        let chat_model = test_utils::load_test_model();
+        assert_eq!(chat_model.model_kind(), ModelKind::Generative);
+
+        let embed_model = test_utils::load_embeddings_model();
+        assert_eq!(embed_model.model_kind(), ModelKind::Embedding);
+
+        let rerank_model = test_utils::load_crossencoder_model();
+        assert_eq!(rerank_model.model_kind(), ModelKind::Reranker);
+    }
 
     #[test]
     fn throttled_callback_drops_intermediate_calls_within_window() {

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -591,7 +591,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         codec: SseCodec(
           decodeSuccessData:
               sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCrossEncoder,
-          decodeErrorData: null,
+          decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateCrossEncoderNewConstMeta,
         argValues: [model, nCtx],
@@ -783,7 +783,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         codec: SseCodec(
           decodeSuccessData:
               sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEncoder,
-          decodeErrorData: null,
+          decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateEncoderNewConstMeta,
         argValues: [model, nCtx],

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -122,7 +122,7 @@ fn wire__crate__CrossEncoder_new_impl(
             >>::sse_decode(&mut deserializer);
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
+            transform_result_sse::<_, String>((move || {
                 let mut api_model_guard = None;
                 let decode_indices_ =
                     flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -137,8 +137,7 @@ fn wire__crate__CrossEncoder_new_impl(
                     }
                 }
                 let api_model_guard = api_model_guard.unwrap();
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::CrossEncoder::new(&*api_model_guard, api_n_ctx))?;
+                let output_ok = crate::CrossEncoder::new(&*api_model_guard, api_n_ctx)?;
                 Ok(output_ok)
             })())
         },
@@ -391,7 +390,7 @@ fn wire__crate__Encoder_new_impl(
             >>::sse_decode(&mut deserializer);
             let api_n_ctx = <u32>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
+            transform_result_sse::<_, String>((move || {
                 let mut api_model_guard = None;
                 let decode_indices_ =
                     flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -406,8 +405,7 @@ fn wire__crate__Encoder_new_impl(
                     }
                 }
                 let api_model_guard = api_model_guard.unwrap();
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::Encoder::new(&*api_model_guard, api_n_ctx))?;
+                let output_ok = crate::Encoder::new(&*api_model_guard, api_n_ctx)?;
                 Ok(output_ok)
             })())
         },

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -423,9 +423,10 @@ pub struct Encoder {
 
 impl Encoder {
     #[flutter_rust_bridge::frb(sync)]
-    pub fn new(model: &Model, #[frb(default = 4096)] n_ctx: u32) -> Self {
-        let handle = nobodywho::encoder::EncoderAsync::new(Arc::clone(&model.model), n_ctx);
-        Self { handle }
+    pub fn new(model: &Model, #[frb(default = 4096)] n_ctx: u32) -> Result<Self, String> {
+        let handle = nobodywho::encoder::EncoderAsync::new(Arc::clone(&model.model), n_ctx)
+            .map_err(|e| nobodywho::render_miette(&e))?;
+        Ok(Self { handle })
     }
 
     /// Load an embedding model from a local path, HuggingFace path, or HTTPS URL.
@@ -454,7 +455,8 @@ impl Encoder {
             Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| nobodywho::render_miette(&e))?;
-        let handle = nobodywho::encoder::EncoderAsync::new(Arc::new(model), n_ctx);
+        let handle = nobodywho::encoder::EncoderAsync::new(Arc::new(model), n_ctx)
+            .map_err(|e| nobodywho::render_miette(&e))?;
 
         Ok(Self { handle })
     }
@@ -474,10 +476,11 @@ pub struct CrossEncoder {
 
 impl CrossEncoder {
     #[flutter_rust_bridge::frb(sync)]
-    pub fn new(model: &Model, #[frb(default = 4096)] n_ctx: u32) -> Self {
+    pub fn new(model: &Model, #[frb(default = 4096)] n_ctx: u32) -> Result<Self, String> {
         let handle =
-            nobodywho::crossencoder::CrossEncoderAsync::new(Arc::clone(&model.model), n_ctx);
-        Self { handle }
+            nobodywho::crossencoder::CrossEncoderAsync::new(Arc::clone(&model.model), n_ctx)
+                .map_err(|e| nobodywho::render_miette(&e))?;
+        Ok(Self { handle })
     }
 
     /// Load a cross-encoder model from a local path, HuggingFace path, or HTTPS URL.
@@ -506,7 +509,8 @@ impl CrossEncoder {
             Some(wrap_progress(on_download_progress)),
         )
         .map_err(|e| nobodywho::render_miette(&e))?;
-        let handle = nobodywho::crossencoder::CrossEncoderAsync::new(Arc::new(model), n_ctx);
+        let handle = nobodywho::crossencoder::CrossEncoderAsync::new(Arc::new(model), n_ctx)
+            .map_err(|e| nobodywho::render_miette(&e))?;
         Ok(Self { handle })
     }
     pub async fn rank(

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -1544,7 +1544,8 @@ impl NobodyWhoEncoder {
             .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         // TODO: configurable n_ctx
-        let handle = nobodywho::encoder::EncoderAsync::new(model, 4096);
+        let handle = nobodywho::encoder::EncoderAsync::new(model, 4096)
+            .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         let mut b = me.bind_mut();
         if let Some(existing) = &b.encoder_handle {
@@ -1730,7 +1731,8 @@ impl NobodyWhoCrossEncoder {
             .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         // TODO: configurable n_ctx like with the embeddings node
-        let handle = nobodywho::crossencoder::CrossEncoderAsync::new(model, 4096);
+        let handle = nobodywho::crossencoder::CrossEncoderAsync::new(model, 4096)
+            .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         let mut b = me.bind_mut();
         if let Some(existing) = &b.crossencoder_handle {
@@ -1874,8 +1876,15 @@ impl NobodyWhoCrossEncoder {
                     return PackedStringArray::new();
                 }
             };
-            self.crossencoder_handle =
-                Some(nobodywho::crossencoder::CrossEncoderAsync::new(model, 4096));
+            match nobodywho::crossencoder::CrossEncoderAsync::new(model, 4096) {
+                Ok(handle) => self.crossencoder_handle = Some(handle),
+                Err(e) => {
+                    let err = GString::from(nobodywho::render_miette(&e).as_str());
+                    godot_error!("Failed initializing cross-encoder: {}", err);
+                    self.signals().worker_failed().emit(&err);
+                    return PackedStringArray::new();
+                }
+            }
         }
 
         let crossencoder_handle = self.crossencoder_handle.as_ref().unwrap().clone();

--- a/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
+++ b/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
@@ -1252,10 +1252,10 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 24505.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 9022.toShort()) {
+    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 63560.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() != 27902.toShort()) {
+    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() != 36527.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new() != 9431.toShort()) {
@@ -2460,7 +2460,7 @@ open class RustCrossEncoder: Disposable, AutoCloseable, RustCrossEncoderInterfac
      */
     constructor(`model`: RustModel, `contextSize`: kotlin.UInt?) :
         this(UniffiWithHandle, 
-    uniffiRustCall() { _status ->
+    uniffiRustCallWithError(NobodyWhoException) { _status ->
     UniffiLib.uniffi_nobodywho_uniffi_fn_constructor_rustcrossencoder_new(
     
         FfiConverterTypeRustModel.lower(`model`),FfiConverterOptionalUInt.lower(`contextSize`),_status)
@@ -2762,7 +2762,7 @@ open class RustEncoder: Disposable, AutoCloseable, RustEncoderInterface
      */
     constructor(`model`: RustModel, `contextSize`: kotlin.UInt?) :
         this(UniffiWithHandle, 
-    uniffiRustCall() { _status ->
+    uniffiRustCallWithError(NobodyWhoException) { _status ->
     UniffiLib.uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(
     
         FfiConverterTypeRustModel.lower(`model`),FfiConverterOptionalUInt.lower(`contextSize`),_status)

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -348,7 +348,8 @@ impl Encoder {
     #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096) -> "Encoder")]
     pub fn new(model: ModelOrPath, n_ctx: u32) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
-        let encoder = nobodywho::encoder::Encoder::new(nw_model, n_ctx);
+        let encoder = nobodywho::encoder::Encoder::new(nw_model, n_ctx)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;
         Ok(Self {
             encoder: Some(encoder),
         })
@@ -412,7 +413,8 @@ impl EncoderAsync {
     #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096) -> "EncoderAsync")]
     pub fn new(model: ModelOrPath, n_ctx: u32) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
-        let encoder_handle = nobodywho::encoder::EncoderAsync::new(nw_model, n_ctx);
+        let encoder_handle = nobodywho::encoder::EncoderAsync::new(nw_model, n_ctx)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;
         Ok(Self {
             encoder_handle: Some(encoder_handle),
         })
@@ -479,7 +481,8 @@ impl CrossEncoder {
     #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096) -> "CrossEncoder")]
     pub fn new(model: ModelOrPath, n_ctx: u32) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
-        let crossencoder = nobodywho::crossencoder::CrossEncoder::new(nw_model, n_ctx);
+        let crossencoder = nobodywho::crossencoder::CrossEncoder::new(nw_model, n_ctx)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;
         Ok(Self {
             crossencoder: Some(crossencoder),
         })
@@ -569,7 +572,8 @@ impl CrossEncoderAsync {
     #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096) -> "CrossEncoderAsync")]
     pub fn new(model: ModelOrPath, n_ctx: u32) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
-        let crossencoder_handle = nobodywho::crossencoder::CrossEncoderAsync::new(nw_model, n_ctx);
+        let crossencoder_handle = nobodywho::crossencoder::CrossEncoderAsync::new(nw_model, n_ctx)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;
         Ok(Self {
             crossencoder_handle: Some(crossencoder_handle),
         })

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -1864,10 +1864,12 @@ export class RustCrossEncoder extends UniffiAbstractObject implements RustCrossE
     /**
      * Create a new cross-encoder for ranking documents by relevance.
      */
-    constructor(model: RustModelInterface, contextSize: /*u32*/number | undefined) {
+    constructor(model: RustModelInterface, contextSize: /*u32*/number | undefined) /*throws*/ {
         super();
         const pointer =
-            uniffiCaller.rustCall(
+            
+        uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError),
             /*caller:*/ (callStatus) => {
                 return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustcrossencoder_new(
         FfiConverterTypeRustModel.lower(model),
@@ -2039,10 +2041,12 @@ export class RustEncoder extends UniffiAbstractObject implements RustEncoderInte
     /**
      * Create a new encoder for generating text embeddings.
      */
-    constructor(model: RustModelInterface, contextSize: /*u32*/number | undefined) {
+    constructor(model: RustModelInterface, contextSize: /*u32*/number | undefined) /*throws*/ {
         super();
         const pointer =
-            uniffiCaller.rustCall(
+            
+        uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError),
             /*caller:*/ (callStatus) => {
                 return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(
         FfiConverterTypeRustModel.lower(model),
@@ -3351,10 +3355,10 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() !== 24505) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() !== 9022) {
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() !== 63560) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() !== 27902) {
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() !== 36527) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new() !== 9431) {

--- a/nobodywho/swift/generated/nobodywho.swift
+++ b/nobodywho/swift/generated/nobodywho.swift
@@ -1058,9 +1058,9 @@ open class RustCrossEncoder: RustCrossEncoderProtocol, @unchecked Sendable {
     /**
      * Create a new cross-encoder for ranking documents by relevance.
      */
-public convenience init(model: RustModel, contextSize: UInt32?) {
+public convenience init(model: RustModel, contextSize: UInt32?)throws  {
     let handle =
-        try! rustCall() {
+        try rustCallWithError(FfiConverterTypeNobodyWhoError_lift) {
     uniffi_nobodywho_uniffi_fn_constructor_rustcrossencoder_new(
         FfiConverterTypeRustModel_lower(model),
         FfiConverterOptionUInt32.lower(contextSize),$0
@@ -1218,9 +1218,9 @@ open class RustEncoder: RustEncoderProtocol, @unchecked Sendable {
     /**
      * Create a new encoder for generating text embeddings.
      */
-public convenience init(model: RustModel, contextSize: UInt32?) {
+public convenience init(model: RustModel, contextSize: UInt32?)throws  {
     let handle =
-        try! rustCall() {
+        try rustCallWithError(FfiConverterTypeNobodyWhoError_lift) {
     uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(
         FfiConverterTypeRustModel_lower(model),
         FfiConverterOptionUInt32.lower(contextSize),$0
@@ -3884,10 +3884,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 24505) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 9022) {
+    if (uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 63560) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() != 27902) {
+    if (uniffi_nobodywho_uniffi_checksum_constructor_rustencoder_new() != 36527) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_constructor_rusttool_new() != 9431) {

--- a/nobodywho/swift/src/CrossEncoder.swift
+++ b/nobodywho/swift/src/CrossEncoder.swift
@@ -13,8 +13,9 @@ public class CrossEncoder {
     /// - Parameters:
     ///   - model: A loaded model to use for ranking.
     ///   - contextSize: Maximum context size in tokens. Defaults to 4096 if nil.
-    public init(model: Model, contextSize: UInt32? = nil) {
-        self.inner = NobodyWhoGenerated.RustCrossEncoder(model: model.inner, contextSize: contextSize)
+    /// - Throws: `NobodyWhoError` if the model is not a reranker.
+    public init(model: Model, contextSize: UInt32? = nil) throws {
+        self.inner = try NobodyWhoGenerated.RustCrossEncoder(model: model.inner, contextSize: contextSize)
     }
 
     /// Create a cross-encoder directly from a model path.
@@ -24,7 +25,7 @@ public class CrossEncoder {
         contextSize: UInt32? = nil
     ) async throws -> CrossEncoder {
         let model = try await Model.load(modelPath: modelPath, useGpu: useGpu)
-        return CrossEncoder(model: model, contextSize: contextSize)
+        return try CrossEncoder(model: model, contextSize: contextSize)
     }
 
     /// Rank documents by relevance to a query. Returns similarity scores.

--- a/nobodywho/swift/src/Encoder.swift
+++ b/nobodywho/swift/src/Encoder.swift
@@ -13,8 +13,9 @@ public class Encoder {
     /// - Parameters:
     ///   - model: A loaded model to use for encoding.
     ///   - contextSize: Maximum context size in tokens. Defaults to 4096 if nil.
-    public init(model: Model, contextSize: UInt32? = nil) {
-        self.inner = NobodyWhoGenerated.RustEncoder(model: model.inner, contextSize: contextSize)
+    /// - Throws: `NobodyWhoError` if the model is not an embedding model.
+    public init(model: Model, contextSize: UInt32? = nil) throws {
+        self.inner = try NobodyWhoGenerated.RustEncoder(model: model.inner, contextSize: contextSize)
     }
 
     /// Create an encoder directly from a model path.
@@ -24,7 +25,7 @@ public class Encoder {
         contextSize: UInt32? = nil
     ) async throws -> Encoder {
         let model = try await Model.load(modelPath: modelPath, useGpu: useGpu)
-        return Encoder(model: model, contextSize: contextSize)
+        return try Encoder(model: model, contextSize: contextSize)
     }
 
     /// Encode text into an embedding vector.

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -657,12 +657,15 @@ pub struct RustEncoder {
 impl RustEncoder {
     /// Create a new encoder for generating text embeddings.
     #[uniffi::constructor]
-    pub fn new(model: &RustModel, context_size: Option<u32>) -> Arc<Self> {
+    pub fn new(model: &RustModel, context_size: Option<u32>) -> Result<Arc<Self>, NobodyWhoError> {
         let handle = nobodywho::encoder::EncoderAsync::new(
             Arc::clone(&model.inner),
             context_size.unwrap_or(4096),
-        );
-        Arc::new(Self { inner: handle })
+        )
+        .map_err(|e| NobodyWhoError::Error {
+            message: nobodywho::render_miette(&e),
+        })?;
+        Ok(Arc::new(Self { inner: handle }))
     }
 
     /// Encode text into an embedding vector.
@@ -716,12 +719,15 @@ pub struct RustCrossEncoder {
 impl RustCrossEncoder {
     /// Create a new cross-encoder for ranking documents by relevance.
     #[uniffi::constructor]
-    pub fn new(model: &RustModel, context_size: Option<u32>) -> Arc<Self> {
+    pub fn new(model: &RustModel, context_size: Option<u32>) -> Result<Arc<Self>, NobodyWhoError> {
         let handle = nobodywho::crossencoder::CrossEncoderAsync::new(
             Arc::clone(&model.inner),
             context_size.unwrap_or(4096),
-        );
-        Arc::new(Self { inner: handle })
+        )
+        .map_err(|e| NobodyWhoError::Error {
+            message: nobodywho::render_miette(&e),
+        })?;
+        Ok(Arc::new(Self { inner: handle }))
     }
 
     /// Rank documents by relevance to a query. Returns similarity scores.


### PR DESCRIPTION
We had an issue with Qwen3Reranker where if you try to create a CrossEncoder with this model, we throw a very useless error from llama-cpp. 
This is because the Qwen3Reranker is actually an autoregressive generative model using logits to do reranking, which means it does not work in the reranker flow we have. We should detect this by enforcing that no autoregressive models can be used for Encoder or CrossEncoder, and that reranker and encoder models cannot be used for Chats. Detecting this is a bit tricky, but we know autoregressive models (which are the generative models we support) use causal attention, while encoders and crossencoders do not. Then we determine crossencoder vs encoder on pooling type. This is slightly flaky and improvements and ideas are welcome, but I believe it is an improvement to before.