### PR TITLE
refactor: Split inference from chat

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -27,9 +27,9 @@ use crate::errors::{
     ChatWorkerError, ContextSyncError, InitWorkerError, MultimodalError, RenderError, SayError,
     SelectTemplateError, SetToolsError, ShiftError, TokenizeError, WrappedResponseError,
 };
+use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
 use crate::inference::{wrap_respond, Generate};
 use crate::llm;
-use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
 use crate::llm::{Worker, WorkerGuard};
 use crate::sampler::read_sampler_from_metadata;
 use crate::sampler::{SamplerConfig, ShiftStep};

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1227,7 +1227,7 @@ fn process_worker_msg(
         ChatMsg::GetStats { output_tx } => {
             let stats = ChatStats {
                 context_size: worker_state.engine.ctx.n_ctx(),
-                context_used: worker_state.engine.n_past as u32,
+                context_used: worker_state.engine.n_past(),
             };
             let _ = output_tx.blocking_send(stats);
         }
@@ -1567,7 +1567,7 @@ impl<'a> Chat<'a> {
 
         while !self.should_stop() {
             // Check if the context is full
-            if self.engine.n_past as u32 == self.engine.ctx.n_ctx() {
+            if self.engine.is_context_full() {
                 self.context_shift()?;
                 self.sync_context_with_render(inference_lock_token)?;
                 self.engine.read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
@@ -1654,18 +1654,14 @@ impl<'a> Chat<'a> {
             .map(|fmt| fmt.begin_token().to_string());
 
         let media_assets = prompt.extract_media_assets();
-        let bitmaps = if let Some(projection_model) = self.engine.projection_model.as_ref() {
-            media_assets
-                .iter()
-                .map(|part| match part {
-                    PromptPart::Image(path) => projection_model.load_image(path),
-                    PromptPart::Audio(path) => projection_model.load_audio(path),
-                    PromptPart::Text(_) => unreachable!(),
-                })
-                .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?
-        } else {
-            vec![]
-        };
+        let bitmaps = media_assets
+            .iter()
+            .map(|part| match part {
+                PromptPart::Image(path) => self.engine.load_image(path),
+                PromptPart::Audio(path) => self.engine.load_audio(path),
+                PromptPart::Text(_) => unreachable!(),
+            })
+            .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?;
 
         debug!("Detected bitmaps: {:?}", bitmaps);
 
@@ -1794,7 +1790,7 @@ impl<'a> Chat<'a> {
             .flat_map(|msg| msg.assets())
             .filter_map(|asset| self.context.bitmaps.get(&asset.id))
             .collect();
-        Ok(self.engine.tokenizer.tokenize(rendered_chat, bitmaps)?)
+        Ok(self.engine.tokenize(rendered_chat, bitmaps)?)
     }
 
     fn wrapped_update_context_and_generate_response<F>(
@@ -1996,21 +1992,17 @@ impl<'a> Chat<'a> {
 
     pub fn tokenize(&mut self, prompt: Prompt) -> Result<Vec<Option<i32>>, TokenizeError> {
         let media_assets = prompt.extract_media_assets();
-        let bitmaps = if let Some(projection_model) = self.engine.projection_model.as_ref() {
-            media_assets
-                .iter()
-                .map(|part| match part {
-                    PromptPart::Image(path) => projection_model.load_image(path),
-                    PromptPart::Audio(path) => projection_model.load_audio(path),
-                    PromptPart::Text(_) => unreachable!(),
-                })
-                .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?
-        } else {
-            vec![]
-        };
+        let bitmaps = media_assets
+            .iter()
+            .map(|part| match part {
+                PromptPart::Image(path) => self.engine.load_image(path),
+                PromptPart::Audio(path) => self.engine.load_audio(path),
+                PromptPart::Text(_) => unreachable!(),
+            })
+            .collect::<Result<Vec<MtmdBitmap>, MultimodalError>>()?;
 
         let bitmap_refs: Vec<&MtmdBitmap> = bitmaps.iter().collect();
-        let chunks = self.engine.tokenizer.tokenize(prompt.to_string(), bitmap_refs)?;
+        let chunks = self.engine.tokenize(prompt.to_string(), bitmap_refs)?;
         Ok(chunks.to_token_ids())
     }
 }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -28,7 +28,7 @@ use crate::errors::{
     RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError, TokenizeError,
     WrappedResponseError,
 };
-use crate::inference::{acquire_inference_lock, wrap_respond, InferenceEngine};
+use crate::inference::{acquire_inference_lock, InferenceEngine};
 use crate::llm;
 use crate::llm::{GlobalInferenceLockToken, Worker, WorkerGuard, WriteOutput};
 use crate::sampler::read_sampler_from_metadata;
@@ -1790,6 +1790,38 @@ impl<'a> Chat<'a> {
         Ok(self.engine.tokenize(rendered_chat, bitmaps)?)
     }
 
+    fn wrap_respond<F>(
+        respond: F,
+        tool_call_begin_token: Option<String>,
+    ) -> (
+        impl FnMut(llm::WriteOutput),
+        std::sync::mpsc::Receiver<String>,
+    )
+    where
+        F: Fn(llm::WriteOutput),
+    {
+        let (resp_sender, resp_receiver) = std::sync::mpsc::channel();
+        let mut emitting = true;
+
+        let wrapped_respond = move |x| {
+            match &x {
+                llm::WriteOutput::Token(tok) if tool_call_begin_token.as_ref() == Some(tok) => {
+                    emitting = false;
+                }
+                llm::WriteOutput::Done(resp) => {
+                    resp_sender
+                        .send(resp.clone())
+                        .expect("Failed sending response");
+                }
+                llm::WriteOutput::Token(_) | llm::WriteOutput::Error(_) => (),
+            }
+            if emitting {
+                respond(x)
+            }
+        };
+        (wrapped_respond, resp_receiver)
+    }
+
     fn wrapped_update_context_and_generate_response<F>(
         &mut self,
         sampler: SamplerConfig,
@@ -1805,7 +1837,8 @@ impl<'a> Chat<'a> {
 
         // wrap the response callback to keep a copy of the completed response
         // and to avoid emitting tool calls
-        let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
+        let (wrapped_respond, resp_receiver) =
+            Self::wrap_respond(respond.clone(), tool_call_begin_token);
 
         // llm go brrr
         self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1132,10 +1132,7 @@ impl std::fmt::Debug for ChatMsg {
     }
 }
 
-fn process_worker_msg(
-    worker_state: &mut Chat<'_>,
-    msg: ChatMsg,
-) -> Result<(), ChatWorkerError> {
+fn process_worker_msg(worker_state: &mut Chat<'_>, msg: ChatMsg) -> Result<(), ChatWorkerError> {
     info!(?msg, "Worker processing:");
     match msg {
         ChatMsg::Ask { prompt, output_tx } => {
@@ -1376,8 +1373,7 @@ impl<'a> Chat<'a> {
 
         // Build the low-level inference engine via the shared Worker constructor,
         // then take ownership of just the engine for the chat session.
-        let Worker { engine, extra: () } =
-            Worker::new_with_type(model, config.n_ctx, false, ())?;
+        let Worker { engine, extra: () } = Worker::new_with_type(model, config.n_ctx, false, ())?;
 
         Ok(Chat {
             engine,
@@ -1397,8 +1393,7 @@ impl<'a> Chat<'a> {
     }
 
     fn should_stop(&self) -> bool {
-        self.should_stop
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.should_stop.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn add_system_message(&mut self, content: String) {
@@ -1443,7 +1438,9 @@ impl<'a> Chat<'a> {
 
         // Diff against the chunks currently in the KV cache and load only the new tail.
         let prev = std::mem::take(&mut self.context.chunks);
-        let new_chunks = self.engine.sync_context(chunks, &prev, inference_lock_token)?;
+        let new_chunks = self
+            .engine
+            .sync_context(chunks, &prev, inference_lock_token)?;
         self.context.chunks = new_chunks;
         self.context.garbage_collect_bitmaps(&self.messages);
 
@@ -1570,7 +1567,8 @@ impl<'a> Chat<'a> {
             if self.engine.is_context_full() {
                 self.context_shift()?;
                 self.sync_context_with_render(inference_lock_token)?;
-                self.engine.read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
+                self.engine
+                    .read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
                 // do not update tokens_in_context as this is done later by ask
             }
 
@@ -1681,25 +1679,25 @@ impl<'a> Chat<'a> {
         self.add_user_message(prompt.to_string(), assets);
 
         // Modify sampler with tool grammar if we have tools
-        let sampler = self.tool_grammar.as_ref().map_or(
-            self.sampler_config.clone(),
-            |tool_grammar| {
-                let mut steps = self.sampler_config.steps.clone();
-                steps.insert(
-                    0,
-                    ShiftStep::Grammar {
-                        trigger_on: tool_call_begin.clone(),
-                        root: tool_grammar.root_name.to_string(),
-                        grammar: tool_grammar.as_str().into(),
-                    },
-                );
-                SamplerConfig::new(
-                    steps,
-                    self.sampler_config.sample_step.clone(),
-                    self.sampler_config.seed,
-                )
-            },
-        );
+        let sampler =
+            self.tool_grammar
+                .as_ref()
+                .map_or(self.sampler_config.clone(), |tool_grammar| {
+                    let mut steps = self.sampler_config.steps.clone();
+                    steps.insert(
+                        0,
+                        ShiftStep::Grammar {
+                            trigger_on: tool_call_begin.clone(),
+                            root: tool_grammar.root_name.to_string(),
+                            grammar: tool_grammar.as_str().into(),
+                        },
+                    );
+                    SamplerConfig::new(
+                        steps,
+                        self.sampler_config.sample_step.clone(),
+                        self.sampler_config.seed,
+                    )
+                });
 
         // get the finished response
         let mut response: String = self.wrapped_update_context_and_generate_response(
@@ -1721,8 +1719,7 @@ impl<'a> Chat<'a> {
                     // this is just a stupid linear search
                     // but I think it's probably faster than something fancy as long as we have few tools
                     // /shrug I'm happy to be wrong
-                    let Some(tool) = self.tools.iter().find(|t| t.name == tool_call.name)
-                    else {
+                    let Some(tool) = self.tools.iter().find(|t| t.name == tool_call.name) else {
                         // in case the tool isn't found.
                         // I *think* this should be impossible, as long as the tool calling grammar
                         // works.

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -24,20 +24,17 @@
 //!
 
 use crate::errors::{
-    ChatWorkerError, ContextSyncError, InitWorkerError,
-    MultimodalError, RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError,
-    TokenizeError, WrappedResponseError,
+    ChatWorkerError, ContextSyncError, InitWorkerError, MultimodalError, RenderError, SayError,
+    SelectTemplateError, SetToolsError, ShiftError, TokenizeError, WrappedResponseError,
 };
-use crate::llm;
-use crate::llm::{GlobalInferenceLockToken, GLOBAL_INFERENCE_LOCK};
 use crate::inference::{wrap_respond, Generate};
+use crate::llm;
+use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
 use crate::llm::{Worker, WorkerGuard};
 use crate::sampler::read_sampler_from_metadata;
 use crate::sampler::{SamplerConfig, ShiftStep};
 use crate::template::{select_template, ChatTemplate, ChatTemplateContext};
-use crate::tokenizer::{
-    ChunkId, Prompt, PromptPart, Promptable, TokenizerChunks,
-};
+use crate::tokenizer::{ChunkId, Prompt, PromptPart, Promptable, TokenizerChunks};
 use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat};
 use ahash::AHasher;
 use indexmap::IndexMap;
@@ -1444,7 +1441,7 @@ impl Worker<'_, ChatWorker> {
             chunks = self.render_as_chunks(true)?;
         }
 
-        let prev = self.extra.context.chunks.clone();
+        let prev = std::mem::take(&mut self.extra.context.chunks);
         let new_chunks = self.sync_context(chunks, &prev, inference_lock_token)?;
         self.extra.context.chunks = new_chunks;
         self.extra
@@ -1719,8 +1716,7 @@ impl Worker<'_, ChatWorker> {
         F: Fn(llm::WriteOutput) + Clone,
     {
         // Check how much of the current KVCache we can keep
-        let _gil_guard = GLOBAL_INFERENCE_LOCK.lock();
-        let inference_lock_token = _gil_guard.unwrap();
+        let inference_lock_token = acquire_inference_lock();
         self.sync_context_with_render(&inference_lock_token)?;
 
         // wrap the response callback to keep a copy of the completed response
@@ -1939,7 +1935,6 @@ impl Worker<'_, ChatWorker> {
         Ok(chunks.to_token_ids())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -24,27 +24,25 @@
 //!
 
 use crate::errors::{
-    ChatWorkerError, ContextSyncError, DecodingError, GenerateResponseError, InitWorkerError,
+    ChatWorkerError, ContextSyncError, InitWorkerError,
     MultimodalError, RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError,
     TokenizeError, WrappedResponseError,
 };
 use crate::llm;
 use crate::llm::{GlobalInferenceLockToken, GLOBAL_INFERENCE_LOCK};
-use crate::llm::{Worker, WorkerGuard, WriteOutput};
+use crate::inference::{wrap_respond, Generate};
+use crate::llm::{Worker, WorkerGuard};
 use crate::sampler::read_sampler_from_metadata;
 use crate::sampler::{SamplerConfig, ShiftStep};
 use crate::template::{select_template, ChatTemplate, ChatTemplateContext};
 use crate::tokenizer::{
-    find_chunks_prefix_difference, ChunkId, Prompt, PromptPart, Promptable, TokenizerChunk,
-    TokenizerChunks,
+    ChunkId, Prompt, PromptPart, Promptable, TokenizerChunks,
 };
 use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat};
 use ahash::AHasher;
 use indexmap::IndexMap;
 use llama_cpp_2::context::params::LlamaPoolingType;
 use llama_cpp_2::mtmd::MtmdBitmap;
-use llama_cpp_2::sampling::LlamaSampler;
-use llama_cpp_2::token::LlamaToken;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
 use std::collections::HashSet;
@@ -52,7 +50,7 @@ use std::hash::Hasher;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, MutexGuard};
-use tracing::{debug, error, info, trace, trace_span};
+use tracing::{debug, error, info};
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Asset {
@@ -1334,6 +1332,12 @@ impl llm::PoolingType for ChatWorker {
     }
 }
 
+impl Generate for ChatWorker {
+    fn should_stop(&self) -> bool {
+        self.should_stop.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 impl Worker<'_, ChatWorker> {
     fn new_chat_worker(
         model: &llm::Model,
@@ -1403,12 +1407,6 @@ impl Worker<'_, ChatWorker> {
         )
     }
 
-    fn should_stop(&self) -> bool {
-        self.extra
-            .should_stop
-            .load(std::sync::atomic::Ordering::Relaxed)
-    }
-
     pub fn add_system_message(&mut self, content: String) {
         self.extra.messages.push(Message::System { content });
     }
@@ -1446,35 +1444,9 @@ impl Worker<'_, ChatWorker> {
             chunks = self.render_as_chunks(true)?;
         }
 
-        let prefix_index = find_chunks_prefix_difference(&self.extra.context.chunks, &chunks);
-
-        // We should never try to sync with an empty render
-        debug_assert!(!chunks.is_empty());
-
-        // this call may remove more than just the tokens from prefix_index
-        // it updates self.n_past to indicate num of tokens in context
-        let old_n_past = self.n_past;
-        self.remove_all_tokens_from_index_from_ctx(prefix_index)?;
-
-        // Use n_past as the actual preserved prefix — may be 0 if a full reset was
-        // required (e.g. hybrid/recurrent models that don't support partial seq_rm).
-        let chunks_to_read = chunks.tail(self.n_past as usize);
-        if chunks_to_read.n_tokens() > 0 {
-            self.read_chunks(chunks_to_read, inference_lock_token)?;
-        } else if self.n_past < old_n_past {
-            // Truncate-only path: the KV cache was trimmed but no new tokens
-            // need to be appended. Re-decode the last remaining token to
-            // refresh the logits buffer, which would otherwise contain stale
-            // values from whatever the previous decode() call happened to be.
-            // llama.cpp requires strictly consecutive positions (Y = X + 1),
-            // so we must remove the last token from the KV cache before we
-            // can re-decode it.
-            self.remove_all_tokens_from_index_from_ctx(self.n_past as usize - 1)?;
-            let refresh_tokens = chunks.tail(self.n_past as usize);
-            self.read_chunks(refresh_tokens, inference_lock_token)?;
-        }
-
-        self.extra.context.chunks = chunks;
+        let prev = self.extra.context.chunks.clone();
+        let new_chunks = self.sync_context(chunks, &prev, inference_lock_token)?;
+        self.extra.context.chunks = new_chunks;
         self.extra
             .context
             .garbage_collect_bitmaps(&self.extra.messages);
@@ -1573,124 +1545,6 @@ impl Worker<'_, ChatWorker> {
     // This is a safety meassure to prevent bugs from multiple
     // contexts with the same model. It might not be necessary
     // but assume it is.
-    pub fn generate_response_until_done<F>(
-        &mut self,
-        sampler_config: SamplerConfig,
-        mut respond: F,
-        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
-    ) -> Result<&mut Self, GenerateResponseError>
-    where
-        F: FnMut(WriteOutput),
-    {
-        // Token generation loop
-        info!("Worker writing until done");
-
-        // pre-allocating 4096 bytes for the response string
-        // 4096 is a very randomly chosen number. how does this affect performance?
-        let mut full_response: String = String::with_capacity(4096);
-        let mut tokens_written_until_now = TokenizerChunks::new();
-
-        // initialize sampler
-        // stateful samplers only live for one response
-        let mut sampler = sampler_config.to_stateful(self.ctx.model)?;
-
-        // init statefull decoder for split up tokens like emojis
-        let mut decoder = encoding_rs::UTF_8.new_decoder();
-
-        while !self.should_stop() {
-            // Check if the context is full
-            if self.n_past as u32 == self.ctx.n_ctx() {
-                self.context_shift()?;
-                self.sync_context_with_render(inference_lock_token)?;
-                self.read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
-                // do not update tokens_in_context as this is done later by ask
-            }
-
-            // Sample next token, no need to use sampler.accept as sample already accepts the token.
-            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
-            // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let new_token = self.sample_and_decode_next_token(&mut sampler)?;
-
-            tokens_written_until_now.append(TokenizerChunk::new_text(vec![new_token]));
-
-            // Attempt to convert token(s) to bytes
-            let token_bytes = match self
-                .ctx
-                .model
-                .token_to_piece_bytes(new_token, 8, true, None)
-            {
-                Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
-                    self.ctx.model.token_to_piece_bytes(
-                        new_token,
-                        (-i).try_into().expect("Error buffer size is positive"),
-                        true,
-                        None,
-                    )
-                }
-                x => x,
-            }?;
-
-            // Attempt to convert bytes to utf8 string.
-            let max_len = decoder
-                .max_utf8_buffer_length(token_bytes.len())
-                .unwrap_or(32);
-            let mut token_str = String::with_capacity(max_len);
-
-            // this is where the utf-8 decoder handles partial unicode
-            // it'll write whatever printable chars it can into `token_str`
-            // and retain partial codepoints for next decoding attempt
-            let (_result, _bytes_read, _had_errors) =
-                decoder.decode_to_string(&token_bytes, &mut token_str, false);
-
-            // XXX: this literal '<eos>' token match is a fucked hotfix for gemma4. it seems like
-            // some gemma4 models will emit a *wrong* eos token (doesn't match the expected format)
-            // after tool calls. This doesn't trigger the is_eog_token match in llama.cpp and
-            // causes a bad infinite generation loop.
-            // it seems like vllm also has a codepath to handle this specific case:
-            // https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
-            let gemma4_eog_hotfix = token_str == "<eos>" && new_token == LlamaToken::new(1);
-
-            let has_eog = self.ctx.model.is_eog_token(new_token) || gemma4_eog_hotfix;
-            trace!(?new_token, ?token_str, ?has_eog);
-
-            if !has_eog {
-                full_response.push_str(&token_str);
-                trace!(?token_str, "Sending out token:");
-                respond(WriteOutput::Token(token_str.to_string()));
-            }
-
-            if has_eog {
-                break;
-            }
-        }
-
-        // we're done!
-        debug!(%full_response, "Sending out");
-        respond(WriteOutput::Done(full_response));
-        Ok(self)
-    }
-
-    fn sample_and_decode_next_token(
-        &mut self,
-        sampler: &mut LlamaSampler,
-    ) -> Result<LlamaToken, DecodingError> {
-        trace!("Applying sampler");
-        let new_token: LlamaToken = sampler.sample(&self.ctx, -1);
-
-        // batch of one
-        self.small_batch.clear();
-        self.small_batch.add(new_token, self.n_past, &[0], true)?;
-
-        // llm go brr
-        let decode_span = trace_span!("write decode", n_past = self.n_past);
-        let decode_guard = decode_span.enter();
-        self.ctx.decode(&mut self.small_batch)?;
-        drop(decode_guard);
-        self.n_past += 1; // keep count
-
-        Ok(new_token)
-    }
-
     pub fn ask<F>(&mut self, prompt: Prompt, respond: F) -> Result<&mut Self, SayError>
     where
         F: Fn(llm::WriteOutput) + Clone,
@@ -1874,7 +1728,17 @@ impl Worker<'_, ChatWorker> {
         let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
 
         // llm go brrr
-        self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
+        self.generate_response_until_done(
+            sampler,
+            wrapped_respond,
+            &inference_lock_token,
+            |worker, tokens_written, lock| {
+                worker.context_shift()?;
+                worker.sync_context_with_render(lock)?;
+                worker.read_chunks(tokens_written.clone(), lock)?;
+                Ok(())
+            },
+        )?;
 
         Ok(resp_receiver.recv()?)
     }
@@ -2076,40 +1940,6 @@ impl Worker<'_, ChatWorker> {
     }
 }
 
-/// wraps a response function in a closure to do two things:
-/// 1. save a copy of the response (using a channel) before sending it out
-/// 2. skip emitting once a tool_call_begin_token has been seen
-fn wrap_respond<F>(
-    respond: F,
-    tool_call_begin_token: Option<String>,
-) -> (
-    impl FnMut(llm::WriteOutput),
-    std::sync::mpsc::Receiver<String>,
-)
-where
-    F: Fn(llm::WriteOutput),
-{
-    let (resp_sender, resp_receiver) = std::sync::mpsc::channel();
-    let mut emitting = true;
-
-    let wrapped_respond = move |x| {
-        match &x {
-            llm::WriteOutput::Token(tok) if tool_call_begin_token.as_ref() == Some(tok) => {
-                emitting = false;
-            }
-            llm::WriteOutput::Done(resp) => {
-                resp_sender
-                    .send(resp.clone())
-                    .expect("Failed sending response");
-            }
-            llm::WriteOutput::Token(_) | llm::WriteOutput::Error(_) => (),
-        }
-        if emitting {
-            respond(x)
-        }
-    };
-    (wrapped_respond, resp_receiver)
-}
 
 #[cfg(test)]
 mod tests {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -24,22 +24,22 @@
 //!
 
 use crate::errors::{
-    ChatWorkerError, ContextSyncError, InitWorkerError, MultimodalError, RenderError, SayError,
-    SelectTemplateError, SetToolsError, ShiftError, TokenizeError, WrappedResponseError,
+    ChatWorkerError, ContextSyncError, GenerateResponseError, InitWorkerError, MultimodalError,
+    RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError, TokenizeError,
+    WrappedResponseError,
 };
-use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
-use crate::inference::{wrap_respond, Generate};
+use crate::inference::{acquire_inference_lock, wrap_respond, InferenceEngine};
 use crate::llm;
-use crate::llm::{Worker, WorkerGuard};
+use crate::llm::{GlobalInferenceLockToken, Worker, WorkerGuard, WriteOutput};
 use crate::sampler::read_sampler_from_metadata;
 use crate::sampler::{SamplerConfig, ShiftStep};
 use crate::template::{select_template, ChatTemplate, ChatTemplateContext};
-use crate::tokenizer::{ChunkId, Prompt, PromptPart, Promptable, TokenizerChunks};
+use crate::tokenizer::{ChunkId, Prompt, PromptPart, Promptable, TokenizerChunk, TokenizerChunks};
 use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat};
 use ahash::AHasher;
 use indexmap::IndexMap;
-use llama_cpp_2::context::params::LlamaPoolingType;
 use llama_cpp_2::mtmd::MtmdBitmap;
+use llama_cpp_2::token::LlamaToken;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
 use std::collections::HashSet;
@@ -47,7 +47,7 @@ use std::hash::Hasher;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, MutexGuard};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Asset {
@@ -301,7 +301,7 @@ impl ChatHandle {
         let should_stop_clone = Arc::clone(&should_stop);
 
         let join_handle = std::thread::spawn(move || {
-            let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
+            let worker = Chat::new_chat_worker(&model, config, should_stop_clone);
             let mut worker_state = match worker {
                 Ok(w) => {
                     let _ = init_tx.send(Ok(()));
@@ -599,7 +599,7 @@ impl ChatHandleAsync {
         let should_stop_clone = Arc::clone(&should_stop);
 
         let join_handle = std::thread::spawn(move || {
-            let worker = Worker::new_chat_worker(&model, config, should_stop_clone);
+            let worker = Chat::new_chat_worker(&model, config, should_stop_clone);
             let mut worker_state = match worker {
                 Ok(w) => {
                     let _ = init_tx.send(Ok(()));
@@ -1133,13 +1133,13 @@ impl std::fmt::Debug for ChatMsg {
 }
 
 fn process_worker_msg(
-    worker_state: &mut Worker<'_, ChatWorker>,
+    worker_state: &mut Chat<'_>,
     msg: ChatMsg,
 ) -> Result<(), ChatWorkerError> {
     info!(?msg, "Worker processing:");
     match msg {
         ChatMsg::Ask { prompt, output_tx } => {
-            let should_stop = Arc::clone(&worker_state.extra.should_stop);
+            let should_stop = Arc::clone(&worker_state.should_stop);
             let error_tx = output_tx.clone();
             let callback = move |out| {
                 if output_tx.send(out).is_err() {
@@ -1226,8 +1226,8 @@ fn process_worker_msg(
         }
         ChatMsg::GetStats { output_tx } => {
             let stats = ChatStats {
-                context_size: worker_state.ctx.n_ctx(),
-                context_used: worker_state.n_past as u32,
+                context_size: worker_state.engine.ctx.n_ctx(),
+                context_used: worker_state.engine.n_past as u32,
             };
             let _ = output_tx.blocking_send(stats);
         }
@@ -1311,7 +1311,10 @@ impl ChatContext {
     }
 }
 
-struct ChatWorker {
+/// A chat session: owns an [`InferenceEngine`] plus all the conversational state
+/// (messages, tools, template, sampler config).
+struct Chat<'a> {
+    engine: InferenceEngine<'a>,
     should_stop: Arc<AtomicBool>,
     tool_grammar: Option<gbnf::GbnfGrammar>,
     tool_format: Option<ToolFormat>,
@@ -1323,24 +1326,12 @@ struct ChatWorker {
     context: ChatContext,
 }
 
-impl llm::PoolingType for ChatWorker {
-    fn pooling_type(&self) -> LlamaPoolingType {
-        LlamaPoolingType::None
-    }
-}
-
-impl Generate for ChatWorker {
-    fn should_stop(&self) -> bool {
-        self.should_stop.load(std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
-impl Worker<'_, ChatWorker> {
+impl<'a> Chat<'a> {
     fn new_chat_worker(
-        model: &llm::Model,
+        model: &'a llm::Model,
         config: ChatConfig,
         should_stop: Arc<AtomicBool>,
-    ) -> Result<Worker<'_, ChatWorker>, InitWorkerError> {
+    ) -> Result<Chat<'a>, InitWorkerError> {
         if !model.is_generative_model() {
             let architecture = model
                 .language_model
@@ -1383,48 +1374,54 @@ impl Worker<'_, ChatWorker> {
             None => read_sampler_from_metadata(&model.language_model).unwrap_or_default(),
         };
 
-        Worker::new_with_type(
-            model,
-            config.n_ctx,
-            false,
-            ChatWorker {
-                should_stop,
-                tool_grammar: grammar,
-                tool_format,
-                sampler_config,
-                messages: match config.system_prompt {
-                    Some(msg) => vec![Message::System { content: msg }],
-                    None => vec![],
-                },
-                chat_template: template,
-                template_variables: config.template_variables,
-                tools: config.tools,
-                context: ChatContext::new(),
+        // Build the low-level inference engine via the shared Worker constructor,
+        // then take ownership of just the engine for the chat session.
+        let Worker { engine, extra: () } =
+            Worker::new_with_type(model, config.n_ctx, false, ())?;
+
+        Ok(Chat {
+            engine,
+            should_stop,
+            tool_grammar: grammar,
+            tool_format,
+            sampler_config,
+            messages: match config.system_prompt {
+                Some(msg) => vec![Message::System { content: msg }],
+                None => vec![],
             },
-        )
+            chat_template: template,
+            template_variables: config.template_variables,
+            tools: config.tools,
+            context: ChatContext::new(),
+        })
+    }
+
+    fn should_stop(&self) -> bool {
+        self.should_stop
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn add_system_message(&mut self, content: String) {
-        self.extra.messages.push(Message::System { content });
+        self.messages.push(Message::System { content });
     }
 
     pub fn add_assistant_message(&mut self, content: String) {
-        self.extra.messages.push(Message::new_assistant(content));
+        self.messages.push(Message::new_assistant(content));
     }
 
     pub fn add_user_message(&mut self, content: String, assets: Vec<Asset>) {
-        self.extra.messages.push(Message::User { content, assets });
+        self.messages.push(Message::User { content, assets });
     }
 
     pub fn add_tool_calls(&mut self, tool_calls: Vec<ToolCall>) {
-        self.extra.messages.push(Message::Assistant {
+        self.messages.push(Message::Assistant {
             content: "".into(),
             tool_calls: Some(tool_calls),
         });
     }
 
     pub fn add_tool_resp(&mut self, name: String, content: String) {
-        self.extra.messages.push(Message::Tool { name, content });
+        self.messages.push(Message::Tool { name, content });
     }
 
     /// Compare tokens from a template-rendered chat history with the tokens in the LLM's context,
@@ -1436,25 +1433,27 @@ impl Worker<'_, ChatWorker> {
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<(), ContextSyncError> {
         let mut chunks = self.render_as_chunks(true)?;
-        if chunks.n_tokens() > self.ctx.n_ctx() as usize {
+        if chunks.n_tokens() > self.engine.ctx.n_ctx() as usize {
             self.context_shift()?;
             chunks = self.render_as_chunks(true)?;
         }
 
-        let prev = std::mem::take(&mut self.extra.context.chunks);
-        let new_chunks = self.sync_context(chunks, &prev, inference_lock_token)?;
-        self.extra.context.chunks = new_chunks;
-        self.extra
-            .context
-            .garbage_collect_bitmaps(&self.extra.messages);
+        // We should never try to sync with an empty render
+        debug_assert!(!chunks.is_empty());
+
+        // Diff against the chunks currently in the KV cache and load only the new tail.
+        let prev = std::mem::take(&mut self.context.chunks);
+        let new_chunks = self.engine.sync_context(chunks, &prev, inference_lock_token)?;
+        self.context.chunks = new_chunks;
+        self.context.garbage_collect_bitmaps(&self.messages);
 
         Ok(())
     }
 
     fn context_shift(&mut self) -> Result<(), ShiftError> {
         info!("Context shift happens!");
-        let target_token_size = (self.ctx.n_ctx() / 2) as usize;
-        let mut messages = self.extra.messages.clone();
+        let target_token_size = (self.engine.ctx.n_ctx() / 2) as usize;
+        let mut messages = self.messages.clone();
 
         // Find indices to preserve
         let system_end = if messages[0].is_system() { 1 } else { 0 };
@@ -1511,7 +1510,7 @@ impl Worker<'_, ChatWorker> {
             last_deletable_index -= messages_deleted;
         }
 
-        self.extra.messages = messages;
+        self.messages = messages;
         Ok(())
     }
 
@@ -1542,24 +1541,120 @@ impl Worker<'_, ChatWorker> {
     // This is a safety meassure to prevent bugs from multiple
     // contexts with the same model. It might not be necessary
     // but assume it is.
+    pub fn generate_response_until_done<F>(
+        &mut self,
+        sampler_config: SamplerConfig,
+        mut respond: F,
+        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+    ) -> Result<&mut Self, GenerateResponseError>
+    where
+        F: FnMut(WriteOutput),
+    {
+        // Token generation loop
+        info!("Worker writing until done");
+
+        // pre-allocating 4096 bytes for the response string
+        // 4096 is a very randomly chosen number. how does this affect performance?
+        let mut full_response: String = String::with_capacity(4096);
+        let mut tokens_written_until_now = TokenizerChunks::new();
+
+        // initialize sampler
+        // stateful samplers only live for one response
+        let mut sampler = sampler_config.to_stateful(self.engine.ctx.model)?;
+
+        // init statefull decoder for split up tokens like emojis
+        let mut decoder = encoding_rs::UTF_8.new_decoder();
+
+        while !self.should_stop() {
+            // Check if the context is full
+            if self.engine.n_past as u32 == self.engine.ctx.n_ctx() {
+                self.context_shift()?;
+                self.sync_context_with_render(inference_lock_token)?;
+                self.engine.read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
+                // do not update tokens_in_context as this is done later by ask
+            }
+
+            // Sample next token, no need to use sampler.accept as sample already accepts the token.
+            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
+            // https://github.com/utilityai/llama-cpp-rs/issues/604
+            let new_token = self.engine.sample_and_decode_next_token(&mut sampler)?;
+
+            tokens_written_until_now.append(TokenizerChunk::new_text(vec![new_token]));
+
+            // Attempt to convert token(s) to bytes
+            let token_bytes = match self
+                .engine
+                .ctx
+                .model
+                .token_to_piece_bytes(new_token, 8, true, None)
+            {
+                Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
+                    self.engine.ctx.model.token_to_piece_bytes(
+                        new_token,
+                        (-i).try_into().expect("Error buffer size is positive"),
+                        true,
+                        None,
+                    )
+                }
+                x => x,
+            }?;
+
+            // Attempt to convert bytes to utf8 string.
+            let max_len = decoder
+                .max_utf8_buffer_length(token_bytes.len())
+                .unwrap_or(32);
+            let mut token_str = String::with_capacity(max_len);
+
+            // this is where the utf-8 decoder handles partial unicode
+            // it'll write whatever printable chars it can into `token_str`
+            // and retain partial codepoints for next decoding attempt
+            let (_result, _bytes_read, _had_errors) =
+                decoder.decode_to_string(&token_bytes, &mut token_str, false);
+
+            // XXX: this literal '<eos>' token match is a fucked hotfix for gemma4. it seems like
+            // some gemma4 models will emit a *wrong* eos token (doesn't match the expected format)
+            // after tool calls. This doesn't trigger the is_eog_token match in llama.cpp and
+            // causes a bad infinite generation loop.
+            // it seems like vllm also has a codepath to handle this specific case:
+            // https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
+            let gemma4_eog_hotfix = token_str == "<eos>" && new_token == LlamaToken::new(1);
+
+            let has_eog = self.engine.ctx.model.is_eog_token(new_token) || gemma4_eog_hotfix;
+            trace!(?new_token, ?token_str, ?has_eog);
+
+            if !has_eog {
+                full_response.push_str(&token_str);
+                trace!(?token_str, "Sending out token:");
+                respond(WriteOutput::Token(token_str.to_string()));
+            }
+
+            if has_eog {
+                break;
+            }
+        }
+
+        // we're done!
+        debug!(%full_response, "Sending out");
+        respond(WriteOutput::Done(full_response));
+        Ok(self)
+    }
+
     pub fn ask<F>(&mut self, prompt: Prompt, respond: F) -> Result<&mut Self, SayError>
     where
         F: Fn(llm::WriteOutput) + Clone,
     {
         // reset the stop flag
-        self.extra
-            .should_stop
+        self.should_stop
             .store(false, std::sync::atomic::Ordering::Relaxed);
 
         // Get the tool call begin token from the format if tools are configured
         let tool_call_begin = self
-            .extra
             .tool_format
             .as_ref()
             .map(|fmt| fmt.begin_token().to_string());
 
         let media_assets = prompt.extract_media_assets();
-        let bitmaps = if let Some(projection_model) = self.projection_model.as_ref() {
+        let bitmaps = if let Some(projection_model) = self.engine.projection_model.as_ref() {
             media_assets
                 .iter()
                 .map(|part| match part {
@@ -1574,7 +1669,7 @@ impl Worker<'_, ChatWorker> {
 
         debug!("Detected bitmaps: {:?}", bitmaps);
 
-        let bitmap_ids = self.extra.context.add_bitmaps(bitmaps)?;
+        let bitmap_ids = self.context.add_bitmaps(bitmaps)?;
         let assets = bitmap_ids
             .iter()
             .zip(media_assets.iter())
@@ -1590,10 +1685,10 @@ impl Worker<'_, ChatWorker> {
         self.add_user_message(prompt.to_string(), assets);
 
         // Modify sampler with tool grammar if we have tools
-        let sampler = self.extra.tool_grammar.as_ref().map_or(
-            self.extra.sampler_config.clone(),
+        let sampler = self.tool_grammar.as_ref().map_or(
+            self.sampler_config.clone(),
             |tool_grammar| {
-                let mut steps = self.extra.sampler_config.steps.clone();
+                let mut steps = self.sampler_config.steps.clone();
                 steps.insert(
                     0,
                     ShiftStep::Grammar {
@@ -1604,8 +1699,8 @@ impl Worker<'_, ChatWorker> {
                 );
                 SamplerConfig::new(
                     steps,
-                    self.extra.sampler_config.sample_step.clone(),
-                    self.extra.sampler_config.seed,
+                    self.sampler_config.sample_step.clone(),
+                    self.sampler_config.seed,
                 )
             },
         );
@@ -1619,7 +1714,7 @@ impl Worker<'_, ChatWorker> {
 
         // Process tool calls if tool format is configured
         // Clone to avoid borrow issues in the loop
-        if let Some(tool_format) = self.extra.tool_format.clone() {
+        if let Some(tool_format) = self.tool_format.clone() {
             while let Some(tool_calls) = tool_format.extract_tool_calls(&response) {
                 debug!(?tool_calls, "Got tool calls:");
 
@@ -1630,7 +1725,7 @@ impl Worker<'_, ChatWorker> {
                     // this is just a stupid linear search
                     // but I think it's probably faster than something fancy as long as we have few tools
                     // /shrug I'm happy to be wrong
-                    let Some(tool) = self.extra.tools.iter().find(|t| t.name == tool_call.name)
+                    let Some(tool) = self.tools.iter().find(|t| t.name == tool_call.name)
                     else {
                         // in case the tool isn't found.
                         // I *think* this should be impossible, as long as the tool calling grammar
@@ -1667,7 +1762,7 @@ impl Worker<'_, ChatWorker> {
             .is_none_or(|t| !response.contains(t.as_str())));
         self.add_assistant_message(response);
 
-        self.extra.context.chunks = self.render_as_chunks(true)?;
+        self.context.chunks = self.render_as_chunks(true)?;
 
         Ok(self)
     }
@@ -1676,34 +1771,30 @@ impl Worker<'_, ChatWorker> {
     /// That is for avoiding the render will concat system message with the first user message.
     /// Otherwise please handle stuff.
     fn render_as_chunks(&mut self, handled: bool) -> Result<TokenizerChunks, RenderError> {
-        let messages = &self.extra.messages;
+        let messages = &self.messages;
         let template_context = ChatTemplateContext::new(
-            self.extra.template_variables.clone(),
-            if self.extra.tools.is_empty() {
+            self.template_variables.clone(),
+            if self.tools.is_empty() {
                 None
             } else {
-                Some(self.extra.tools.clone())
+                Some(self.tools.clone())
             },
         );
 
         let rendered_chat = if handled {
-            self.extra
-                .chat_template
-                .render(messages, &template_context)?
+            self.chat_template.render(messages, &template_context)?
         } else {
-            self.extra
-                .chat_template
+            self.chat_template
                 .render_unhandled(messages, &template_context)?
         };
 
         let bitmaps: Vec<&MtmdBitmap> = self
-            .extra
             .messages
             .iter()
             .flat_map(|msg| msg.assets())
-            .filter_map(|asset| self.extra.context.bitmaps.get(&asset.id))
+            .filter_map(|asset| self.context.bitmaps.get(&asset.id))
             .collect();
-        Ok(self.tokenizer.tokenize(rendered_chat, bitmaps)?)
+        Ok(self.engine.tokenizer.tokenize(rendered_chat, bitmaps)?)
     }
 
     fn wrapped_update_context_and_generate_response<F>(
@@ -1724,17 +1815,7 @@ impl Worker<'_, ChatWorker> {
         let (wrapped_respond, resp_receiver) = wrap_respond(respond.clone(), tool_call_begin_token);
 
         // llm go brrr
-        self.generate_response_until_done(
-            sampler,
-            wrapped_respond,
-            &inference_lock_token,
-            |worker, tokens_written, lock| {
-                worker.context_shift()?;
-                worker.sync_context_with_render(lock)?;
-                worker.read_chunks(tokens_written.clone(), lock)?;
-                Ok(())
-            },
-        )?;
+        self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
 
         Ok(resp_receiver.recv()?)
     }
@@ -1744,14 +1825,14 @@ impl Worker<'_, ChatWorker> {
         system_prompt: Option<String>,
         tools: Vec<Tool>,
     ) -> Result<(), SelectTemplateError> {
-        self.reset_context();
+        self.engine.reset_context();
 
         // Detect tool format if not already detected and tools are provided
-        if !tools.is_empty() && self.extra.tool_format.is_none() {
-            match detect_tool_format(self.ctx.model) {
+        if !tools.is_empty() && self.tool_format.is_none() {
+            match detect_tool_format(self.engine.ctx.model) {
                 Ok(format) => {
                     debug!(format = ?format, "Detected tool calling format");
-                    self.extra.tool_format = Some(format);
+                    self.tool_format = Some(format);
                 }
                 Err(e) => {
                     debug!(error = %e, "Failed to detect tool format, tools will not work");
@@ -1759,8 +1840,8 @@ impl Worker<'_, ChatWorker> {
             }
         }
 
-        self.extra.tool_grammar = if !tools.is_empty() {
-            if let Some(ref format) = self.extra.tool_format {
+        self.tool_grammar = if !tools.is_empty() {
+            if let Some(ref format) = self.tool_format {
                 match format.generate_grammar(&tools) {
                     Ok(g) => Some(g),
                     Err(e) => {
@@ -1774,9 +1855,9 @@ impl Worker<'_, ChatWorker> {
         } else {
             None
         };
-        self.extra.tools = tools;
-        self.extra.messages = Vec::new();
-        self.extra.context = ChatContext::new();
+        self.tools = tools;
+        self.messages = Vec::new();
+        self.context = ChatContext::new();
         if let Some(sys_msg) = system_prompt {
             self.add_system_message(sys_msg);
         }
@@ -1789,7 +1870,7 @@ impl Worker<'_, ChatWorker> {
         name: String,
         value: bool,
     ) -> Result<(), ChatWorkerError> {
-        self.extra.template_variables.insert(name, value);
+        self.template_variables.insert(name, value);
         Ok(())
     }
 
@@ -1798,17 +1879,17 @@ impl Worker<'_, ChatWorker> {
         &mut self,
         variables: std::collections::HashMap<String, bool>,
     ) -> Result<(), ChatWorkerError> {
-        self.extra.template_variables = variables;
+        self.template_variables = variables;
         Ok(())
     }
 
     /// Get all template variables.
     pub fn get_template_variables(&self) -> std::collections::HashMap<String, bool> {
-        self.extra.template_variables.clone()
+        self.template_variables.clone()
     }
 
     pub fn set_sampler_config(&mut self, sampler_config: SamplerConfig) {
-        self.extra.sampler_config = sampler_config;
+        self.sampler_config = sampler_config;
     }
 
     pub fn set_system_prompt(
@@ -1818,17 +1899,17 @@ impl Worker<'_, ChatWorker> {
         match system_prompt {
             Some(sys_msg) => {
                 let system_message = Message::System { content: sys_msg };
-                if self.extra.messages.is_empty() {
-                    self.extra.messages.push(system_message);
-                } else if self.extra.messages[0].is_system() {
-                    self.extra.messages[0] = system_message;
+                if self.messages.is_empty() {
+                    self.messages.push(system_message);
+                } else if self.messages[0].is_system() {
+                    self.messages[0] = system_message;
                 } else {
-                    self.extra.messages.insert(0, system_message);
+                    self.messages.insert(0, system_message);
                 }
             }
             None => {
-                if !self.extra.messages.is_empty() && self.extra.messages[0].is_system() {
-                    self.extra.messages.remove(0);
+                if !self.messages.is_empty() && self.messages[0].is_system() {
+                    self.messages.remove(0);
                 }
             }
         }
@@ -1837,10 +1918,10 @@ impl Worker<'_, ChatWorker> {
     }
 
     pub fn get_system_prompt(&self) -> Option<String> {
-        if self.extra.messages.is_empty() {
+        if self.messages.is_empty() {
             return None;
         };
-        match &self.extra.messages[0] {
+        match &self.messages[0] {
             Message::System { content } => Some(content.clone()),
             _ => None,
         }
@@ -1848,11 +1929,11 @@ impl Worker<'_, ChatWorker> {
 
     pub fn set_tools(&mut self, tools: Vec<Tool>) -> Result<(), SetToolsError> {
         // Detect tool format if not already detected and tools are provided
-        if !tools.is_empty() && self.extra.tool_format.is_none() {
-            match detect_tool_format(self.ctx.model) {
+        if !tools.is_empty() && self.tool_format.is_none() {
+            match detect_tool_format(self.engine.ctx.model) {
                 Ok(format) => {
                     debug!(format = ?format, "Detected tool calling format");
-                    self.extra.tool_format = Some(format);
+                    self.tool_format = Some(format);
                 }
                 Err(e) => {
                     debug!(error = %e, "Failed to detect tool format, tools will not work");
@@ -1860,8 +1941,8 @@ impl Worker<'_, ChatWorker> {
             }
         }
 
-        self.extra.tool_grammar = if !tools.is_empty() {
-            if let Some(ref format) = self.extra.tool_format {
+        self.tool_grammar = if !tools.is_empty() {
+            if let Some(ref format) = self.tool_format {
                 match format.generate_grammar(&tools) {
                     Ok(g) => Some(g),
                     Err(e) => {
@@ -1875,21 +1956,21 @@ impl Worker<'_, ChatWorker> {
         } else {
             None
         };
-        self.extra.tools = tools;
+        self.tools = tools;
 
-        self.extra.chat_template = select_template(self.ctx.model, !self.extra.tools.is_empty())?;
+        self.chat_template = select_template(self.engine.ctx.model, !self.tools.is_empty())?;
 
         Ok(())
     }
 
     pub fn set_chat_history(&mut self, messages: Vec<Message>) -> Result<(), ContextSyncError> {
         // get system prompt, if it is there
-        let system_msg: Option<Message> = match self.extra.messages.as_slice() {
+        let system_msg: Option<Message> = match self.messages.as_slice() {
             [msg @ Message::System { .. }, ..] => Some(msg.clone()),
             _ => None,
         };
 
-        self.extra.messages = system_msg.into_iter().chain(messages).collect();
+        self.messages = system_msg.into_iter().chain(messages).collect();
 
         // We used to call sync_context_with_render here but this can
         // crash as some chat templates will attempt to access fields on
@@ -1897,27 +1978,25 @@ impl Worker<'_, ChatWorker> {
         // sync with an empty render and we only render when there are
         // messages present in the history.
 
-        self.extra
-            .context
-            .garbage_collect_bitmaps(&self.extra.messages);
+        self.context.garbage_collect_bitmaps(&self.messages);
 
         Ok(())
     }
 
     pub fn get_chat_history(&self) -> Vec<Message> {
-        match self.extra.messages.as_slice() {
+        match self.messages.as_slice() {
             [Message::System { .. }, rest @ ..] => rest.to_vec(),
-            _ => self.extra.messages.clone(),
+            _ => self.messages.clone(),
         }
     }
 
     pub fn get_sampler_config(&self) -> SamplerConfig {
-        self.extra.sampler_config.clone()
+        self.sampler_config.clone()
     }
 
     pub fn tokenize(&mut self, prompt: Prompt) -> Result<Vec<Option<i32>>, TokenizeError> {
         let media_assets = prompt.extract_media_assets();
-        let bitmaps = if let Some(projection_model) = self.projection_model.as_ref() {
+        let bitmaps = if let Some(projection_model) = self.engine.projection_model.as_ref() {
             media_assets
                 .iter()
                 .map(|part| match part {
@@ -1931,7 +2010,7 @@ impl Worker<'_, ChatWorker> {
         };
 
         let bitmap_refs: Vec<&MtmdBitmap> = bitmaps.iter().collect();
-        let chunks = self.tokenizer.tokenize(prompt.to_string(), bitmap_refs)?;
+        let chunks = self.engine.tokenizer.tokenize(prompt.to_string(), bitmap_refs)?;
         Ok(chunks.to_token_ids())
     }
 }
@@ -1992,7 +2071,7 @@ mod tests {
         // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 n_ctx: 1024,
@@ -2028,7 +2107,7 @@ mod tests {
     fn test_reset_chat() -> Result<(), Box<dyn std::error::Error>> {
         // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 system_prompt: Some("You're a dog. End all responses with 'woof'".into()),
@@ -2070,7 +2149,7 @@ mod tests {
     fn test_stop_mid_write() -> Result<(), Box<dyn std::error::Error>> {
         // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 system_prompt: Some("You are a counter, only outputting numbers".into()),
@@ -2079,7 +2158,7 @@ mod tests {
             },
             Arc::new(AtomicBool::new(false)),
         )?;
-        let should_stop = worker.extra.should_stop.clone();
+        let should_stop = worker.should_stop.clone();
 
         // ensure that the generationworker resets the flag when creating a new response.
         should_stop.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -2176,7 +2255,7 @@ mod tests {
     fn test_tool_chat() {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 system_prompt: Some("You're a helpful assistant.".into()),
@@ -2205,7 +2284,7 @@ mod tests {
 
         let result = receiver.recv().unwrap();
         println!("{}", result);
-        println!("{}", worker.extra.tool_grammar.unwrap().as_str());
+        println!("{}", worker.tool_grammar.unwrap().as_str());
         assert!(result.contains("13.37"));
         assert!(result.contains("42.69"));
     }
@@ -2214,7 +2293,7 @@ mod tests {
     fn test_multi_tool_call() {
         test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 tools: vec![test_tool(), dkk_exchange_rate()],
@@ -2292,7 +2371,7 @@ mod tests {
         // Use a very small context size to force shifting
         let n_ctx = 512;
         let n_messages = 8;
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 n_ctx,
@@ -2317,7 +2396,7 @@ mod tests {
         worker.add_user_message("Hello!".into(), vec![]);
 
         // Check that we have many messages before shift
-        let messages_before = worker.extra.messages.len();
+        let messages_before = worker.messages.len();
         assert!(
             messages_before > 6,
             "Should have more than 6 messages before shift"
@@ -2326,9 +2405,9 @@ mod tests {
         // Trigger context shift
         worker.context_shift()?;
 
-        println!("{:?}", worker.extra.messages);
+        println!("{:?}", worker.messages);
 
-        let messages_after = worker.extra.messages.clone();
+        let messages_after = worker.messages.clone();
 
         // Verify essential messages are preserved:
         // 1. System prompt should be first
@@ -2404,7 +2483,7 @@ mod tests {
         // Use a very small context size to force shifting
         let n_ctx = 1024;
         let n_messages = 10;
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 n_ctx,
@@ -2444,15 +2523,15 @@ mod tests {
         worker.add_user_message("Final question!".into(), vec![]);
 
         // Check that we have many messages before shift
-        let messages_before = worker.extra.messages.len();
+        let messages_before = worker.messages.len();
         println!("Messages before shift: {}", messages_before);
 
         // Trigger context shift
         worker.context_shift()?;
 
-        println!("{:?}", worker.extra.messages);
+        println!("{:?}", worker.messages);
 
-        let messages_after = worker.extra.messages.clone();
+        let messages_after = worker.messages.clone();
 
         // Verify essential messages are preserved:
         // 1. System prompt should be first
@@ -2518,7 +2597,7 @@ mod tests {
         let n_messages = 14;
         // n_messages is chosen by trial and error. This exactly fills up the
         // the context so much that the next user message cannot be read and a context shift happens.
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 system_prompt: Some("You are a helpful assistant.".into()),
@@ -2537,7 +2616,7 @@ mod tests {
             worker.add_assistant_message(format!("The answer is {}.", i * i));
         }
 
-        let messages_before_shift = worker.extra.messages.len();
+        let messages_before_shift = worker.messages.len();
         println!("Messages before shift: {}", messages_before_shift);
 
         let (sender, receiver) = std::sync::mpsc::channel();
@@ -2554,7 +2633,7 @@ mod tests {
         )?;
 
         let _response = receiver.recv()?;
-        let messages_after = worker.extra.messages.clone();
+        let messages_after = worker.messages.clone();
 
         println!("Messages after operation: {}", messages_after.len());
 
@@ -2601,7 +2680,7 @@ mod tests {
         // the context so much that the next assistant message cannot be fully written.
         // The same is true for n_ctx. It needs to be large enough to where n_ctx/2 is large enough
         // to contain the response but also small enough to fill easily and test wihtout being to slow.
-        let mut worker = Worker::new_chat_worker(
+        let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
                 n_ctx: 768, // Use a small context size to force shifting
@@ -2620,7 +2699,7 @@ mod tests {
             worker.add_assistant_message(format!("The answer is {}.", i * i));
         }
 
-        let messages_before_shift = worker.extra.messages.len();
+        let messages_before_shift = worker.messages.len();
         println!("Messages before shift: {}", messages_before_shift);
 
         let (sender, receiver) = std::sync::mpsc::channel();
@@ -2634,7 +2713,7 @@ mod tests {
         worker.ask("What is 10 * 10?".into(), f)?;
 
         let _response = receiver.recv()?;
-        let messages_after = worker.extra.messages.clone();
+        let messages_after = worker.messages.clone();
 
         println!("Messages after operation: {}", messages_after.len());
 

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -162,7 +162,8 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         // Get CLS and SEP tokens from the model (CLS = BOS per llama.cpp, the current CLS token is deprecated.)
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let cls = self
-            .engine.ctx
+            .engine
+            .ctx
             .model
             .token_to_piece(self.engine.ctx.model.token_bos(), &mut decoder, true, None)
             .unwrap_or_else(|_| {
@@ -171,7 +172,8 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
             });
 
         let sep = self
-            .engine.ctx
+            .engine
+            .ctx
             .model
             .token_to_piece(self.engine.ctx.model.token_sep(), &mut decoder, true, None)
             .unwrap_or_else(|_| {

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -145,7 +145,7 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         // For crossencodering, all tokens have embeddings enabled (logits=true) but only the final token's
         // embedding contains the relevance score. embeddings_seq_ith(0) gets the sequence's embedding
         // vector, and embeddings[0] extracts the classification score from the final token.
-        let embeddings = self.ctx.embeddings_seq_ith(0)?;
+        let embeddings = self.engine.ctx.embeddings_seq_ith(0)?;
 
         if !embeddings.is_empty() {
             Ok(embeddings[0])
@@ -162,18 +162,18 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         // Get CLS and SEP tokens from the model (CLS = BOS per llama.cpp, the current CLS token is deprecated.)
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let cls = self
-            .ctx
+            .engine.ctx
             .model
-            .token_to_piece(self.ctx.model.token_bos(), &mut decoder, true, None)
+            .token_to_piece(self.engine.ctx.model.token_bos(), &mut decoder, true, None)
             .unwrap_or_else(|_| {
                 warn!("Failed to convert BOS/CLS token to string, using fallback");
                 "<s>".to_string()
             });
 
         let sep = self
-            .ctx
+            .engine.ctx
             .model
-            .token_to_piece(self.ctx.model.token_sep(), &mut decoder, true, None)
+            .token_to_piece(self.engine.ctx.model.token_sep(), &mut decoder, true, None)
             .unwrap_or_else(|_| {
                 warn!("Failed to convert SEP token to string, using fallback");
                 "</s>".to_string()

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -111,7 +111,7 @@ impl<'a> Worker<'a, EncoderWorker> {
     }
 
     pub fn get_embedding(&self) -> Result<Vec<f32>, llama_cpp_2::EmbeddingsError> {
-        Ok(self.ctx.embeddings_seq_ith(0)?.to_vec())
+        Ok(self.engine.ctx.embeddings_seq_ith(0)?.to_vec())
     }
 }
 

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -597,6 +597,9 @@ pub enum MultimodalError {
     #[error("Multimodal context not initialized. Use with_mmproj() when building ChatHandle.")]
     ContextNotInitialized,
 
+    #[error("Projection model not initialized. Use with_mmproj() when building ChatHandle.")]
+    ProjectionModelNotInitialized,
+
     #[error("Failed to set chunk ID for bitmap: {0}")]
     FailedToSetBitmapId(#[from] std::ffi::NulError),
 }

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,32 +1,190 @@
 //! Generic inference pipeline, independent of chat history.
 
-use crate::errors::{ContextSyncError, DecodingError, GenerateResponseError};
-use crate::llm::{PoolingType, Worker, WriteOutput};
-use crate::sampler::SamplerConfig;
-use crate::tokenizer::{find_chunks_prefix_difference, TokenizerChunk, TokenizerChunks};
-use lazy_static::lazy_static;
+use crate::errors::{ContextSyncError, DecodingError, ReadError};
+use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
+use crate::tokenizer::{
+    find_chunks_prefix_difference, ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks,
+};
+use llama_cpp_2::context::kv_cache::KvCacheConversionError;
+use llama_cpp_2::context::LlamaContext;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
-use std::sync::{Mutex, MutexGuard};
-use tracing::{debug, info, trace, trace_span};
-
-#[derive(Debug)]
-pub(crate) struct GlobalInferenceLockToken;
-
-lazy_static! {
-    static ref GLOBAL_INFERENCE_LOCK: Mutex<GlobalInferenceLockToken> =
-        Mutex::new(GlobalInferenceLockToken);
-}
+use std::rc::Rc;
+use std::sync::MutexGuard;
+use tracing::{debug, debug_span, trace, trace_span, warn};
 
 pub(crate) fn acquire_inference_lock() -> MutexGuard<'static, GlobalInferenceLockToken> {
     GLOBAL_INFERENCE_LOCK.lock().unwrap()
 }
 
-pub(crate) trait Generate {
-    fn should_stop(&self) -> bool;
+/// The low-level inference state for a single llama.cpp context.
+///
+/// Holds everything needed to read tokens/media into the KV cache and sample new tokens,
+/// independent of any higher-level concept like chat history. Both `Worker` (encoder /
+/// crossencoder) and `Chat` own one of these.
+#[derive(Debug)]
+pub(crate) struct InferenceEngine<'a> {
+    pub(crate) n_past: i32,
+    pub(crate) ctx: LlamaContext<'a>,
+    pub(crate) big_batch: LlamaBatch<'a>,
+    pub(crate) small_batch: LlamaBatch<'a>,
+    pub(crate) projection_model: Option<&'a ProjectionModel>,
+    pub(crate) tokenizer: Tokenizer<'a>,
+    pub(crate) use_embeddings: bool,
+    // The configured n_batch (= planned n_ctx before llama.cpp's internal rounding).
+    // Used to guard against sending more tokens than the context can decode in one batch.
+    pub(crate) n_batch: usize,
 }
 
-impl<'a, T: Generate + PoolingType> Worker<'a, T> {
+impl<'a> InferenceEngine<'a> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub(crate) fn reset_context(&mut self) -> &mut Self {
+        self.ctx.clear_kv_cache();
+        self.n_past = 0;
+        self
+    }
+
+    pub(crate) fn read_chunks(
+        &mut self,
+        chunks: TokenizerChunks,
+        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+    ) -> Result<&mut Self, ReadError> {
+        for chunk in chunks.into_iter() {
+            match chunk {
+                TokenizerChunk::Text(tokens, _) => {
+                    self.read_text_tokens(tokens, inference_lock_token)?;
+                }
+                TokenizerChunk::Image(embeddings, _) | TokenizerChunk::Audio(embeddings, _) => {
+                    self.read_media_embeddings(embeddings, inference_lock_token)?;
+                }
+            }
+        }
+
+        Ok(self)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn read_media_embeddings(
+        &mut self,
+        embeddings: Rc<MtmdInputChunks>,
+        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+    ) -> Result<&mut Self, ReadError> {
+        let projection_model = self
+            .projection_model
+            .as_ref()
+            .ok_or(ReadError::ProjectionModelNotInitialized)?;
+
+        let n_tokens = embeddings.as_ref().total_tokens();
+        debug!(n_tokens, "Reading media embeddings:");
+
+        let decode_span = debug_span!("read media embeddings", n_tokens = n_tokens);
+        let decode_guard = decode_span.enter();
+        let n_ctx = self.ctx.n_ctx() as i32;
+        self.n_past = embeddings.eval_chunks(
+            &projection_model.ctx,
+            &self.ctx,
+            self.n_past,
+            0,
+            n_ctx,
+            true,
+        )?;
+
+        drop(decode_guard);
+        debug!(
+            "Completed read media embeddings operation, n_past: {}",
+            self.n_past
+        );
+
+        Ok(self)
+    }
+
+    // ---------- IMPORTANT ----------
+    // Should only be used under a global inference lock
+    // This is a safety meassure to prevent bugs from multiple
+    // contexts with the same model. It might not be necessary
+    // but assume it is.
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn read_text_tokens(
+        &mut self,
+        tokens: Vec<LlamaToken>,
+        _inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+    ) -> Result<&mut Self, ReadError> {
+        let n_tokens = tokens.len();
+        debug!(n_tokens, "Reading tokens:");
+
+        // can't read nothing
+        debug_assert!(!tokens.is_empty());
+
+        if n_tokens > self.n_batch {
+            return Err(ReadError::InputExceedsContext {
+                n_tokens,
+                n_ctx: self.n_batch,
+            });
+        }
+
+        {
+            debug!("Populating batch");
+            // make batch
+            self.big_batch.clear();
+            let seq_ids = &[0];
+            for (i, token) in (0..).zip(tokens.iter()) {
+                // For LLM workers only the last token's logits are needed (sampling).
+                // For encoder workers every token must be marked as an output so the
+                // pooling layer has hidden states to work with — otherwise llama.cpp
+                // logs "embeddings required but some input tokens were not marked as
+                // outputs -> overriding" and silently flips them on for us.
+                let output_logits = self.use_embeddings || i == n_tokens - 1;
+                self.big_batch
+                    .add(*token, self.n_past + i as i32, seq_ids, output_logits)?;
+            }
+        }
+
+        // llm go brr
+        let decode_span = debug_span!("read decode", n_tokens = n_tokens);
+        let decode_guard = decode_span.enter();
+        self.ctx.decode(&mut self.big_batch)?;
+        drop(decode_guard);
+        // brrr
+
+        self.n_past += tokens.len() as i32;
+
+        debug!("Completed read tokens operation, n_past: {}", self.n_past);
+
+        Ok(self)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub(crate) fn remove_all_tokens_from_index_from_ctx(
+        &mut self,
+        index: usize,
+    ) -> Result<i32, KvCacheConversionError> {
+        if self.n_past <= index as i32 {
+            return Ok(0);
+        }
+
+        let before = self.n_past;
+        let seq_rm_success = self
+            .ctx
+            .clear_kv_cache_seq(Some(0), Some(index as u32), None)?;
+
+        if seq_rm_success {
+            self.n_past = index as i32;
+        } else {
+            // Partial sequence removal is not supported by this model's memory type
+            // (e.g. hybrid models with recurrent components). Fall back to full reset.
+            warn!(
+                index,
+                n_past = self.n_past,
+                "Partial KV cache removal not supported, falling back to full context reset"
+            );
+            self.reset_context();
+        }
+
+        Ok(before - self.n_past)
+    }
+
     /// Diff `target` chunks against `prev` and load only the new tail into the KV cache.
     /// Returns the new KV-cache mirror; the caller is responsible for storing it.
     pub(crate) fn sync_context(
@@ -72,94 +230,6 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
         self.n_past += 1;
 
         Ok(new_token)
-    }
-
-    /// Run the token-generation loop until EOG or the stop flag.
-    ///
-    /// `on_context_full` is called when the KV cache fills up mid-generation. Chat passes a
-    /// closure that does `context_shift` + re-sync + re-read of already-written tokens.
-    /// A stateless caller can pass a closure that immediately returns `Err(...)`.
-    pub(crate) fn generate_response_until_done<F, H>(
-        &mut self,
-        sampler_config: SamplerConfig,
-        mut respond: F,
-        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
-        mut on_context_full: H,
-    ) -> Result<&mut Self, GenerateResponseError>
-    where
-        F: FnMut(WriteOutput),
-        H: FnMut(
-            &mut Worker<'a, T>,
-            &TokenizerChunks,
-            &MutexGuard<'_, GlobalInferenceLockToken>,
-        ) -> Result<(), GenerateResponseError>,
-    {
-        info!("Worker writing until done");
-
-        let mut full_response: String = String::with_capacity(4096);
-        let mut tokens_written_until_now = TokenizerChunks::new();
-
-        let mut sampler = sampler_config.to_stateful(self.ctx.model)?;
-        let mut decoder = encoding_rs::UTF_8.new_decoder();
-
-        while !self.extra.should_stop() {
-            if self.n_past as u32 == self.ctx.n_ctx() {
-                on_context_full(self, &tokens_written_until_now, inference_lock_token)?;
-            }
-
-            // Do not use sampler.accept — it crashes with grammar sampling.
-            // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let new_token = self.sample_and_decode_next_token(&mut sampler)?;
-
-            tokens_written_until_now.append(TokenizerChunk::new_text(vec![new_token]));
-
-            let token_bytes = match self
-                .ctx
-                .model
-                .token_to_piece_bytes(new_token, 8, true, None)
-            {
-                Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
-                    self.ctx.model.token_to_piece_bytes(
-                        new_token,
-                        (-i).try_into().expect("Error buffer size is positive"),
-                        true,
-                        None,
-                    )
-                }
-                x => x,
-            }?;
-
-            let max_len = decoder
-                .max_utf8_buffer_length(token_bytes.len())
-                .unwrap_or(32);
-            let mut token_str = String::with_capacity(max_len);
-
-            // Partial unicode: the decoder retains incomplete codepoints across calls.
-            let (_result, _bytes_read, _had_errors) =
-                decoder.decode_to_string(&token_bytes, &mut token_str, false);
-
-            // XXX: gemma4 hotfix — some gemma4 models emit a wrong EOS token after tool calls
-            // that llama.cpp's is_eog_token does not catch, causing an infinite generation loop.
-            // vllm handles the same case: https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
-            let gemma4_eog_hotfix = token_str == "<eos>" && new_token == LlamaToken::new(1);
-
-            let has_eog = self.ctx.model.is_eog_token(new_token) || gemma4_eog_hotfix;
-            trace!(?new_token, ?token_str, ?has_eog);
-
-            if !has_eog {
-                full_response.push_str(&token_str);
-                trace!(?token_str, "Sending out token:");
-                respond(WriteOutput::Token(token_str.to_string()));
-            }
-
-            if has_eog {
-                break;
-            }
-        }
-
-        debug!(%full_response, "Sending out");
-        respond(WriteOutput::Done(full_response));
-        Ok(self)
     }
 }
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,10 +1,12 @@
 //! Generic inference pipeline, independent of chat history.
 
-use crate::errors::{ContextSyncError, DecodingError, ReadError};
+use crate::errors::{ContextSyncError, DecodingError, MultimodalError, ReadError};
 use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
 use crate::tokenizer::{
     find_chunks_prefix_difference, ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks,
 };
+use llama_cpp_2::mtmd::MtmdBitmap;
+use std::path::Path;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_batch::LlamaBatch;
@@ -26,19 +28,40 @@ pub(crate) fn acquire_inference_lock() -> MutexGuard<'static, GlobalInferenceLoc
 /// crossencoder) and `Chat` own one of these.
 #[derive(Debug)]
 pub(crate) struct InferenceEngine<'a> {
-    pub(crate) n_past: i32,
     pub(crate) ctx: LlamaContext<'a>,
-    pub(crate) big_batch: LlamaBatch<'a>,
-    pub(crate) small_batch: LlamaBatch<'a>,
-    pub(crate) projection_model: Option<&'a ProjectionModel>,
-    pub(crate) tokenizer: Tokenizer<'a>,
-    pub(crate) use_embeddings: bool,
+    projection_model: Option<&'a ProjectionModel>,
+    n_past: i32,
+    tokenizer: Tokenizer<'a>,
     // The configured n_batch (= planned n_ctx before llama.cpp's internal rounding).
     // Used to guard against sending more tokens than the context can decode in one batch.
-    pub(crate) n_batch: usize,
+    n_batch: usize,
+    big_batch: LlamaBatch<'a>,
+    small_batch: LlamaBatch<'a>,
+    use_embeddings: bool,
 }
 
 impl<'a> InferenceEngine<'a> {
+    pub(crate) fn new(
+        ctx: LlamaContext<'a>,
+        big_batch: LlamaBatch<'a>,
+        small_batch: LlamaBatch<'a>,
+        projection_model: Option<&'a ProjectionModel>,
+        n_batch: usize,
+        tokenizer: Tokenizer<'a>,
+        use_embeddings: bool,
+    ) -> Self {
+        Self {
+            n_past: 0,
+            ctx,
+            big_batch,
+            small_batch,
+            projection_model,
+            n_batch,
+            tokenizer,
+            use_embeddings,
+        }
+    }
+
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn reset_context(&mut self) -> &mut Self {
         self.ctx.clear_kv_cache();
@@ -211,6 +234,36 @@ impl<'a> InferenceEngine<'a> {
         }
 
         Ok(target)
+    }
+
+    pub(crate) fn n_past(&self) -> u32 {
+        self.n_past as u32
+    }
+
+    pub(crate) fn is_context_full(&self) -> bool {
+        self.n_past as u32 == self.ctx.n_ctx()
+    }
+
+    pub(crate) fn tokenize(
+        &self,
+        text: String,
+        bitmaps: Vec<&MtmdBitmap>,
+    ) -> Result<TokenizerChunks, crate::errors::TokenizationError> {
+        self.tokenizer.tokenize(text, bitmaps)
+    }
+
+    pub(crate) fn load_image(&self, path: &Path) -> Result<MtmdBitmap, MultimodalError> {
+        self.projection_model
+            .as_ref()
+            .ok_or(MultimodalError::ProjectionModelNotInitialized)?
+            .load_image(path)
+    }
+
+    pub(crate) fn load_audio(&self, path: &Path) -> Result<MtmdBitmap, MultimodalError> {
+        self.projection_model
+            .as_ref()
+            .ok_or(MultimodalError::ProjectionModelNotInitialized)?
+            .load_audio(path)
     }
 
     pub(crate) fn sample_and_decode_next_token(

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -39,21 +39,17 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
 
         debug_assert!(!target.is_empty());
 
-        // remove_all_tokens_from_index_from_ctx may remove more tokens than prefix_index alone;
-        // it updates self.n_past to the count of tokens still in the KV cache afterward.
-        let old_n_past = self.n_past;
-        self.remove_all_tokens_from_index_from_ctx(prefix_index)?;
+        let trimmed = self.remove_all_tokens_from_index_from_ctx(prefix_index)?;
 
         let chunks_to_read = target.tail(self.n_past as usize);
         if chunks_to_read.n_tokens() > 0 {
             self.read_chunks(chunks_to_read, inference_lock_token)?;
-        } else if self.n_past < old_n_past {
+        } else if trimmed > 0 {
             // Truncate-only: KV cache was trimmed but no new tokens need appending.
             // Re-decode the last token to refresh stale logits — llama.cpp requires
             // consecutive positions so we must evict it before re-reading.
             self.remove_all_tokens_from_index_from_ctx(self.n_past as usize - 1)?;
-            let refresh_tokens = target.tail(self.n_past as usize);
-            self.read_chunks(refresh_tokens, inference_lock_token)?;
+            self.read_chunks(target.tail(self.n_past as usize), inference_lock_token)?;
         }
 
         Ok(target)

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,0 +1,231 @@
+//! Generic inference pipeline shared by all worker types.
+//!
+//! This module contains the inference primitives that are independent of chat history:
+//! - KV-cache synchronisation (`sync_context`)
+//! - Token sampling and decoding (`sample_and_decode_next_token`)
+//! - The generation loop (`generate_response_until_done`)
+//! - Stream helper (`wrap_respond`)
+//!
+//! `ChatWorker` (and future stateless workers) layer their own state management on top of
+//! these primitives. Neither the trait nor the impl block knows about message history,
+//! context shifting, or tool calling.
+
+use crate::errors::{ContextSyncError, DecodingError, GenerateResponseError};
+use crate::llm::{GlobalInferenceLockToken, PoolingType, Worker, WriteOutput};
+use crate::sampler::SamplerConfig;
+use crate::tokenizer::{find_chunks_prefix_difference, TokenizerChunk, TokenizerChunks};
+use llama_cpp_2::sampling::LlamaSampler;
+use llama_cpp_2::token::LlamaToken;
+use std::sync::MutexGuard;
+use tracing::{debug, info, trace, trace_span};
+
+/// Implemented by any worker payload that supports stop-flag-based interruption of the
+/// generation loop.
+pub(crate) trait Generate {
+    fn should_stop(&self) -> bool;
+}
+
+impl<'a, T: Generate + PoolingType> Worker<'a, T> {
+    /// Diff `target` chunks against `prev` (the KV-cache mirror stored by the caller) and load
+    /// only the new tail into the KV cache. Returns the new mirror; the caller is responsible for
+    /// storing it.
+    ///
+    /// This function does **not** render messages, call context_shift, or handle any chat-specific
+    /// concerns — those are the caller's responsibility.
+    pub(crate) fn sync_context(
+        &mut self,
+        target: TokenizerChunks,
+        prev: &TokenizerChunks,
+        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+    ) -> Result<TokenizerChunks, ContextSyncError> {
+        let prefix_index = find_chunks_prefix_difference(prev, &target);
+
+        // We should never try to sync with an empty render.
+        debug_assert!(!target.is_empty());
+
+        // remove_all_tokens_from_index_from_ctx may remove more than just the tokens from
+        // prefix_index; it updates self.n_past to indicate the number of tokens still in context.
+        let old_n_past = self.n_past;
+        self.remove_all_tokens_from_index_from_ctx(prefix_index)?;
+
+        // Use n_past as the actual preserved prefix — may be 0 if a full reset was required
+        // (e.g. hybrid/recurrent models that don't support partial seq_rm).
+        let chunks_to_read = target.tail(self.n_past as usize);
+        if chunks_to_read.n_tokens() > 0 {
+            self.read_chunks(chunks_to_read, inference_lock_token)?;
+        } else if self.n_past < old_n_past {
+            // Truncate-only path: the KV cache was trimmed but no new tokens need to be appended.
+            // Re-decode the last remaining token to refresh the logits buffer, which would
+            // otherwise contain stale values from whatever the previous decode() call was.
+            // llama.cpp requires strictly consecutive positions (Y = X + 1), so we must remove
+            // the last token from the KV cache before we can re-decode it.
+            self.remove_all_tokens_from_index_from_ctx(self.n_past as usize - 1)?;
+            let refresh_tokens = target.tail(self.n_past as usize);
+            self.read_chunks(refresh_tokens, inference_lock_token)?;
+        }
+
+        Ok(target)
+    }
+
+    pub(crate) fn sample_and_decode_next_token(
+        &mut self,
+        sampler: &mut LlamaSampler,
+    ) -> Result<LlamaToken, DecodingError> {
+        trace!("Applying sampler");
+        let new_token: LlamaToken = sampler.sample(&self.ctx, -1);
+
+        // batch of one
+        self.small_batch.clear();
+        self.small_batch.add(new_token, self.n_past, &[0], true)?;
+
+        // llm go brr
+        let decode_span = trace_span!("write decode", n_past = self.n_past);
+        let decode_guard = decode_span.enter();
+        self.ctx.decode(&mut self.small_batch)?;
+        drop(decode_guard);
+        self.n_past += 1; // keep count
+
+        Ok(new_token)
+    }
+
+    /// Run the token-generation loop until an end-of-generation token is produced or the stop
+    /// flag is set.
+    ///
+    /// `on_context_full` is called when the KV cache fills up mid-generation. Chat passes a
+    /// closure that performs `context_shift` + re-sync + re-read of already-written tokens.
+    /// A future stateless caller can pass a closure that returns `Err(...)` immediately.
+    pub(crate) fn generate_response_until_done<F, H>(
+        &mut self,
+        sampler_config: SamplerConfig,
+        mut respond: F,
+        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
+        mut on_context_full: H,
+    ) -> Result<&mut Self, GenerateResponseError>
+    where
+        F: FnMut(WriteOutput),
+        H: FnMut(
+            &mut Worker<'a, T>,
+            &TokenizerChunks,
+            &MutexGuard<'_, GlobalInferenceLockToken>,
+        ) -> Result<(), GenerateResponseError>,
+    {
+        // Token generation loop
+        info!("Worker writing until done");
+
+        // pre-allocating 4096 bytes for the response string
+        // 4096 is a very randomly chosen number. how does this affect performance?
+        let mut full_response: String = String::with_capacity(4096);
+        let mut tokens_written_until_now = TokenizerChunks::new();
+
+        // initialize sampler
+        // stateful samplers only live for one response
+        let mut sampler = sampler_config.to_stateful(self.ctx.model)?;
+
+        // init stateful decoder for split up tokens like emojis
+        let mut decoder = encoding_rs::UTF_8.new_decoder();
+
+        while !self.extra.should_stop() {
+            // Check if the context is full
+            if self.n_past as u32 == self.ctx.n_ctx() {
+                on_context_full(self, &tokens_written_until_now, inference_lock_token)?;
+            }
+
+            // Sample next token, no need to use sampler.accept as sample already accepts the token.
+            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
+            // https://github.com/utilityai/llama-cpp-rs/issues/604
+            let new_token = self.sample_and_decode_next_token(&mut sampler)?;
+
+            tokens_written_until_now.append(TokenizerChunk::new_text(vec![new_token]));
+
+            // Attempt to convert token(s) to bytes
+            let token_bytes = match self
+                .ctx
+                .model
+                .token_to_piece_bytes(new_token, 8, true, None)
+            {
+                Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
+                    self.ctx.model.token_to_piece_bytes(
+                        new_token,
+                        (-i).try_into().expect("Error buffer size is positive"),
+                        true,
+                        None,
+                    )
+                }
+                x => x,
+            }?;
+
+            // Attempt to convert bytes to utf8 string.
+            let max_len = decoder
+                .max_utf8_buffer_length(token_bytes.len())
+                .unwrap_or(32);
+            let mut token_str = String::with_capacity(max_len);
+
+            // this is where the utf-8 decoder handles partial unicode
+            // it'll write whatever printable chars it can into `token_str`
+            // and retain partial codepoints for next decoding attempt
+            let (_result, _bytes_read, _had_errors) =
+                decoder.decode_to_string(&token_bytes, &mut token_str, false);
+
+            // XXX: this literal '<eos>' token match is a fucked hotfix for gemma4. it seems like
+            // some gemma4 models will emit a *wrong* eos token (doesn't match the expected format)
+            // after tool calls. This doesn't trigger the is_eog_token match in llama.cpp and
+            // causes a bad infinite generation loop.
+            // it seems like vllm also has a codepath to handle this specific case:
+            // https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
+            let gemma4_eog_hotfix = token_str == "<eos>" && new_token == LlamaToken::new(1);
+
+            let has_eog = self.ctx.model.is_eog_token(new_token) || gemma4_eog_hotfix;
+            trace!(?new_token, ?token_str, ?has_eog);
+
+            if !has_eog {
+                full_response.push_str(&token_str);
+                trace!(?token_str, "Sending out token:");
+                respond(WriteOutput::Token(token_str.to_string()));
+            }
+
+            if has_eog {
+                break;
+            }
+        }
+
+        // we're done!
+        debug!(%full_response, "Sending out");
+        respond(WriteOutput::Done(full_response));
+        Ok(self)
+    }
+}
+
+/// Wraps a response callback to do two things:
+/// 1. Save a copy of the completed response (via a channel) before forwarding it.
+/// 2. Stop emitting tokens to the outer callback once a `tool_call_begin_token` has been seen.
+pub(crate) fn wrap_respond<F>(
+    respond: F,
+    tool_call_begin_token: Option<String>,
+) -> (
+    impl FnMut(WriteOutput),
+    std::sync::mpsc::Receiver<String>,
+)
+where
+    F: Fn(WriteOutput),
+{
+    let (resp_sender, resp_receiver) = std::sync::mpsc::channel();
+    let mut emitting = true;
+
+    let wrapped_respond = move |x| {
+        match &x {
+            WriteOutput::Token(tok) if tool_call_begin_token.as_ref() == Some(tok) => {
+                emitting = false;
+            }
+            WriteOutput::Done(resp) => {
+                resp_sender
+                    .send(resp.clone())
+                    .expect("Failed sending response");
+            }
+            WriteOutput::Token(_) | WriteOutput::Error(_) => (),
+        }
+        if emitting {
+            respond(x)
+        }
+    };
+    (wrapped_respond, resp_receiver)
+}

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -5,14 +5,14 @@ use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
 use crate::tokenizer::{
     find_chunks_prefix_difference, ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks,
 };
-use llama_cpp_2::mtmd::MtmdBitmap;
-use std::path::Path;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
 use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::mtmd::MtmdBitmap;
 use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::MutexGuard;
 use tracing::{debug, debug_span, trace, trace_span, warn};

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,7 +1,7 @@
 //! Generic inference pipeline, independent of chat history.
 
 use crate::errors::{ContextSyncError, DecodingError, MultimodalError, ReadError};
-use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
+use crate::llm::{GlobalInferenceLockToken, GLOBAL_INFERENCE_LOCK};
 use crate::tokenizer::{
     find_chunks_prefix_difference, ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks,
 };
@@ -284,35 +284,4 @@ impl<'a> InferenceEngine<'a> {
 
         Ok(new_token)
     }
-}
-
-/// Wraps a respond callback to capture the completed response and suppress tokens after
-/// `tool_call_begin_token`.
-pub(crate) fn wrap_respond<F>(
-    respond: F,
-    tool_call_begin_token: Option<String>,
-) -> (impl FnMut(WriteOutput), std::sync::mpsc::Receiver<String>)
-where
-    F: Fn(WriteOutput),
-{
-    let (resp_sender, resp_receiver) = std::sync::mpsc::channel();
-    let mut emitting = true;
-
-    let wrapped_respond = move |x| {
-        match &x {
-            WriteOutput::Token(tok) if tool_call_begin_token.as_ref() == Some(tok) => {
-                emitting = false;
-            }
-            WriteOutput::Done(resp) => {
-                resp_sender
-                    .send(resp.clone())
-                    .expect("Failed sending response");
-            }
-            WriteOutput::Token(_) | WriteOutput::Error(_) => (),
-        }
-        if emitting {
-            respond(x)
-        }
-    };
-    (wrapped_respond, resp_receiver)
 }

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,37 +1,34 @@
-//! Generic inference pipeline shared by all worker types.
-//!
-//! This module contains the inference primitives that are independent of chat history:
-//! - KV-cache synchronisation (`sync_context`)
-//! - Token sampling and decoding (`sample_and_decode_next_token`)
-//! - The generation loop (`generate_response_until_done`)
-//! - Stream helper (`wrap_respond`)
-//!
-//! `ChatWorker` (and future stateless workers) layer their own state management on top of
-//! these primitives. Neither the trait nor the impl block knows about message history,
-//! context shifting, or tool calling.
+//! Generic inference pipeline, independent of chat history.
 
 use crate::errors::{ContextSyncError, DecodingError, GenerateResponseError};
-use crate::llm::{GlobalInferenceLockToken, PoolingType, Worker, WriteOutput};
+use crate::llm::{PoolingType, Worker, WriteOutput};
 use crate::sampler::SamplerConfig;
 use crate::tokenizer::{find_chunks_prefix_difference, TokenizerChunk, TokenizerChunks};
+use lazy_static::lazy_static;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
-use std::sync::MutexGuard;
+use std::sync::{Mutex, MutexGuard};
 use tracing::{debug, info, trace, trace_span};
 
-/// Implemented by any worker payload that supports stop-flag-based interruption of the
-/// generation loop.
+#[derive(Debug)]
+pub(crate) struct GlobalInferenceLockToken;
+
+lazy_static! {
+    static ref GLOBAL_INFERENCE_LOCK: Mutex<GlobalInferenceLockToken> =
+        Mutex::new(GlobalInferenceLockToken);
+}
+
+pub(crate) fn acquire_inference_lock() -> MutexGuard<'static, GlobalInferenceLockToken> {
+    GLOBAL_INFERENCE_LOCK.lock().unwrap()
+}
+
 pub(crate) trait Generate {
     fn should_stop(&self) -> bool;
 }
 
 impl<'a, T: Generate + PoolingType> Worker<'a, T> {
-    /// Diff `target` chunks against `prev` (the KV-cache mirror stored by the caller) and load
-    /// only the new tail into the KV cache. Returns the new mirror; the caller is responsible for
-    /// storing it.
-    ///
-    /// This function does **not** render messages, call context_shift, or handle any chat-specific
-    /// concerns — those are the caller's responsibility.
+    /// Diff `target` chunks against `prev` and load only the new tail into the KV cache.
+    /// Returns the new KV-cache mirror; the caller is responsible for storing it.
     pub(crate) fn sync_context(
         &mut self,
         target: TokenizerChunks,
@@ -40,25 +37,20 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
     ) -> Result<TokenizerChunks, ContextSyncError> {
         let prefix_index = find_chunks_prefix_difference(prev, &target);
 
-        // We should never try to sync with an empty render.
         debug_assert!(!target.is_empty());
 
-        // remove_all_tokens_from_index_from_ctx may remove more than just the tokens from
-        // prefix_index; it updates self.n_past to indicate the number of tokens still in context.
+        // remove_all_tokens_from_index_from_ctx may remove more tokens than prefix_index alone;
+        // it updates self.n_past to the count of tokens still in the KV cache afterward.
         let old_n_past = self.n_past;
         self.remove_all_tokens_from_index_from_ctx(prefix_index)?;
 
-        // Use n_past as the actual preserved prefix — may be 0 if a full reset was required
-        // (e.g. hybrid/recurrent models that don't support partial seq_rm).
         let chunks_to_read = target.tail(self.n_past as usize);
         if chunks_to_read.n_tokens() > 0 {
             self.read_chunks(chunks_to_read, inference_lock_token)?;
         } else if self.n_past < old_n_past {
-            // Truncate-only path: the KV cache was trimmed but no new tokens need to be appended.
-            // Re-decode the last remaining token to refresh the logits buffer, which would
-            // otherwise contain stale values from whatever the previous decode() call was.
-            // llama.cpp requires strictly consecutive positions (Y = X + 1), so we must remove
-            // the last token from the KV cache before we can re-decode it.
+            // Truncate-only: KV cache was trimmed but no new tokens need appending.
+            // Re-decode the last token to refresh stale logits — llama.cpp requires
+            // consecutive positions so we must evict it before re-reading.
             self.remove_all_tokens_from_index_from_ctx(self.n_past as usize - 1)?;
             let refresh_tokens = target.tail(self.n_past as usize);
             self.read_chunks(refresh_tokens, inference_lock_token)?;
@@ -74,26 +66,23 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
         trace!("Applying sampler");
         let new_token: LlamaToken = sampler.sample(&self.ctx, -1);
 
-        // batch of one
         self.small_batch.clear();
         self.small_batch.add(new_token, self.n_past, &[0], true)?;
 
-        // llm go brr
         let decode_span = trace_span!("write decode", n_past = self.n_past);
         let decode_guard = decode_span.enter();
         self.ctx.decode(&mut self.small_batch)?;
         drop(decode_guard);
-        self.n_past += 1; // keep count
+        self.n_past += 1;
 
         Ok(new_token)
     }
 
-    /// Run the token-generation loop until an end-of-generation token is produced or the stop
-    /// flag is set.
+    /// Run the token-generation loop until EOG or the stop flag.
     ///
     /// `on_context_full` is called when the KV cache fills up mid-generation. Chat passes a
-    /// closure that performs `context_shift` + re-sync + re-read of already-written tokens.
-    /// A future stateless caller can pass a closure that returns `Err(...)` immediately.
+    /// closure that does `context_shift` + re-sync + re-read of already-written tokens.
+    /// A stateless caller can pass a closure that immediately returns `Err(...)`.
     pub(crate) fn generate_response_until_done<F, H>(
         &mut self,
         sampler_config: SamplerConfig,
@@ -109,35 +98,25 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
             &MutexGuard<'_, GlobalInferenceLockToken>,
         ) -> Result<(), GenerateResponseError>,
     {
-        // Token generation loop
         info!("Worker writing until done");
 
-        // pre-allocating 4096 bytes for the response string
-        // 4096 is a very randomly chosen number. how does this affect performance?
         let mut full_response: String = String::with_capacity(4096);
         let mut tokens_written_until_now = TokenizerChunks::new();
 
-        // initialize sampler
-        // stateful samplers only live for one response
         let mut sampler = sampler_config.to_stateful(self.ctx.model)?;
-
-        // init stateful decoder for split up tokens like emojis
         let mut decoder = encoding_rs::UTF_8.new_decoder();
 
         while !self.extra.should_stop() {
-            // Check if the context is full
             if self.n_past as u32 == self.ctx.n_ctx() {
                 on_context_full(self, &tokens_written_until_now, inference_lock_token)?;
             }
 
-            // Sample next token, no need to use sampler.accept as sample already accepts the token.
-            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
+            // Do not use sampler.accept — it crashes with grammar sampling.
             // https://github.com/utilityai/llama-cpp-rs/issues/604
             let new_token = self.sample_and_decode_next_token(&mut sampler)?;
 
             tokens_written_until_now.append(TokenizerChunk::new_text(vec![new_token]));
 
-            // Attempt to convert token(s) to bytes
             let token_bytes = match self
                 .ctx
                 .model
@@ -154,24 +133,18 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
                 x => x,
             }?;
 
-            // Attempt to convert bytes to utf8 string.
             let max_len = decoder
                 .max_utf8_buffer_length(token_bytes.len())
                 .unwrap_or(32);
             let mut token_str = String::with_capacity(max_len);
 
-            // this is where the utf-8 decoder handles partial unicode
-            // it'll write whatever printable chars it can into `token_str`
-            // and retain partial codepoints for next decoding attempt
+            // Partial unicode: the decoder retains incomplete codepoints across calls.
             let (_result, _bytes_read, _had_errors) =
                 decoder.decode_to_string(&token_bytes, &mut token_str, false);
 
-            // XXX: this literal '<eos>' token match is a fucked hotfix for gemma4. it seems like
-            // some gemma4 models will emit a *wrong* eos token (doesn't match the expected format)
-            // after tool calls. This doesn't trigger the is_eog_token match in llama.cpp and
-            // causes a bad infinite generation loop.
-            // it seems like vllm also has a codepath to handle this specific case:
-            // https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
+            // XXX: gemma4 hotfix — some gemma4 models emit a wrong EOS token after tool calls
+            // that llama.cpp's is_eog_token does not catch, causing an infinite generation loop.
+            // vllm handles the same case: https://docs.vllm.ai/en/stable/api/vllm/model_executor/models/gemma4_utils/#vllm.model_executor.models.gemma4_utils.has_tool_response_tag
             let gemma4_eog_hotfix = token_str == "<eos>" && new_token == LlamaToken::new(1);
 
             let has_eog = self.ctx.model.is_eog_token(new_token) || gemma4_eog_hotfix;
@@ -188,23 +161,18 @@ impl<'a, T: Generate + PoolingType> Worker<'a, T> {
             }
         }
 
-        // we're done!
         debug!(%full_response, "Sending out");
         respond(WriteOutput::Done(full_response));
         Ok(self)
     }
 }
 
-/// Wraps a response callback to do two things:
-/// 1. Save a copy of the completed response (via a channel) before forwarding it.
-/// 2. Stop emitting tokens to the outer callback once a `tool_call_begin_token` has been seen.
+/// Wraps a respond callback to capture the completed response and suppress tokens after
+/// `tool_call_begin_token`.
 pub(crate) fn wrap_respond<F>(
     respond: F,
     tool_call_begin_token: Option<String>,
-) -> (
-    impl FnMut(WriteOutput),
-    std::sync::mpsc::Receiver<String>,
-)
+) -> (impl FnMut(WriteOutput), std::sync::mpsc::Receiver<String>)
 where
     F: Fn(WriteOutput),
 {

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod crossencoder;
 pub mod encoder;
 pub mod errors;
+pub(crate) mod inference;
 pub mod llm;
 pub mod memory;
 pub mod sampler;

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -2,7 +2,7 @@ pub mod chat;
 pub mod crossencoder;
 pub mod encoder;
 pub mod errors;
-pub(crate) mod inference;
+pub mod inference;
 pub mod llm;
 pub mod memory;
 pub mod sampler;

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -714,8 +714,7 @@ where
 
         let tokenizer = Tokenizer::new(&model.language_model, projection_model, add_bos);
 
-        let engine = InferenceEngine {
-            n_past: 0,
+        let engine = InferenceEngine::new(
             ctx,
             big_batch,
             small_batch,
@@ -723,7 +722,7 @@ where
             n_batch,
             tokenizer,
             use_embeddings,
-        };
+        );
         Ok(Worker { engine, extra })
     }
 
@@ -737,7 +736,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn read_string(&mut self, text: String) -> Result<&mut Self, ReadError> {
         let inference_lock_token = acquire_inference_lock();
-        let chunks = self.engine.tokenizer.tokenize(text, vec![])?;
+        let chunks = self.engine.tokenize(text, vec![])?;
         self.engine.read_chunks(chunks, &inference_lock_token)?;
         Ok(self)
     }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,26 +1,28 @@
 use crate::errors::{InitWorkerError, LoadModelError, ReadError};
+use crate::inference::{acquire_inference_lock, InferenceEngine};
 use crate::memory;
-use crate::tokenizer::{ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks};
+use crate::tokenizer::{ProjectionModel, Tokenizer};
 use indicatif::{ProgressBar, ProgressStyle};
-use llama_cpp_2::context::kv_cache::KvCacheConversionError;
+use lazy_static::lazy_static;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaPoolingType};
-use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
-use llama_cpp_2::mtmd::MtmdInputChunks;
-use llama_cpp_2::token::LlamaToken;
 use std::io::{Read, Write};
 use std::pin::pin;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
-use tracing::{debug, debug_span, error, info, info_span, warn};
+use tracing::{debug, error, info, info_span, warn};
 
-pub(crate) use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
+#[derive(Debug)]
+pub(crate) struct GlobalInferenceLockToken;
+lazy_static! {
+    pub(crate) static ref GLOBAL_INFERENCE_LOCK: Mutex<GlobalInferenceLockToken> =
+        Mutex::new(GlobalInferenceLockToken);
+}
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
@@ -633,17 +635,7 @@ fn read_add_bos_metadata(model: &LlamaModel) -> Result<AddBos, InitWorkerError> 
 
 #[derive(Debug)]
 pub(crate) struct Worker<'a, S> {
-    pub(crate) n_past: i32,
-    pub(crate) ctx: LlamaContext<'a>,
-    pub(crate) big_batch: LlamaBatch<'a>,
-    pub(crate) small_batch: LlamaBatch<'a>,
-    pub(crate) projection_model: Option<&'a ProjectionModel>,
-    pub(crate) tokenizer: Tokenizer<'a>,
-    pub(crate) use_embeddings: bool,
-    // The configured n_batch (= planned n_ctx before llama.cpp's internal rounding).
-    // Used to guard against sending more tokens than the context can decode in one batch.
-    pub(crate) n_batch: usize,
-
+    pub(crate) engine: InferenceEngine<'a>,
     pub(crate) extra: S,
 }
 
@@ -651,9 +643,10 @@ pub trait PoolingType {
     fn pooling_type(&self) -> LlamaPoolingType;
 }
 
-impl<'a, T> PoolingType for Worker<'a, T> {
+/// Pooling type for a plain generative chat session (no pooling).
+impl PoolingType for () {
     fn pooling_type(&self) -> LlamaPoolingType {
-        LlamaPoolingType::Unspecified
+        LlamaPoolingType::None
     }
 }
 
@@ -721,171 +714,32 @@ where
 
         let tokenizer = Tokenizer::new(&model.language_model, projection_model, add_bos);
 
-        let state = Worker {
+        let engine = InferenceEngine {
             n_past: 0,
             ctx,
             big_batch,
             small_batch,
             projection_model,
             n_batch,
-            extra,
             tokenizer,
             use_embeddings,
         };
-        Ok(state)
+        Ok(Worker { engine, extra })
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    /// Reset the KV cache and token count. Delegates to the inference engine.
     pub fn reset_context(&mut self) -> &mut Self {
-        self.ctx.clear_kv_cache();
-        self.n_past = 0;
+        self.engine.reset_context();
         self
     }
 
+    /// Tokenize `text` and read it into the context under the global inference lock.
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn read_string(&mut self, text: String) -> Result<&mut Self, ReadError> {
         let inference_lock_token = acquire_inference_lock();
-        let chunks = self.tokenizer.tokenize(text, vec![])?;
-        self.read_chunks(chunks, &inference_lock_token)
-    }
-
-    pub fn read_chunks(
-        &mut self,
-        chunks: TokenizerChunks,
-        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
-    ) -> Result<&mut Self, ReadError> {
-        for chunk in chunks.into_iter() {
-            match chunk {
-                TokenizerChunk::Text(tokens, _) => {
-                    self.read_text_tokens(tokens, inference_lock_token)?;
-                }
-                TokenizerChunk::Image(embeddings, _) | TokenizerChunk::Audio(embeddings, _) => {
-                    self.read_media_embeddings(embeddings, inference_lock_token)?;
-                }
-            }
-        }
-
+        let chunks = self.engine.tokenizer.tokenize(text, vec![])?;
+        self.engine.read_chunks(chunks, &inference_lock_token)?;
         Ok(self)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    fn read_media_embeddings(
-        &mut self,
-        embeddings: Rc<MtmdInputChunks>,
-        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
-    ) -> Result<&mut Self, ReadError> {
-        let projection_model = self
-            .projection_model
-            .as_ref()
-            .ok_or(ReadError::ProjectionModelNotInitialized)?;
-
-        let n_tokens = embeddings.as_ref().total_tokens();
-        debug!(n_tokens, "Reading media embeddings:");
-
-        let decode_span = debug_span!("read media embeddings", n_tokens = n_tokens);
-        let decode_guard = decode_span.enter();
-        let n_ctx = self.ctx.n_ctx() as i32;
-        self.n_past = embeddings.eval_chunks(
-            &projection_model.ctx,
-            &self.ctx,
-            self.n_past,
-            0,
-            n_ctx,
-            true,
-        )?;
-
-        drop(decode_guard);
-        debug!(
-            "Completed read media embeddings operation, n_past: {}",
-            self.n_past
-        );
-
-        Ok(self)
-    }
-
-    // ---------- IMPORTANT ----------
-    // Should only be used under a global inference lock
-    // This is a safety meassure to prevent bugs from multiple
-    // contexts with the same model. It might not be necessary
-    // but assume it is.
-    #[tracing::instrument(level = "trace", skip(self))]
-    fn read_text_tokens(
-        &mut self,
-        tokens: Vec<LlamaToken>,
-        inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
-    ) -> Result<&mut Self, ReadError> {
-        let n_tokens = tokens.len();
-        debug!(n_tokens, "Reading tokens:");
-
-        // can't read nothing
-        debug_assert!(!tokens.is_empty());
-
-        if n_tokens > self.n_batch {
-            return Err(ReadError::InputExceedsContext {
-                n_tokens,
-                n_ctx: self.n_batch,
-            });
-        }
-
-        {
-            debug!("Populating batch");
-            // make batch
-            self.big_batch.clear();
-            let seq_ids = &[0];
-            for (i, token) in (0..).zip(tokens.iter()) {
-                // For LLM workers only the last token's logits are needed (sampling).
-                // For encoder workers every token must be marked as an output so the
-                // pooling layer has hidden states to work with — otherwise llama.cpp
-                // logs "embeddings required but some input tokens were not marked as
-                // outputs -> overriding" and silently flips them on for us.
-                let output_logits = self.use_embeddings || i == n_tokens - 1;
-                self.big_batch
-                    .add(*token, self.n_past + i as i32, seq_ids, output_logits)?;
-            }
-        }
-
-        // llm go brr
-        let decode_span = debug_span!("read decode", n_tokens = n_tokens);
-        let decode_guard = decode_span.enter();
-        self.ctx.decode(&mut self.big_batch)?;
-        drop(decode_guard);
-        // brrr
-
-        self.n_past += tokens.len() as i32;
-
-        debug!("Completed read tokens operation, n_past: {}", self.n_past);
-
-        Ok(self)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub fn remove_all_tokens_from_index_from_ctx(
-        &mut self,
-        index: usize,
-    ) -> Result<i32, KvCacheConversionError> {
-        if self.n_past <= index as i32 {
-            return Ok(0);
-        }
-
-        let before = self.n_past;
-        let seq_rm_success = self
-            .ctx
-            .clear_kv_cache_seq(Some(0), Some(index as u32), None)?;
-
-        if seq_rm_success {
-            self.n_past = index as i32;
-        } else {
-            // Partial sequence removal is not supported by this model's memory type
-            // (e.g. hybrid models with recurrent components). Fall back to full reset.
-            warn!(
-                index,
-                n_past = self.n_past,
-                "Partial KV cache removal not supported, falling back to full context reset"
-            );
-            self.reset_context();
-        }
-
-        Ok(before - self.n_past)
     }
 }
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -862,11 +862,12 @@ where
     pub fn remove_all_tokens_from_index_from_ctx(
         &mut self,
         index: usize,
-    ) -> Result<(), KvCacheConversionError> {
+    ) -> Result<i32, KvCacheConversionError> {
         if self.n_past <= index as i32 {
-            return Ok(());
+            return Ok(0);
         }
 
+        let before = self.n_past;
         let seq_rm_success = self
             .ctx
             .clear_kv_cache_seq(Some(0), Some(index as u32), None)?;
@@ -884,7 +885,7 @@ where
             self.reset_context();
         }
 
-        Ok(())
+        Ok(before - self.n_past)
     }
 }
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -2,7 +2,6 @@ use crate::errors::{InitWorkerError, LoadModelError, ReadError};
 use crate::memory;
 use crate::tokenizer::{ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks};
 use indicatif::{ProgressBar, ProgressStyle};
-use lazy_static::lazy_static;
 use llama_cpp_2::context::kv_cache::KvCacheConversionError;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaPoolingType};
 use llama_cpp_2::context::LlamaContext;
@@ -21,12 +20,7 @@ use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 use tracing::{debug, debug_span, error, info, info_span, warn};
 
-#[derive(Debug)]
-pub(crate) struct GlobalInferenceLockToken;
-lazy_static! {
-    pub(crate) static ref GLOBAL_INFERENCE_LOCK: Mutex<GlobalInferenceLockToken> =
-        Mutex::new(GlobalInferenceLockToken);
-}
+pub(crate) use crate::inference::{acquire_inference_lock, GlobalInferenceLockToken};
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
@@ -750,8 +744,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn read_string(&mut self, text: String) -> Result<&mut Self, ReadError> {
-        let _gil_guard = GLOBAL_INFERENCE_LOCK.lock();
-        let inference_lock_token = _gil_guard.unwrap();
+        let inference_lock_token = acquire_inference_lock();
         let chunks = self.tokenizer.tokenize(text, vec![])?;
         self.read_chunks(chunks, &inference_lock_token)
     }


### PR DESCRIPTION
This is only a refactor; every functionality should stay the same.
- `chat.rs` - stateful stuff around chat, so keeping the messages, shifting, etc.
- `inference.rs` - the unstateful things ("give me message list, i will give you back the new answer")

this should be first step towards continuous batching -> now there is more clear distinction between what is the chat (history, messages, context shifting etc.) and what is inference (template, tokenization, etc.) although is still not perfect (inference engine stll leaks `model`).