### PR TITLE
Updated CI to be path gated

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,8 +31,10 @@ Two cascade rules:
 
 | trigger | what runs |
 |---|---|
-| PR opened/updated | path-filtered buckets only |
-| PR with `full-ci` label | every bucket (sticky; remove label to revert) |
+| **Draft PR** opened/updated | only the bucket(s) touched by *the latest push*, no cascade |
+| **Non-draft PR** opened/updated | bucket(s) touched by *the whole PR diff* + cross-bucket cascade (core → all bindings, uniffi → swift/kotlin/RN) |
+| PR marked **ready-for-review** | re-runs CI in non-draft mode (full diff + cascade) |
+| PR with `full-ci` label | every bucket (sticky; remove label to revert) — overrides draft mode |
 | PR comment `/full-ci` | one-shot full run via `workflow_dispatch` (see `full_ci_comment.yml`) |
 | PR with `test:python-models` label | adds the 6-model matrix on top of path-filtered |
 | Push to `main` | every bucket (post-merge canonical run) + docs deploy |
@@ -40,6 +42,12 @@ Two cascade rules:
 | Merge queue (`merge_group`) | every bucket against the merged tree |
 | `workflow_dispatch` (Actions UI) | every bucket if `full_ci=true`, else lint+regen only |
 | `[skip ci]` in commit message | nothing (GitHub native) |
+
+### Why draft vs non-draft matters
+
+While a PR is **draft**, paths-filter compares only the latest push (`before..after`), and cascade rules are disabled. This lets you push messy core changes without dragging every binding's CI into every iteration. When you flip the PR to **ready-for-review**, CI re-runs with the full cumulative PR diff and the cross-bucket cascade — that's the real verification before merge queue picks it up.
+
+Merge queue refuses to queue drafts, so a draft can't sneak into `main` on the lighter draft-mode CI.
 
 Concurrency: PR runs cancel each other (new push kills stale CI). `merge_group`, `main` pushes, tags, and dispatches always run to completion.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,104 @@
+# CI overview
+
+This directory holds the GitHub Actions workflows that build, test, and release nobodywho across its language bindings (Rust core, Python, Godot, Flutter, Swift, Kotlin, React Native).
+
+The headline rule: **`main.yml` invokes a `plan` job that reads the event, paths, and labels, then emits a `run_*` boolean per CI bucket. Every other job gates on those outputs.** No other workflow inspects labels, paths, or the event type.
+
+## The buckets
+
+| bucket | what runs | path triggers (auto-on) | label opt-in | always on |
+|---|---|---|---|---|
+| `lint` | `cargo fmt --check`, `cargo clippy` | any | — | every event |
+| `regen` | uniffi swift / kotlin / RN bindings regen + flutter doctest regen | any | — | every event |
+| `rust_core` | `nix flake check` (canonical core test suite) | `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `python` | wheel build, pytest, pip-install, multimodal, model-downloading, **plus the always-run python static checks** (ruff/ty/stub regen) | `python/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `python_models` | 6-model tool-calling matrix (multi-GB downloads) | — | `test:python-models`, `full-ci` | main, tag, merge queue |
+| `godot` | godot integration build (linux, windows, macos, android) | `godot/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `flutter` | flutter integration build + multimodal tests + xcframework | `flutter/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `swift` | uniffi Apple build + swift xcframework + swift tests | `swift/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `kotlin` | uniffi build for desktop+android + JVM/Android compile + tests | `kotlin/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `react_native` | uniffi iOS+android build + RN xcframework | `react-native/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `docs` | docusaurus build + Cloudflare Pages deploy | `docs/` | — | main only |
+| `release` | publish to PyPI / pub.dev / npm / Maven Central / Swift mirror | — | — | release tag only |
+
+Two cascade rules:
+
+- A change to `nobodywho/core/**` cascades to **every** Rust-consuming bucket (each binding links core).
+- A change to `nobodywho/uniffi/**` cascades to `swift`, `kotlin`, `react_native`.
+- A change to `Cargo.lock` or `.github/workflows/**` forces everything on (safety net).
+
+## Trigger → behavior
+
+| trigger | what runs |
+|---|---|
+| PR opened/updated | path-filtered buckets only |
+| PR with `full-ci` label | every bucket (sticky; remove label to revert) |
+| PR comment `/full-ci` | one-shot full run via `workflow_dispatch` (see `full_ci_comment.yml`) |
+| PR with `test:python-models` label | adds the 6-model matrix on top of path-filtered |
+| Push to `main` | every bucket (post-merge canonical run) + docs deploy |
+| Push to `nobodywho-*` tag | every bucket + `release.yml` |
+| Merge queue (`merge_group`) | every bucket against the merged tree |
+| `workflow_dispatch` (Actions UI) | every bucket if `full_ci=true`, else lint+regen only |
+| `[skip ci]` in commit message | nothing (GitHub native) |
+
+Concurrency: PR runs cancel each other (new push kills stale CI). `merge_group`, `main` pushes, tags, and dispatches always run to completion.
+
+## Workflow files
+
+```
+plan.yml             Source of truth. Reads paths/labels/event → emits run_* outputs.
+main.yml             Top-level entry. Calls plan, wires every child workflow's gates,
+                     defines the `required` aggregator and concurrency.
+
+linting.yml          Always-on Rust lint (rustfmt, clippy).
+regen_checks.yml     Always-on regen-drift checks (uniffi bindings + flutter doctests).
+
+build.yml            Per-platform cargo builds (linux, windows, macos, android).
+                     A `matrix-gen` job emits the integration list from the bucket
+                     flags; each platform job is gated on whether any consumer
+                     bucket needs it. Apple xcframeworks (flutter / RN / swift)
+                     are separate jobs gated on their owner bucket.
+test.yml             nix flake check (gated by run_rust_core),
+                     flutter multimodal tests (gated by run_flutter).
+python_ci.yml        Static checks always run when invoked; wheel builds + pytest
+                     gated by run_python; 6-model matrix by run_python_models.
+swift_ci.yml         Swift macro + integration tests. Single job, gated upstream.
+kotlin_ci.yml        Kotlin/JVM + Android tests. Single job, gated upstream.
+
+docs.yml             Build + deploy docusaurus to Cloudflare Pages. Gated by main.yml
+                     to main branch only.
+release.yml          PyPI / pub.dev / npm / Maven Central / Swift mirror publish.
+                     Gated by release tag.
+
+full_ci_comment.yml  Handles `/full-ci` PR comments: permission-checks the commenter,
+                     dispatches main.yml with full_ci=true.
+
+rust-install-test.yml  Smoke test that `cargo check -p nobodywho-rust` works on
+                       Ubuntu / macOS / Windows / Nix. workflow_dispatch only.
+test_npm_publish.yml   Standalone test for the React Native npm publish flow.
+docs.yml               (above)
+```
+
+## The `required` aggregator
+
+`main.yml` defines a single job named `required` that depends on every other top-level job. It passes when each `needs.*.result` is `success` or `skipped` (skipped is correct when the plan job gated a bucket out). Failed or cancelled = it exits 1.
+
+**Branch protection on `main` should require exactly one check: `required`.** Renaming a matrix entry inside `build.yml` doesn't break protection because protection points only at the aggregator.
+
+## How to add a new bucket
+
+If you add a new binding or test scope:
+
+1. Add a `run_<new_bucket>` workflow_call output in `plan.yml` and decide its trigger logic in the `decide` step.
+2. In `main.yml`, add the workflow call with `needs: plan` and `if: needs.plan.outputs.run_<new_bucket> == 'true'`.
+3. Add the new workflow call to the `required` aggregator's `needs:` list.
+4. Update the table at the top of this file.
+
+## Manually re-running a stalled merge queue run
+
+If a `merge_group` run fails for an infrastructure reason (flaky runner, network blip), re-trigger by:
+
+1. Re-queue the PR from the GitHub UI (Merge → Add to queue), or
+2. Push an empty commit to the PR branch to bump it, then re-queue.
+
+Don't cancel an in-flight `merge_group` run — `cancel-in-progress` is intentionally `false` for them.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,55 @@ name: "Build"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full build matrix (all platforms, all targets, all profiles)."
+      run_godot:
+        description: "Build godot integration."
+        type: boolean
+        default: false
+      run_flutter:
+        description: "Build flutter integration + xcframework."
+        type: boolean
+        default: false
+      run_swift:
+        description: "Build uniffi for Apple targets + swift xcframework."
+        type: boolean
+        default: false
+      run_kotlin:
+        description: "Build uniffi for desktop + android (kotlin consumer)."
+        type: boolean
+        default: false
+      run_react_native:
+        description: "Build uniffi for iOS + android + RN xcframework."
         type: boolean
         default: false
 
 jobs:
+  # Compute which Rust integrations need to be built. Every platform matrix
+  # below uses this list as its integration axis, so a swift-only PR only
+  # builds `uniffi`, a godot-only PR only builds `godot`, etc.
+  matrix-gen:
+    runs-on: ubuntu-latest
+    outputs:
+      integrations: ${{ steps.gen.outputs.integrations }}
+    steps:
+      - id: gen
+        run: |
+          ints=()
+          [[ "${{ inputs.run_godot }}"   == "true" ]] && ints+=('"godot"')   || true
+          [[ "${{ inputs.run_flutter }}" == "true" ]] && ints+=('"flutter"') || true
+          if [[ "${{ inputs.run_swift }}"        == "true" ]] || \
+             [[ "${{ inputs.run_kotlin }}"       == "true" ]] || \
+             [[ "${{ inputs.run_react_native }}" == "true" ]]; then
+            ints+=('"uniffi"')
+          fi
+          IFS=,
+          echo "integrations=[${ints[*]}]" >> "$GITHUB_OUTPUT"
+
   cargo-build-linux:
-    if: inputs.full_ci
+    needs: matrix-gen
+    # Linux artifacts feed godot, flutter, and kotlin (desktop JNA). Swift
+    # and React Native don't consume Linux builds, so a swift-only or
+    # RN-only run skips this job entirely.
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin
     strategy:
       fail-fast: false
       matrix:
@@ -19,10 +60,7 @@ jobs:
         profile:
           - "debug"
           - "release"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
         exclude:
           # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
           - integration: "flutter"
@@ -94,7 +132,9 @@ jobs:
           path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.so
 
   cargo-build-windows:
-    if: inputs.full_ci
+    needs: matrix-gen
+    # Windows artifacts feed godot, flutter, and kotlin (desktop JNA).
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -104,10 +144,7 @@ jobs:
         profile:
           - "debug"
           - "release"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
         exclude:
           # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
           - integration: "flutter"
@@ -203,7 +240,9 @@ jobs:
             ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.pdb
 
   cargo-build-macos:
-    if: inputs.full_ci
+    needs: matrix-gen
+    # macOS artifacts feed every consumer (godot, flutter, swift, kotlin, RN).
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_swift || inputs.run_kotlin || inputs.run_react_native
     runs-on: warp-macos-15-arm64-6x
     strategy:
       fail-fast: false
@@ -220,10 +259,7 @@ jobs:
         profile:
           - "debug"
           - "release"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
         exclude:
           # uniffi doesn't need macOS x86_64 (Intel Macs are EOL)
           - integration: "uniffi"
@@ -312,7 +348,7 @@ jobs:
   # builds an "xcframework"
   # which is an apple thing that contains binaries for multiple systems
   build-flutter-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_flutter
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -391,7 +427,7 @@ jobs:
 
   # builds an xcframework containing static libraries for React Native iOS
   build-react-native-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_react_native
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -427,7 +463,7 @@ jobs:
 
   # builds an xcframework containing static libraries + headers for Swift SPM
   build-swift-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_swift
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -481,7 +517,10 @@ jobs:
           path: ./NobodyWhoNative.xcframework.zip
 
   cargo-build-android:
-    if: inputs.full_ci
+    needs: matrix-gen
+    # Android artifacts feed godot, flutter, kotlin, and React Native.
+    # Swift never consumes Android.
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin || inputs.run_react_native
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       fail-fast: false
@@ -492,10 +531,7 @@ jobs:
         profile:
           - "debug"
           - "release"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
         exclude:
           # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
           - integration: "flutter"

--- a/.github/workflows/kotlin_ci.yml
+++ b/.github/workflows/kotlin_ci.yml
@@ -1,19 +1,15 @@
 name: "kotlin_ci"
 
-on:
-  workflow_call:
-    inputs:
-      full_ci:
-        description: "Run full Kotlin CI (compilation and integration tests with model)."
-        type: boolean
-        default: false
+# Gated by main.yml on needs.plan.outputs.run_kotlin — the workflow itself
+# unconditionally runs its single job when invoked.
+
+on: workflow_call
 
 permissions:
   contents: read
 
 jobs:
   test:
-    if: inputs.full_ci
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,20 @@ on:
     tags: ['nobodywho-*']
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       full_ci:
         type: boolean
         default: true
         description: 'Run full CI suite (all platforms, all tests)'
+
+# Cancel in-flight PR runs when a new commit is pushed to that PR.
+# Don't cancel merge_group / main / tag / dispatch runs — those are
+# canonical signals we want to see through to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
@@ -19,6 +27,14 @@ permissions:
   deployments: write
 
 jobs:
+  # Single source of truth for "what should this CI run do?" — reads paths,
+  # labels, and the event, emits a run_* boolean per bucket. Every other job
+  # gates on these outputs; no other workflow inspects labels or paths.
+  plan:
+    uses: ./.github/workflows/plan.yml
+    with:
+      dispatch_full_ci: ${{ github.event_name == 'workflow_dispatch' && inputs.full_ci }}
+
   linting:
     uses: ./.github/workflows/linting.yml
 
@@ -26,37 +42,52 @@ jobs:
     uses: ./.github/workflows/regen_checks.yml
 
   python_ci:
+    needs: plan
+    if: needs.plan.outputs.run_python == 'true' || needs.plan.outputs.run_python_models == 'true'
     uses: ./.github/workflows/python_ci.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_python:        ${{ needs.plan.outputs.run_python == 'true' }}
+      run_python_models: ${{ needs.plan.outputs.run_python_models == 'true' }}
 
   build:
+    needs: plan
+    if: |
+      needs.plan.outputs.run_godot == 'true' ||
+      needs.plan.outputs.run_flutter == 'true' ||
+      needs.plan.outputs.run_swift == 'true' ||
+      needs.plan.outputs.run_kotlin == 'true' ||
+      needs.plan.outputs.run_react_native == 'true'
     uses: ./.github/workflows/build.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_godot:        ${{ needs.plan.outputs.run_godot == 'true' }}
+      run_flutter:      ${{ needs.plan.outputs.run_flutter == 'true' }}
+      run_swift:        ${{ needs.plan.outputs.run_swift == 'true' }}
+      run_kotlin:       ${{ needs.plan.outputs.run_kotlin == 'true' }}
+      run_react_native: ${{ needs.plan.outputs.run_react_native == 'true' }}
 
   swift_ci:
-    needs: [build]
+    needs: [plan, build]
+    if: needs.plan.outputs.run_swift == 'true'
     uses: ./.github/workflows/swift_ci.yml
-    with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
 
   kotlin_ci:
-    needs: [build]
+    needs: [plan, build]
+    if: needs.plan.outputs.run_kotlin == 'true'
     uses: ./.github/workflows/kotlin_ci.yml
-    with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
 
   test:
+    needs: plan
+    if: needs.plan.outputs.run_rust_core == 'true' || needs.plan.outputs.run_flutter == 'true'
     uses: ./.github/workflows/test.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_rust_core: ${{ needs.plan.outputs.run_rust_core == 'true' }}
+      run_flutter:   ${{ needs.plan.outputs.run_flutter == 'true' }}
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/nobodywho-')
-    needs: [linting, regen_checks, build, test, python_ci, swift_ci, kotlin_ci]
+    needs: [plan, linting, regen_checks, build, test, python_ci, swift_ci, kotlin_ci]
+    if: needs.plan.outputs.run_release == 'true'
     uses: ./.github/workflows/release.yml
     secrets:
       TEST_PYPI_AUTH_TOKEN: ${{ secrets.TEST_PYPI_AUTH_TOKEN }}
@@ -69,8 +100,41 @@ jobs:
       MAVEN_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
 
   docs:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy-cloudflare-pages'
+    # Build+deploy only happens on main (or the legacy deploy branch). On PRs
+    # docs.yml would publish from a non-main ref, so keep this ref-gated even
+    # when run_docs is true. PR-time docs verification is a future improvement.
+    needs: plan
+    if: needs.plan.outputs.run_docs == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy-cloudflare-pages')
     uses: ./.github/workflows/docs.yml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  # Single check name for branch protection / merge queue. Passes when every
+  # listed job either succeeded or was correctly skipped by the plan job.
+  # Renaming any matrix entry inside a child workflow no longer breaks the
+  # protection rule.
+  required:
+    if: always()
+    needs:
+      - plan
+      - linting
+      - regen_checks
+      - python_ci
+      - build
+      - swift_ci
+      - kotlin_ci
+      - test
+      - docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Verify required jobs succeeded or were skipped"
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            echo "::error::One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs succeeded or were correctly skipped."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,9 @@ on:
     branches: [main]
     tags: ['nobodywho-*']
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # ready_for_review needs to be in this list so flipping a draft PR to
+    # "ready" re-triggers CI with the full PR-base diff + cascade rules.
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1,0 +1,213 @@
+name: "plan"
+
+# Reads event, labels, and changed paths and emits a `run_*` boolean per CI
+# bucket. Every other workflow gates on these outputs. This is the only place
+# that knows about routing — child workflows just consume their input.
+
+on:
+  workflow_call:
+    inputs:
+      dispatch_full_ci:
+        description: "True when main.yml was invoked via workflow_dispatch with full_ci=true."
+        type: boolean
+        default: false
+    outputs:
+      run_rust_core:
+        value: ${{ jobs.plan.outputs.run_rust_core }}
+      run_python:
+        value: ${{ jobs.plan.outputs.run_python }}
+      run_python_models:
+        value: ${{ jobs.plan.outputs.run_python_models }}
+      run_godot:
+        value: ${{ jobs.plan.outputs.run_godot }}
+      run_flutter:
+        value: ${{ jobs.plan.outputs.run_flutter }}
+      run_swift:
+        value: ${{ jobs.plan.outputs.run_swift }}
+      run_kotlin:
+        value: ${{ jobs.plan.outputs.run_kotlin }}
+      run_react_native:
+        value: ${{ jobs.plan.outputs.run_react_native }}
+      run_docs:
+        value: ${{ jobs.plan.outputs.run_docs }}
+      run_release:
+        value: ${{ jobs.plan.outputs.run_release }}
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run_rust_core:     ${{ steps.decide.outputs.run_rust_core }}
+      run_python:        ${{ steps.decide.outputs.run_python }}
+      run_python_models: ${{ steps.decide.outputs.run_python_models }}
+      run_godot:         ${{ steps.decide.outputs.run_godot }}
+      run_flutter:       ${{ steps.decide.outputs.run_flutter }}
+      run_swift:         ${{ steps.decide.outputs.run_swift }}
+      run_kotlin:        ${{ steps.decide.outputs.run_kotlin }}
+      run_react_native:  ${{ steps.decide.outputs.run_react_native }}
+      run_docs:          ${{ steps.decide.outputs.run_docs }}
+      run_release:       ${{ steps.decide.outputs.run_release }}
+    steps:
+      - uses: actions/checkout@v5
+
+      # paths-filter only makes sense on PRs and pushes that have a diff base.
+      # For merge_group / workflow_dispatch / tag pushes we force the full
+      # surface in the decide step below, so the dorny outputs aren't read.
+      - name: "Detect changed paths (PRs and main pushes)"
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: dorny/paths-filter@v3
+        id: paths
+        with:
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+            cargo_lock:
+              - 'nobodywho/Cargo.lock'
+            core:
+              - 'nobodywho/core/**'
+            uniffi:
+              - 'nobodywho/uniffi/**'
+            python:
+              - 'nobodywho/python/**'
+            godot:
+              - 'nobodywho/godot/**'
+            flutter:
+              - 'nobodywho/flutter/**'
+            swift:
+              - 'nobodywho/swift/**'
+            kotlin:
+              - 'nobodywho/kotlin/**'
+            react_native:
+              - 'nobodywho/react-native/**'
+            docs:
+              - 'docs/**'
+
+      - name: "Decide which buckets to run"
+        id: decide
+        env:
+          EVENT:            ${{ github.event_name }}
+          REF:              ${{ github.ref }}
+          IS_DRAFT:         ${{ github.event.pull_request.draft }}
+          LABELS:           ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          DISPATCH_FULL_CI: ${{ inputs.dispatch_full_ci }}
+          P_WORKFLOWS:      ${{ steps.paths.outputs.workflows }}
+          P_CARGO_LOCK:     ${{ steps.paths.outputs.cargo_lock }}
+          P_CORE:           ${{ steps.paths.outputs.core }}
+          P_UNIFFI:         ${{ steps.paths.outputs.uniffi }}
+          P_PYTHON:         ${{ steps.paths.outputs.python }}
+          P_GODOT:          ${{ steps.paths.outputs.godot }}
+          P_FLUTTER:        ${{ steps.paths.outputs.flutter }}
+          P_SWIFT:          ${{ steps.paths.outputs.swift }}
+          P_KOTLIN:         ${{ steps.paths.outputs.kotlin }}
+          P_RN:             ${{ steps.paths.outputs.react_native }}
+          P_DOCS:           ${{ steps.paths.outputs.docs }}
+        run: |
+          set -euo pipefail
+
+          # Returns "true" if any positional arg equals "true".
+          any() {
+            for v in "$@"; do
+              if [[ "$v" == "true" ]]; then echo true; return; fi
+            done
+            echo false
+          }
+          has_label() { echo "${LABELS:-[]}" | grep -q "\"$1\""; }
+
+          # Normalize dorny outputs (may be empty when the step was skipped).
+          p_workflows="${P_WORKFLOWS:-false}"
+          p_cargo_lock="${P_CARGO_LOCK:-false}"
+          p_core="${P_CORE:-false}"
+          p_uniffi="${P_UNIFFI:-false}"
+          p_python="${P_PYTHON:-false}"
+          p_godot="${P_GODOT:-false}"
+          p_flutter="${P_FLUTTER:-false}"
+          p_swift="${P_SWIFT:-false}"
+          p_kotlin="${P_KOTLIN:-false}"
+          p_rn="${P_RN:-false}"
+          p_docs="${P_DOCS:-false}"
+
+          # ---- "run everything" conditions ---------------------------------
+          everything=false
+          # Push to main: full surface (this is the post-merge canonical run).
+          if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then everything=true; fi
+          # Release tag: full surface, then release.yml fires.
+          if [[ "$REF" == refs/tags/nobodywho-* ]]; then everything=true; fi
+          # Merge queue: full surface against the would-be merged tree.
+          if [[ "$EVENT" == "merge_group" ]]; then everything=true; fi
+          # workflow_dispatch with full_ci checked.
+          if [[ "$DISPATCH_FULL_CI" == "true" ]]; then everything=true; fi
+          # `full-ci` label on the PR.
+          if has_label "full-ci"; then everything=true; fi
+          # CI infra changes: safety net — verify everything still works.
+          if [[ "$p_workflows" == "true" ]]; then everything=true; fi
+          # Cargo.lock change: any Rust binding could be affected.
+          if [[ "$p_cargo_lock" == "true" ]]; then everything=true; fi
+
+          # ---- cascading scopes --------------------------------------------
+          # core/** is shared by every binding — cascade to all of them.
+          core_cascade="$p_core"
+          # uniffi/** is shared by swift+kotlin+react-native (regen is always-on
+          # and covers the bindings-regen aspect on its own).
+          uniffi_cascade="$p_uniffi"
+
+          # ---- per-bucket decisions ----------------------------------------
+          run_rust_core=$(any "$everything" "$core_cascade")
+          run_python=$(any "$everything" "$core_cascade" "$p_python")
+          run_godot=$(any "$everything" "$core_cascade" "$p_godot")
+          run_flutter=$(any "$everything" "$core_cascade" "$p_flutter")
+          run_swift=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_swift")
+          run_kotlin=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_kotlin")
+          run_react_native=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_rn")
+
+          # python_models: heavy 6-model matrix. On main / full-ci / explicit label.
+          run_python_models=false
+          if [[ "$everything" == "true" ]] || has_label "test:python-models"; then
+            run_python_models=true
+          fi
+
+          # The model matrix consumes the python wheel, so force-on the python
+          # wheel build/test bucket whenever the model matrix is requested.
+          if [[ "$run_python_models" == "true" ]]; then
+            run_python=true
+          fi
+
+          # docs: rebuild whenever docs/** changed, or on a full run.
+          run_docs=$(any "$everything" "$p_docs")
+
+          # release: only on a release tag.
+          run_release=false
+          if [[ "$REF" == refs/tags/nobodywho-* ]]; then run_release=true; fi
+
+          # ---- emit --------------------------------------------------------
+          {
+            echo "run_rust_core=$run_rust_core"
+            echo "run_python=$run_python"
+            echo "run_python_models=$run_python_models"
+            echo "run_godot=$run_godot"
+            echo "run_flutter=$run_flutter"
+            echo "run_swift=$run_swift"
+            echo "run_kotlin=$run_kotlin"
+            echo "run_react_native=$run_react_native"
+            echo "run_docs=$run_docs"
+            echo "run_release=$run_release"
+          } >> "$GITHUB_OUTPUT"
+
+          # ---- run summary -------------------------------------------------
+          {
+            echo "## CI Plan"
+            echo
+            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  full-everything: \`$everything\`"
+            echo
+            echo "| bucket | run? |"
+            echo "|---|---|"
+            echo "| rust_core | $run_rust_core |"
+            echo "| python | $run_python |"
+            echo "| python_models | $run_python_models |"
+            echo "| godot | $run_godot |"
+            echo "| flutter | $run_flutter |"
+            echo "| swift | $run_swift |"
+            echo "| kotlin | $run_kotlin |"
+            echo "| react_native | $run_react_native |"
+            echo "| docs | $run_docs |"
+            echo "| release | $run_release |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -53,11 +53,19 @@ jobs:
       # paths-filter only makes sense on PRs and pushes that have a diff base.
       # For merge_group / workflow_dispatch / tag pushes we force the full
       # surface in the decide step below, so the dorny outputs aren't read.
+      #
+      # `base:` selects what we diff against:
+      #   - draft PR on a synchronize event → ${{ github.event.before }}, so we
+      #     only diff the latest push (cheap iteration mode while in draft).
+      #   - non-draft PR, or PR open / ready_for_review / labeled → empty,
+      #     which makes dorny default to the PR base branch (full PR diff).
+      #   - push to main → empty, dorny diffs against the parent commit.
       - name: "Detect changed paths (PRs and main pushes)"
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: dorny/paths-filter@v3
         id: paths
         with:
+          base: ${{ (github.event.pull_request.draft && github.event.before) || '' }}
           filters: |
             workflows:
               - '.github/workflows/**'
@@ -143,12 +151,29 @@ jobs:
           # Cargo.lock change: any Rust binding could be affected.
           if [[ "$p_cargo_lock" == "true" ]]; then everything=true; fi
 
+          # ---- draft-PR mode ----------------------------------------------
+          # On a draft PR we run cheap mode: paths-filter already diffs the
+          # last push only (see the dorny step's `base:` input), and we
+          # disable the cross-bucket cascade rules so a one-off core touch
+          # doesn't drag every binding into CI on subsequent pushes.
+          # Marking the PR ready-for-review re-triggers CI with the full
+          # cumulative diff + cascade.
+          is_draft_pr=false
+          if [[ "$EVENT" == "pull_request" && "$IS_DRAFT" == "true" ]]; then
+            is_draft_pr=true
+          fi
+
           # ---- cascading scopes --------------------------------------------
           # core/** is shared by every binding — cascade to all of them.
-          core_cascade="$p_core"
-          # uniffi/** is shared by swift+kotlin+react-native (regen is always-on
-          # and covers the bindings-regen aspect on its own).
-          uniffi_cascade="$p_uniffi"
+          # uniffi/** is shared by swift+kotlin+react-native.
+          # Both cascades disabled in draft mode.
+          if $is_draft_pr; then
+            core_cascade=false
+            uniffi_cascade=false
+          else
+            core_cascade="$p_core"
+            uniffi_cascade="$p_uniffi"
+          fi
 
           # ---- per-bucket decisions ----------------------------------------
           run_rust_core=$(any "$everything" "$core_cascade")
@@ -196,7 +221,7 @@ jobs:
           {
             echo "## CI Plan"
             echo
-            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  full-everything: \`$everything\`"
+            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  draft-mode: \`$is_draft_pr\`  ·  full-everything: \`$everything\`"
             echo
             echo "| bucket | run? |"
             echo "|---|---|"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -48,7 +48,39 @@ jobs:
       run_docs:          ${{ steps.decide.outputs.run_docs }}
       run_release:       ${{ steps.decide.outputs.run_release }}
     steps:
+      # fetch-depth: 0 is required for dorny/paths-filter to be able to
+      # `git diff` against an arbitrary base SHA (we pass github.event.before
+      # for draft PRs). With the default shallow clone (depth 1) the base
+      # commit is unreachable, dorny silently falls back to its API mode
+      # (which returns the full PR diff) and our draft-mode last-push diff
+      # stops working.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Diagnostic line: surfaces what the event, action, and base SHA were
+      # so the next time draft-mode CI behaves oddly we can read it directly
+      # from the job summary instead of guessing.
+      - name: "Echo event diagnostics"
+        run: |
+          echo "event:    ${{ github.event_name }}"
+          echo "action:   ${{ github.event.action }}"
+          echo "ref:      ${{ github.ref }}"
+          echo "draft:    ${{ github.event.pull_request.draft }}"
+          echo "before:   ${{ github.event.before }}"
+          echo "after:    ${{ github.event.after }}"
+          {
+            echo "## Event diagnostics"
+            echo
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| event | \`${{ github.event_name }}\` |"
+            echo "| action | \`${{ github.event.action }}\` |"
+            echo "| ref | \`${{ github.ref }}\` |"
+            echo "| draft | \`${{ github.event.pull_request.draft }}\` |"
+            echo "| before | \`${{ github.event.before || '(empty)' }}\` |"
+            echo "| after | \`${{ github.event.after || '(empty)' }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # paths-filter only makes sense on PRs and pushes that have a diff base.
       # For merge_group / workflow_dispatch / tag pushes we force the full

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -82,45 +82,109 @@ jobs:
             echo "| after | \`${{ github.event.after || '(empty)' }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # paths-filter only makes sense on PRs and pushes that have a diff base.
-      # For merge_group / workflow_dispatch / tag pushes we force the full
-      # surface in the decide step below, so the dorny outputs aren't read.
+      # Compute the changed-file list ourselves with `git diff`. We tried
+      # dorny/paths-filter v3 first but it silently kept returning the full
+      # PR diff on synchronize events even with `base:` set to the previous
+      # push SHA and `fetch-depth: 0` on the checkout. Bypassing it removes
+      # the unknown.
       #
-      # `base:` selects what we diff against:
-      #   - draft PR on a synchronize event → ${{ github.event.before }}, so we
-      #     only diff the latest push (cheap iteration mode while in draft).
-      #   - non-draft PR, or PR open / ready_for_review / labeled → empty,
-      #     which makes dorny default to the PR base branch (full PR diff).
-      #   - push to main → empty, dorny diffs against the parent commit.
-      - name: "Detect changed paths (PRs and main pushes)"
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: dorny/paths-filter@v3
+      # Diff base by event:
+      #   - draft PR + synchronize + non-empty `before`: base = before SHA
+      #       (cheap last-push diff while iterating in draft).
+      #   - draft PR + any other action (opened, labeled, ready_for_review[*],
+      #       edited): no meaningful "last push" — leave base empty, no diff.
+      #       Always-on jobs and label-driven `everything=true` still work.
+      #   - non-draft PR: base = PR base SHA → full PR diff + cascade.
+      #   - push to main: base = github.event.before of the push.
+      #   - merge_group / workflow_dispatch / tag push: skip (decide step
+      #       forces everything=true).
+      #
+      # [*] ready_for_review flips pull_request.draft to false, so it falls
+      #     into the non-draft branch.
+      - name: "Detect changed paths"
         id: paths
-        with:
-          base: ${{ (github.event.pull_request.draft && github.event.before) || '' }}
-          filters: |
-            workflows:
-              - '.github/workflows/**'
-            cargo_lock:
-              - 'nobodywho/Cargo.lock'
-            core:
-              - 'nobodywho/core/**'
-            uniffi:
-              - 'nobodywho/uniffi/**'
-            python:
-              - 'nobodywho/python/**'
-            godot:
-              - 'nobodywho/godot/**'
-            flutter:
-              - 'nobodywho/flutter/**'
-            swift:
-              - 'nobodywho/swift/**'
-            kotlin:
-              - 'nobodywho/kotlin/**'
-            react_native:
-              - 'nobodywho/react-native/**'
-            docs:
-              - 'docs/**'
+        run: |
+          set -uo pipefail
+
+          BASE=""
+          HEAD=""
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              DRAFT="${{ github.event.pull_request.draft }}"
+              ACTION="${{ github.event.action }}"
+              EVT_BEFORE="${{ github.event.before }}"
+              PR_BASE_SHA="${{ github.event.pull_request.base.sha }}"
+              PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+              if [[ "$DRAFT" == "true" ]]; then
+                if [[ "$ACTION" == "synchronize" ]] && [[ -n "$EVT_BEFORE" ]]; then
+                  BASE="$EVT_BEFORE"
+                  HEAD="$PR_HEAD_SHA"
+                fi
+                # else: draft non-synchronize → leave BASE empty, no buckets
+              else
+                BASE="$PR_BASE_SHA"
+                HEAD="$PR_HEAD_SHA"
+              fi
+              ;;
+            push)
+              if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+                BASE="${{ github.event.before }}"
+                HEAD="${{ github.event.after }}"
+              fi
+              ;;
+          esac
+
+          if [[ -n "$BASE" ]] && [[ -n "$HEAD" ]]; then
+            echo "Diffing $BASE..$HEAD"
+            CHANGED="$(git diff --name-only "$BASE..$HEAD" 2>&1)"
+            git_rc=$?
+            if [[ $git_rc -ne 0 ]]; then
+              echo "::warning::git diff failed (exit $git_rc); treating as no changes"
+              CHANGED=""
+            fi
+          else
+            echo "No diff base; treating as no changes"
+            CHANGED=""
+          fi
+
+          echo "---- Changed files ----"
+          if [[ -z "$CHANGED" ]]; then echo "(none)"; else echo "$CHANGED"; fi
+          echo "-----------------------"
+
+          contains() {
+            [[ -n "$CHANGED" ]] && echo "$CHANGED" | grep -qE "$1"
+          }
+          out() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
+          # Emit one p_* per filter, mirroring the names the decide step reads.
+          contains '^\.github/workflows/'    && out workflows    true || out workflows    false
+          contains '^nobodywho/Cargo\.lock$' && out cargo_lock   true || out cargo_lock   false
+          contains '^nobodywho/core/'        && out core         true || out core         false
+          contains '^nobodywho/uniffi/'      && out uniffi       true || out uniffi       false
+          contains '^nobodywho/python/'      && out python       true || out python       false
+          contains '^nobodywho/godot/'       && out godot        true || out godot        false
+          contains '^nobodywho/flutter/'     && out flutter      true || out flutter      false
+          contains '^nobodywho/swift/'       && out swift        true || out swift        false
+          contains '^nobodywho/kotlin/'      && out kotlin       true || out kotlin       false
+          contains '^nobodywho/react-native/' && out react_native true || out react_native false
+          contains '^docs/'                  && out docs         true || out docs         false
+
+          {
+            echo "## Path detection"
+            echo
+            echo "Base: \`${BASE:-(none)}\`  ·  Head: \`${HEAD:-(none)}\`"
+            echo
+            if [[ -z "$CHANGED" ]]; then
+              echo "Changed files: _none_"
+            else
+              echo "Changed files:"
+              echo
+              echo '```'
+              echo "$CHANGED"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: "Decide which buckets to run"
         id: decide

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -563,12 +563,15 @@ jobs:
 
       - name: "Download wheel"
         uses: actions/download-artifact@v5
+        with:
+          name: nobodywho_python_macos
+          path: ./wheels
 
       - name: Install wheel
         run: |
           python3 -m venv maturinvenv
           source ./maturinvenv/bin/activate
-          pip install nobodywho_python_macos/nobodywho*macosx*.whl
+          pip install wheels/nobodywho*.whl
 
       - name: Download models
         run: |

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -3,8 +3,12 @@ name: "python_ci"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full Python CI (builds, tests, pip-install checks). If false, only static checks run."
+      run_python:
+        description: "Build wheels and run pytest / pip-install / multimodal / model-downloading tests."
+        type: boolean
+        default: false
+      run_python_models:
+        description: "Run the 6-model tool-calling matrix (heavy — multi-GB model downloads)."
         type: boolean
         default: false
 
@@ -63,7 +67,7 @@ jobs:
         run: uv run ty check
 
   linux-build:
-    if: inputs.full_ci
+    if: inputs.run_python || inputs.run_python_models
     # Build inside manylinux_2_34 container for glibc 2.34 compatibility
     # This targets glibc version 2.34 which covers most distros going back to 2021
     # See: https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#distro-compatibility
@@ -161,7 +165,7 @@ jobs:
           path: ./wheelhouse/nobodywho*.whl
 
   windows-build:
-    if: inputs.full_ci
+    if: inputs.run_python
     strategy:
       fail-fast: false
       matrix:
@@ -220,7 +224,7 @@ jobs:
           path: C:/target/wheels/nobodywho*.whl
 
   mac-os-build:
-    if: inputs.full_ci
+    if: inputs.run_python
     runs-on: warp-macos-latest-arm64-6x
     strategy:
       fail-fast: false
@@ -242,7 +246,7 @@ jobs:
           path: ./nobodywho/target/wheels/nobodywho*.whl
 
   linux-pytest:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
@@ -288,7 +292,7 @@ jobs:
           python3 -m pytest --markdown-docs ../../docs --markdown-docs-syntax=superfences
 
   linux-multimodal-tests:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
@@ -324,6 +328,7 @@ jobs:
   
 
   linux-model-downloading-tests:
+    if: inputs.run_python
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
@@ -359,7 +364,7 @@ jobs:
     
 
   linux-tool-calling-tests:
-    if: inputs.full_ci
+    if: inputs.run_python_models
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:
@@ -437,7 +442,7 @@ jobs:
           echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
   linux-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     strategy:
       fail-fast: false
@@ -487,7 +492,7 @@ jobs:
           bash nobodywho/python/tests/test_reliability.sh -n ${{ matrix.model_iterations }} nobodywho/python/examples/small_model_demo.py "linux/nobodypython/models/${{ matrix.model_name }}"
 
   windows-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [windows-build]
     strategy:
       fail-fast: false
@@ -538,7 +543,7 @@ jobs:
           ./nobodywho/python/tests/test_reliability.ps1 -ScriptPath "${{ github.workspace }}/nobodywho/python/examples/small_model_demo.py" -Iterations ${{ matrix.model_iterations }} "${{ github.workspace }}/windows/nobodywho_python/models/${{ matrix.model_name }}"
 
   mac-os-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [mac-os-build]
     runs-on: warp-macos-latest-arm64-6x
     strategy:

--- a/.github/workflows/regen_checks.yml
+++ b/.github/workflows/regen_checks.yml
@@ -1,10 +1,14 @@
 name: "regen_checks"
 
-# Verifies that committed generated bindings (Swift, Kotlin, React Native) are
-# up to date with the Rust source. A single `build-uniffi-host` job compiles
-# the uniffi crate + uniffi-bindgen binary once; three downstream jobs (one per
-# binding language) download that artifact and run their language-specific
-# generator. Separate jobs surface which binding is stale in the run summary.
+# Verifies that every committed generated artifact is up to date with its
+# source of truth:
+#   - Swift / Kotlin / React Native uniffi bindings (regenerated from the
+#     uniffi crate via uniffi-bindgen). One `build-uniffi-host` job builds
+#     the host artifact; three downstream jobs run their language generator.
+#   - Flutter doctests (regenerated from docs/docs-flutter via a dart tool).
+#
+# Always runs — these checks are cheap and the failure mode for forgetting
+# to wire one up is silent drift in committed files.
 
 on: workflow_call
 
@@ -12,6 +16,32 @@ permissions:
   contents: read
 
 jobs:
+  flutter-doctest-check:
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Generate doctest file
+        working-directory: nobodywho/flutter/nobodywho
+        run: dart run tool/doctest.dart ../../../docs/docs-flutter --generate-only
+
+      - name: Verify committed doctests are up to date
+        run: |
+          if git diff --quiet nobodywho/flutter/nobodywho/test/doctest_generated_test.dart; then
+            echo "Generated doctests are up to date"
+          else
+            echo "ERROR: Committed Flutter doctests are out of date."
+            echo "Run the generator and commit the result:"
+            echo "  cd nobodywho/flutter/nobodywho"
+            echo "  dart run tool/doctest.dart ../../../docs/docs-flutter --generate-only"
+            exit 1
+          fi
+
   build-uniffi-host:
     runs-on: warp-ubuntu-latest-x64-4x
     steps:

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -1,19 +1,15 @@
 name: "swift_ci"
 
-on:
-  workflow_call:
-    inputs:
-      full_ci:
-        description: "Run full Swift CI (integration tests with model)."
-        type: boolean
-        default: false
+# Gated by main.yml on needs.plan.outputs.run_swift — the workflow itself
+# unconditionally runs its single job when invoked.
+
+on: workflow_call
 
 permissions:
   contents: read
 
 jobs:
   tests:
-    if: inputs.full_ci
     runs-on: warp-macos-15-arm64-6x
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,49 +2,23 @@ name: "Test"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full test suite. If false, only flutter-doc-tests-check and nix-flake-check run."
+      run_rust_core:
+        description: "Run the nix flake check (canonical core test suite)."
+        type: boolean
+        default: false
+      run_flutter:
+        description: "Run the Flutter multimodal integration tests."
         type: boolean
         default: false
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
 
-
 jobs:
-
-
-  flutter-doc-tests-check:
-    runs-on: warp-ubuntu-latest-x64-2x
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - name: Generate doctest file
-        working-directory: nobodywho/flutter/nobodywho
-        run: dart run tool/doctest.dart ../../../docs/docs-flutter --generate-only
-
-      - name: Check if generated tests are up to date
-        run: |
-          if git diff --quiet nobodywho/flutter/nobodywho/test/doctest_generated_test.dart; then
-            echo "✅ Generated doctests are up to date"
-          else
-            echo "❌ Generated doctests are out of date!"
-            echo ""
-            echo "Please run the following command and commit the changes:"
-            echo "dart run tool/doctest.dart ../../../docs/docs-flutter --generate-only"
-            exit 1
-          fi
-
-
-
   # cachix actions as per these docs:
   # https://nix.dev/guides/recipes/continuous-integration-github-actions
   nix-flake-check:
+    if: inputs.run_rust_core
     runs-on: warp-ubuntu-latest-x64-4x
     timeout-minutes: 360
     steps:
@@ -75,7 +49,7 @@ jobs:
 
 
   flutter-multimodal-tests:
-    if: inputs.full_ci
+    if: inputs.run_flutter
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v5

--- a/nobodywho/python/README.md
+++ b/nobodywho/python/README.md
@@ -1,6 +1,7 @@
 # Python integration for Nobodywho
 
 ## Setting up
+
 Creating virtual-env with `uv` should be enough.
 ```
 uv venv

--- a/nobodywho/python/README.md
+++ b/nobodywho/python/README.md
@@ -1,7 +1,6 @@
 # Python integration for Nobodywho
 
 ## Setting up
-
 Creating virtual-env with `uv` should be enough.
 ```
 uv venv


### PR DESCRIPTION
Our CI has long been way to thorough for must pushes/commits.
However we also want to keep the coverage across integrations, systems and so on.
To fix the first problem while keeping this condition mind, we introduce path gated jobs. The flow in simple terms is:
plan.yml: Detects which files have been changed and creates a set of booleans based on this.
->
main.yml: Uses the bools from plan.yml to decide which jobs to run and distributes the bools to the jobs that need to make further distinctions.
-> 
Any jobs that need to run are run

Once this PR has been approved I suggest we consider using a merge queue, so we each PR runs full-ci before merging. This will also require adding branch protection using required checks. This will depend on the job "required".