### PR TITLE
Updated react-native wrapper message struct

### DIFF
--- a/nobodywho/react-native/src/message.ts
+++ b/nobodywho/react-native/src/message.ts
@@ -74,7 +74,7 @@ export function toInternal(msg: Message): InternalMessage {
   } else if (msg.role === "assistant") {
     return new InternalMessage.Assistant({
       content: msg.content,
-      toolCalls: null,
+      toolCalls: undefined,
     });
   } else if (msg.role === "system") {
     return new InternalMessage.System({


### PR DESCRIPTION
This was done so an empty toolCall array is no longer needed when constructing an assistant message