### PR TITLE
fix(python): let unspecified sampler fall through to GGUF sampling metadata

### DIFF
--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -33,7 +33,7 @@ class Chat:
     to use, whether to allow extended thinking, etc.
     See `ChatAsync` for the async version of this class.
     """
-    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: SamplerConfig = ..., allow_thinking: "bool | None" = None) -> "Chat":
+    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "Chat":
         """
         Create a new Chat instance for conversational text generation.
         
@@ -43,7 +43,9 @@ class Chat:
             system_prompt: System message to guide the model's behavior. Defaults to empty string.
             template_variables: Dict of template variables to pass to the chat template (e.g., {"enable_thinking": True}). Defaults to empty dict.
             tools: List of Tool instances the model can call. Defaults to empty list.
-            sampler: SamplerConfig for token selection. Defaults to SamplerConfig.default().
+            sampler: SamplerConfig for token selection. If not given, sampling settings
+                embedded in the model file (general.sampling.* metadata) are used when
+                present, otherwise SamplerConfig.default().
             allow_thinking: DEPRECATED. Use template_variables={"enable_thinking": True} instead. If set, overrides enable_thinking in template_variables.
         
         Returns:
@@ -210,7 +212,7 @@ class ChatAsync:
     This is the async version of the `Chat` class.
     See the docs for the `Chat` class for more information.
     """
-    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: SamplerConfig = ..., allow_thinking: "bool | None" = None) -> "ChatAsync":
+    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync":
         """
         Create a new async Chat instance for conversational text generation.
         
@@ -220,7 +222,9 @@ class ChatAsync:
             system_prompt: System message to guide the model's behavior. Defaults to empty string.
             template_variables: Dict of template variables to pass to the chat template (e.g., {"enable_thinking": True}). Defaults to empty dict.
             tools: List of Tool instances the model can call. Defaults to empty list.
-            sampler: SamplerConfig for token selection. Defaults to SamplerConfig.default().
+            sampler: SamplerConfig for token selection. If not given, sampling settings
+                embedded in the model file (general.sampling.* metadata) are used when
+                present, otherwise SamplerConfig.default().
             allow_thinking: DEPRECATED. Use template_variables={"enable_thinking": True} instead. If set, overrides enable_thinking in template_variables.
         
         Returns:

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -656,7 +656,9 @@ impl Chat {
     ///     system_prompt: System message to guide the model's behavior. Defaults to empty string.
     ///     template_variables: Dict of template variables to pass to the chat template (e.g., {"enable_thinking": True}). Defaults to empty dict.
     ///     tools: List of Tool instances the model can call. Defaults to empty list.
-    ///     sampler: SamplerConfig for token selection. Defaults to SamplerConfig.default().
+    ///     sampler: SamplerConfig for token selection. If not given, sampling settings
+    ///         embedded in the model file (general.sampling.* metadata) are used when
+    ///         present, otherwise SamplerConfig.default().
     ///     allow_thinking: DEPRECATED. Use template_variables={"enable_thinking": True} instead. If set, overrides enable_thinking in template_variables.
     ///
     /// Returns:
@@ -666,14 +668,14 @@ impl Chat {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler = SamplerConfig::default(), allow_thinking: "bool | None" = None) -> "Chat")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "Chat")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
         system_prompt: Option<&str>,
         template_variables: std::collections::HashMap<String, bool>,
         tools: Vec<Tool>,
-        sampler: SamplerConfig,
+        sampler: Option<SamplerConfig>,
         allow_thinking: Option<bool>,
         py: Python<'_>,
     ) -> PyResult<Self> {
@@ -696,13 +698,18 @@ impl Chat {
         }
 
         let build_result = py.detach(|| {
-            nobodywho::chat::ChatBuilder::new(nw_model)
+            let mut builder = nobodywho::chat::ChatBuilder::new(nw_model)
                 .with_context_size(n_ctx)
                 .with_tools(tools.into_iter().map(|t| t.tool).collect())
                 .with_template_variables(template_vars)
-                .with_system_prompt(system_prompt)
-                .with_sampler(sampler.sampler_config)
-                .build()
+                .with_system_prompt(system_prompt);
+            // When no sampler is given, leave it unset so the worker falls back
+            // to sampling settings embedded in the GGUF (general.sampling.*),
+            // and only then to the built-in default.
+            if let Some(s) = sampler {
+                builder = builder.with_sampler(s.sampler_config);
+            }
+            builder.build()
         });
         let chat_handle = build_result
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;
@@ -1005,7 +1012,9 @@ impl ChatAsync {
     ///     system_prompt: System message to guide the model's behavior. Defaults to empty string.
     ///     template_variables: Dict of template variables to pass to the chat template (e.g., {"enable_thinking": True}). Defaults to empty dict.
     ///     tools: List of Tool instances the model can call. Defaults to empty list.
-    ///     sampler: SamplerConfig for token selection. Defaults to SamplerConfig.default().
+    ///     sampler: SamplerConfig for token selection. If not given, sampling settings
+    ///         embedded in the model file (general.sampling.* metadata) are used when
+    ///         present, otherwise SamplerConfig.default().
     ///     allow_thinking: DEPRECATED. Use template_variables={"enable_thinking": True} instead. If set, overrides enable_thinking in template_variables.
     ///
     /// Returns:
@@ -1015,14 +1024,14 @@ impl ChatAsync {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler = SamplerConfig::default(), allow_thinking: "bool | None" = None) -> "ChatAsync")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
         system_prompt: Option<&str>,
         template_variables: std::collections::HashMap<String, bool>,
         tools: Vec<Tool>,
-        sampler: SamplerConfig,
+        sampler: Option<SamplerConfig>,
         allow_thinking: Option<bool>,
         py: Python<'_>,
     ) -> PyResult<Self> {
@@ -1045,13 +1054,18 @@ impl ChatAsync {
         }
 
         let build_result = py.detach(|| {
-            nobodywho::chat::ChatBuilder::new(nw_model)
+            let mut builder = nobodywho::chat::ChatBuilder::new(nw_model)
                 .with_context_size(n_ctx)
                 .with_tools(tools.into_iter().map(|t| t.tool).collect())
                 .with_template_variables(template_vars)
-                .with_system_prompt(system_prompt)
-                .with_sampler(sampler.sampler_config)
-                .build_async()
+                .with_system_prompt(system_prompt);
+            // When no sampler is given, leave it unset so the worker falls back
+            // to sampling settings embedded in the GGUF (general.sampling.*),
+            // and only then to the built-in default.
+            if let Some(s) = sampler {
+                builder = builder.with_sampler(s.sampler_config);
+            }
+            builder.build_async()
         });
         let chat_handle = build_result
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(render_miette(&e)))?;


### PR DESCRIPTION
## What

Core resolves the chat sampler with a documented three-tier precedence (`core/src/chat.rs`):

```rust
let sampler_config = match config.sampler_config {
    Some(sc) => sc,                                              // 1. user-specified
    None => read_sampler_from_metadata(&model.language_model)    // 2. general.sampling.* GGUF metadata
                .unwrap_or_default(),                            // 3. built-in default
};
```

…but the python binding eagerly defaulted the constructor argument (`sampler = SamplerConfig::default()`), so `ChatConfig.sampler_config` was always `Some(...)` and tier 2 — `read_sampler_from_metadata`, which parses 13 `general.sampling.*` keys plus an optional `general.sampling.sequence` — was unreachable from python. Core could never distinguish "the user chose the default settings" from "the user expressed no preference".

This makes the argument `Optional` (default `None`) in both `Chat` and `ChatAsync` and only sets it on the builder when given, restoring the documented precedence.

## Why it matters

Model authors publish recommended sampling settings (e.g. LiquidAI specifies temperature 0.1 / top_k 50 / repetition_penalty 1.05 for the LFM family, which without a repetition penalty can spiral into degenerate token loops). With this fix, a GGUF carrying those settings as `general.sampling.*` metadata is self-configuring:

```
python: Chat(model)                      # no sampler argument
file:   general.sampling.temp = 0.1
        general.sampling.top_k = 50
        general.sampling.penalty_last_n = 64
        general.sampling.penalty_repeat = 1.05
result: penalties → top_k(50) → temp(0.1) → dist, read from the file
```

## Compatibility

- Files **without** `general.sampling.*` keys (every GGUF inspected, incl. all current LiquidAI/Qwen/Gemma files): tier 2 finds nothing → `unwrap_or_default()` → byte-identical behavior to today. Verified: full python tool-calling suite on Qwen3-0.6B (14/14) and on metadata-less LFM files reproduces previous results exactly.
- Explicit `sampler=` callers: unchanged (tier 1).
- A GGUF with sampling metadata demonstrably configures the sampler (verified via `chat.get_sampler_config()`).

Note: the Godot/Flutter/JS bindings likely have the same eager-default pattern; this PR fixes python only — follow-ups can mirror it.
