### PR TITLE
feat(python): accept an un-terminated SamplerBuilder (default to dist())

### DIFF
--- a/docs/docs-python/sampling.md
+++ b/docs/docs-python/sampling.md
@@ -127,12 +127,16 @@ Chat(
         .dist()
 )
 ```
-With `SamplerBuilder` you can chain multiple steps together and then select how do you
-want to sample from the distribution. Keep in mind, that `SamplerBuilder` provides two
-types of methods: ones which modify the distribution (returning again the instance of
-`SamplerBuilder`) and ones which sample from the distribution (returning `SamplerConfig`).
-So in order to have the sampler working properly and not giving you type errors, be careful
-to always end the chain with one of the sampling steps (e.g. `dist`, `greedy`, `mirostat_v2`, etc.).
+With `SamplerBuilder` you can chain multiple steps together and then select how you
+want to sample from the distribution. It provides two kinds of methods: **shift steps**
+that modify the distribution, and **terminal steps** that sample from it (`dist`, `greedy`,
+`mirostat_v1`, `mirostat_v2`). End the chain with a terminal step to choose how tokens are
+drawn — or omit it, and NobodyWho defaults to `dist()`:
+
+```python
+# the terminal step is optional — an unfinished builder defaults to dist()
+Chat("./model.gguf", sampler=SamplerBuilder().temperature(0.8).top_k(5))
+```
 
 For reproducible output, set the RNG seed with `.seed(value)` anywhere in the chain.
 It is consumed by every random sampler in the chain — `dist`, `mirostat_v1`, `mirostat_v2`,
@@ -159,7 +163,7 @@ Shift steps — add as many as you want, applied in order:
 - `.seed(42)` — fix the RNG for reproducible output
 - `.grammar(...)` — deprecated; use the `constrain_with_*` presets above
 
-Terminal step — one of these turns the chain into a `SamplerConfig`, so finish with exactly one:
+Terminal step — optionally end the chain with one; if you omit it, `dist()` is used:
 
 - `.dist()` — pick a token with weighted randomness (the usual choice)
 - `.greedy()` — always take the most likely token

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -33,7 +33,7 @@ class Chat:
     to use, whether to allow extended thinking, etc.
     See `ChatAsync` for the async version of this class.
     """
-    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "Chat":
+    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | SamplerBuilder | None" = None, allow_thinking: "bool | None" = None) -> "Chat":
         """
         Create a new Chat instance for conversational text generation.
         
@@ -147,7 +147,7 @@ class Chat:
             ValueError: If message format is invalid
             RuntimeError: If setting history fails
         """
-    def set_sampler_config(self, /, sampler: SamplerConfig) -> None:
+    def set_sampler_config(self, /, sampler: "SamplerConfig | SamplerBuilder") -> None:
         """
         Update the sampler configuration without resetting chat history.
         
@@ -212,7 +212,7 @@ class ChatAsync:
     This is the async version of the `Chat` class.
     See the docs for the `Chat` class for more information.
     """
-    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync":
+    def __new__(cls, /, model: "Model | os.PathLike | str", n_ctx: int = 4096, system_prompt: str | None = None, template_variables: "dict[str, bool]" = ..., tools: "list[Tool]" = ..., sampler: "SamplerConfig | SamplerBuilder | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync":
         """
         Create a new async Chat instance for conversational text generation.
         
@@ -326,7 +326,7 @@ class ChatAsync:
             ValueError: If message format is invalid
             RuntimeError: If setting history fails
         """
-    async def set_sampler_config(self, /, sampler: SamplerConfig) -> None:
+    async def set_sampler_config(self, /, sampler: "SamplerConfig | SamplerBuilder") -> None:
         """
         Update the sampler configuration without resetting chat history.
         

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -668,14 +668,14 @@ impl Chat {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "Chat")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler: "SamplerConfig | SamplerBuilder | None" = None, allow_thinking: "bool | None" = None) -> "Chat")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
         system_prompt: Option<&str>,
         template_variables: std::collections::HashMap<String, bool>,
         tools: Vec<Tool>,
-        sampler: Option<SamplerConfig>,
+        sampler: Option<SamplerConfigOrBuilder>,
         allow_thinking: Option<bool>,
         py: Python<'_>,
     ) -> PyResult<Self> {
@@ -707,7 +707,7 @@ impl Chat {
             // to sampling settings embedded in the GGUF (general.sampling.*),
             // and only then to the built-in default.
             if let Some(s) = sampler {
-                builder = builder.with_sampler(s.sampler_config);
+                builder = builder.with_sampler(s.into_config());
             }
             builder.build()
         });
@@ -939,10 +939,11 @@ impl Chat {
     ///
     /// Raises:
     ///     RuntimeError: If the sampler config cannot be changed
-    pub fn set_sampler_config(&self, sampler: SamplerConfig, py: Python) -> PyResult<()> {
+    #[pyo3(signature = (sampler: "SamplerConfig | SamplerBuilder"))]
+    pub fn set_sampler_config(&self, sampler: SamplerConfigOrBuilder, py: Python) -> PyResult<()> {
         py.detach(|| {
             self.handle()
-                .set_sampler_config(sampler.sampler_config)
+                .set_sampler_config(sampler.into_config())
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
         })
     }
@@ -1024,14 +1025,14 @@ impl ChatAsync {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler: "SamplerConfig | SamplerBuilder | None" = None, allow_thinking: "bool | None" = None) -> "ChatAsync")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
         system_prompt: Option<&str>,
         template_variables: std::collections::HashMap<String, bool>,
         tools: Vec<Tool>,
-        sampler: Option<SamplerConfig>,
+        sampler: Option<SamplerConfigOrBuilder>,
         allow_thinking: Option<bool>,
         py: Python<'_>,
     ) -> PyResult<Self> {
@@ -1063,7 +1064,7 @@ impl ChatAsync {
             // to sampling settings embedded in the GGUF (general.sampling.*),
             // and only then to the built-in default.
             if let Some(s) = sampler {
-                builder = builder.with_sampler(s.sampler_config);
+                builder = builder.with_sampler(s.into_config());
             }
             builder.build_async()
         });
@@ -1287,9 +1288,10 @@ impl ChatAsync {
     ///
     /// Raises:
     ///     RuntimeError: If the sampler config cannot be changed
-    pub async fn set_sampler_config(&self, sampler: SamplerConfig) -> PyResult<()> {
+    #[pyo3(signature = (sampler: "SamplerConfig | SamplerBuilder"))]
+    pub async fn set_sampler_config(&self, sampler: SamplerConfigOrBuilder) -> PyResult<()> {
         self.handle()
-            .set_sampler_config(sampler.sampler_config)
+            .set_sampler_config(sampler.into_config())
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
@@ -1675,6 +1677,26 @@ fn shift_step(builder: SamplerBuilder, step: nobodywho::sampler::ShiftStep) -> S
 fn sample_step(builder: SamplerBuilder, step: nobodywho::sampler::SampleStep) -> SamplerConfig {
     SamplerConfig {
         sampler_config: builder.inner.sample(step),
+    }
+}
+
+/// Represents a `SamplerConfig | SamplerBuilder` from Python.
+/// The intent is to let callers pass a builder chain directly without remembering to
+/// call a terminal step: a bare `SamplerBuilder` (no `dist`/`greedy`/`mirostat_*`
+/// called) is finalized with `dist()` — the default Kotlin's `buildSampler { }` uses.
+#[derive(FromPyObject)]
+pub enum SamplerConfigOrBuilder {
+    Config(SamplerConfig),
+    Builder(SamplerBuilder),
+}
+
+impl SamplerConfigOrBuilder {
+    fn into_config(self) -> nobodywho::sampler::SamplerConfig {
+        match self {
+            SamplerConfigOrBuilder::Config(config) => config.sampler_config,
+            // No terminal step was called; default to dist() (the SamplerBuilder.dist() path).
+            SamplerConfigOrBuilder::Builder(builder) => builder.dist().sampler_config,
+        }
     }
 }
 

--- a/nobodywho/python/tests/test_nobodywho.py
+++ b/nobodywho/python/tests/test_nobodywho.py
@@ -454,3 +454,36 @@ def test_constrain_with_grammar_gbnf(model):
     )
     response = chat.ask("Explain in detail why the sky appears blue.").completed()
     assert response in ("yes", "no"), f"Expected 'yes' or 'no', got: {response!r}"
+
+
+def test_sampler_builder_without_terminal_defaults_to_dist(model):
+    """An un-terminated SamplerBuilder is accepted wherever a sampler is expected
+    and is finalized with dist() — matching the same chain ending in .dist()."""
+    chat = nobodywho.Chat(
+        model,
+        # note: no .dist() — Chat finalizes the builder with dist() automatically
+        sampler=nobodywho.SamplerBuilder().temperature(0.8).top_k(5),
+        template_variables={"enable_thinking": False},
+    )
+    explicit = nobodywho.SamplerBuilder().temperature(0.8).top_k(5).dist()
+    assert chat.get_sampler_config().to_json() == explicit.to_json()
+
+
+def test_set_sampler_config_accepts_builder(model):
+    """set_sampler_config() also accepts an un-terminated SamplerBuilder."""
+    chat = nobodywho.Chat(model, template_variables={"enable_thinking": False})
+    chat.set_sampler_config(nobodywho.SamplerBuilder().temperature(0.5).top_k(10))
+    explicit = nobodywho.SamplerBuilder().temperature(0.5).top_k(10).dist()
+    assert chat.get_sampler_config().to_json() == explicit.to_json()
+
+
+@pytest.mark.asyncio
+async def test_async_chat_accepts_builder_without_terminal(model):
+    """ChatAsync also accepts an un-terminated SamplerBuilder, finalized with dist()."""
+    chat = nobodywho.ChatAsync(
+        model,
+        sampler=nobodywho.SamplerBuilder().temperature(0.8).top_k(5),
+        template_variables={"enable_thinking": False},
+    )
+    explicit = nobodywho.SamplerBuilder().temperature(0.8).top_k(5).dist()
+    assert (await chat.get_sampler_config()).to_json() == explicit.to_json()


### PR DESCRIPTION
Kotlin already lets you skip the terminal step — its `buildSampler { }` defaults to `dist()`. This brings the same to Python, making it the **second binding** to support it.

| Binding | Terminal step |
|---|---|
| Kotlin | optional _(shipped)_ |
| Python | optional _(this PR)_ ← |
| Swift / RN / Flutter / Godot | required |

Open scope decision: **(a)** keep Python-only · **(b)** follow up to bring the remaining bindings in line for full consistency (more work — uniffi/Flutter/Godot lack easy union/overload support, which is why Kotlin was first and Python is second).

## What it does

`Chat(sampler=...)` and `set_sampler_config()` accept a bare `SamplerBuilder`; with no terminal it defaults to `dist()`:

```python
Chat(model, sampler=SamplerBuilder().temperature(0.8).top_k(5))  # no .dist()
```

`FromPyObject` enum (`SamplerConfigOrBuilder`, mirroring `ModelOrPath`), reuses `dist()`, stub regenerates via `make_stubs`, tests cover sync + async, Python docs updated.

> Stacked on #571 — merge that first (or retarget to `main`).
