### PR TITLE
docs: underline markdown links

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -296,6 +296,12 @@ article img {
 }
 
 /* ── Links ──────────────────────────────────────────────── */
+.markdown a:not(.button):not(.hash-link) {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+}
+
 [data-theme='dark'] a {
   color: var(--ifm-color-primary);
 }
@@ -346,6 +352,17 @@ article img {
 }
 
 /* ── Version dropdown ──────────────────────────────────── */
+.sidebar-version-select {
+  color: var(--ifm-font-color-base) !important;
+  background-color: var(--ifm-background-surface-color) !important;
+  border-color: var(--ifm-toc-border-color) !important;
+}
+
+.sidebar-version-select option {
+  color: var(--ifm-font-color-base);
+  background-color: var(--ifm-background-surface-color);
+}
+
 [data-theme='dark'] .sidebar-version-select {
   color: #fff !important;
   background-color: #111 !important;

--- a/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -57,7 +57,7 @@ function VersionSelector() {
           borderRadius: '6px',
           border: '1px solid var(--ifm-toc-border-color)',
           backgroundColor: 'var(--ifm-background-surface-color)',
-          color: '#fff',
+          color: 'var(--ifm-font-color-base)',
           cursor: 'pointer',
           appearance: 'auto',
         }}


### PR DESCRIPTION
- Links very hard to see in dark mode
- Underline to make them explicit