### PR TITLE
Fix/unfuck stt tests on main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 recipes=(fmt clippy regen-python regen-flutter ruff regen-uniffi flutter-analyze godot-build)
 pids=()

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -275,13 +275,13 @@ jobs:
           curl -L --fail --progress-bar https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf -o models/bge-reranker-v2-m3-Q8_0.gguf
           curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/google_gemma-4-E2B-it-Q4_K_M.gguf -o models/google_gemma-4-E2B-it-Q4_K_M.gguf
           curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/mmproj-google_gemma-4-E2B-it-f16.gguf -o models/mmproj-google_gemma-4-E2B-it-f16.gguf
-          # Whisper ONNX — only the files we actually load (q4 quantization is the
-          # library default; keep this in sync with DEFAULT_QUANTIZATION in
-          # nobodywho/core/src/stt/backends/whisper.rs)
+          # Whisper ONNX — only the files we actually load. The STT tests
+          # request quantization="default" (fp32), so we download the unsuffixed
+          # ONNX files here. (Keep in sync with the tests and models.nix.)
           WHISPER_BASE="https://huggingface.co/onnx-community/whisper-base/resolve/main"
           mkdir -p models/whisper-base/onnx
-          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/encoder_model_q4.onnx"       -o models/whisper-base/onnx/encoder_model_q4.onnx
-          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/decoder_model_merged_q4.onnx" -o models/whisper-base/onnx/decoder_model_merged_q4.onnx
+          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/encoder_model.onnx"       -o models/whisper-base/onnx/encoder_model.onnx
+          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/decoder_model_merged.onnx" -o models/whisper-base/onnx/decoder_model_merged.onnx
           curl -L --fail --progress-bar "$WHISPER_BASE/tokenizer.json"                 -o models/whisper-base/tokenizer.json
           curl -L --fail --progress-bar "$WHISPER_BASE/generation_config.json"         -o models/whisper-base/generation_config.json
           curl -L --fail --progress-bar "$WHISPER_BASE/config.json"                    -o models/whisper-base/config.json

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -61,4 +61,5 @@ jobs:
           TEST_VISION_MODEL: ${{ github.workspace }}/test-models/vision-model.gguf
           TEST_MMPROJ: ${{ github.workspace }}/test-models/mmproj.gguf
           TEST_WHISPER_MODEL: ${{ github.workspace }}/test-models/whisper-base
+          TEST_AUDIO_FILE: ${{ github.workspace }}/assets/sound.mp3
         run: swift test --filter NobodyWhoTests

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -43,7 +43,8 @@ jobs:
             "https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q4_K_M.gguf"
           curl -L -o test-models/mmproj.gguf \
             "https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/mmproj-F16.gguf"
-          # Whisper ONNX — only the files we actually load (~295 MB vs 2.4 GB for the full repo)
+          # Whisper ONNX — only the files we actually load (fp32 / "default"
+          # quantization, matching the STT tests' quantization="default").
           WHISPER_BASE="https://huggingface.co/onnx-community/whisper-base/resolve/main"
           mkdir -p test-models/whisper-base/onnx
           curl -L --fail "$WHISPER_BASE/onnx/encoder_model.onnx"       -o test-models/whisper-base/onnx/encoder_model.onnx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
 
       - name: Download Whisper model
         run: |
+          # fp32 ("default") files, matching the Flutter STT test's quantization='default'.
           WHISPER_BASE="https://huggingface.co/onnx-community/whisper-base/resolve/main"
           mkdir -p models/whisper-base/onnx
           curl -L --fail --progress-bar "$WHISPER_BASE/onnx/encoder_model.onnx"       -o models/whisper-base/onnx/encoder_model.onnx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,5 +162,6 @@ jobs:
         working-directory: ./nobodywho/flutter/nobodywho
         env:
           TEST_WHISPER_MODEL: ${{ github.workspace }}/models/whisper-base
+          TEST_AUDIO_FILE: ${{ github.workspace }}/assets/sound.mp3
           LD_LIBRARY_PATH: ${{ github.workspace }}/nobodywho/target/debug
         run: flutter test test/nobodywho_test.dart --name "STT" --reporter expanded

--- a/docs/docs-flutter/speech-to-text.md
+++ b/docs/docs-flutter/speech-to-text.md
@@ -41,7 +41,7 @@ You can also pick a `quantization` variant of the model to download and load. Lo
 ```dart
 final stt = nobodywho.Stt(
   source: 'onnx-community/whisper-base',
-  quantization: 'int8',
+  quantization: 'q4',
 );
 ```
 

--- a/docs/docs-godot/speech-to-text.md
+++ b/docs/docs-godot/speech-to-text.md
@@ -67,7 +67,7 @@ You can also pick a `quantization` variant of the model to download and load. Lo
 
 ```gdscript
 stt.model_path = "onnx-community/whisper-base"
-stt.quantization = "int8"
+stt.quantization = "q4"
 ```
 
 ## Improving performance

--- a/docs/docs-kotlin/speech-to-text.md
+++ b/docs/docs-kotlin/speech-to-text.md
@@ -40,7 +40,7 @@ You can also pick a `quantization` variant of the model to download and load. Lo
 ```kotlin
 val stt = Stt(
     source = "onnx-community/whisper-base",
-    quantization = "int8"
+    quantization = "q4"
 )
 ```
 

--- a/docs/docs-python/speech-to-text.md
+++ b/docs/docs-python/speech-to-text.md
@@ -39,7 +39,7 @@ You can also pick a `quantization` variant of the model to download and load. Lo
 ```python notest
 stt = STT(
     source="onnx-community/whisper-base",
-    quantization="int8",
+    quantization="q4",
 )
 ```
 

--- a/docs/docs-swift/speech-to-text.md
+++ b/docs/docs-swift/speech-to-text.md
@@ -38,7 +38,7 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```swift
-let stt = try STT(source: "onnx-community/whisper-base", quantization: "int8")
+let stt = try STT(source: "onnx-community/whisper-base", quantization: "q4")
 ```
 
 ## Improving performance

--- a/nobodywho/flutter/nobodywho/default.nix
+++ b/nobodywho/flutter/nobodywho/default.nix
@@ -50,6 +50,13 @@ flutter.buildFlutterApplication {
     export TEST_CROSSENCODER_MODEL="${models.TEST_CROSSENCODER_MODEL}"
     export TEST_WHISPER_MODEL="${models.TEST_WHISPER_MODEL}"
     export TEST_AUDIO_FILE="${../../../assets/sound.mp3}"
+    # Populate the HuggingFace download cache so doctests that hardcode the
+    # whisper repo ID resolve offline (the cache dir + .nobodywho-complete
+    # marker short-circuit the network call in core/src/huggingface.rs).
+    # Nix store paths are read-only, so stage into a writable TMPDIR cache.
+    export XDG_CACHE_HOME="$TMPDIR/cache"
+    mkdir -p "$XDG_CACHE_HOME/nobodywho/models"
+    cp -R ${models.TEST_WHISPER_HF_CACHE}/onnx-community "$XDG_CACHE_HOME/nobodywho/models/"
 
     flutter test --fail-fast test/
 

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -384,7 +384,7 @@ void main() {
     test('speech-to-text.md:41', () async {
       final stt = nobodywho.Stt(
         source: 'onnx-community/whisper-base',
-        quantization: 'int8',
+        quantization: 'q4',
       );
     });
 

--- a/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
+++ b/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
@@ -724,7 +724,9 @@ void main() {
       if (whisperModel == null || audioFile == null) {
         return; // Skip test if model or audio file not provided
       }
-      final stt = nobodywho.Stt(source: whisperModel);
+      // Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
+      // "Billy" as "Bailey", while fp32 gets it right.
+      final stt = nobodywho.Stt(source: whisperModel, quantization: 'default');
       final stream = stt.transcribeFile(audioFile);
       final text = await stream.completed();
       expect(text.toLowerCase(), contains('ron'));

--- a/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
+++ b/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
@@ -74,14 +74,18 @@ String addTwoNumbers({required double a, required double b}) {
 }
 
 void main() {
+  // Initialize flutter_rust_bridge once for the whole file. A top-level
+  // setUpAll runs before any group, even when a CI job filters to a single
+  // group with `--name`. (flutter_rust_bridge throws on double-init, so we keep
+  // a single init here rather than one per group.)
+  setUpAll(() async {
+    await nobodywho.NobodyWho.init();
+  });
+
   group('A group of tests', () {
     final modelPath = Platform.environment["TEST_MODEL"];
     if (modelPath == null) return; // skip all LLM tests if no model provided
     nobodywho.Chat? chat;
-
-    setUpAll(() async {
-      await nobodywho.NobodyWho.init();
-    });
 
     setUp(() async {
       // Additional setup goes here.

--- a/nobodywho/godot/integration-test/stt_test.gd
+++ b/nobodywho/godot/integration-test/stt_test.gd
@@ -19,6 +19,9 @@ func run_test() -> bool:
 
 	var stt := NobodyWhoSTT.new()
 	stt.model_path = WHISPER_MODEL
+	# Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
+	# "Billy" as "Bailey", while fp32 gets it right.
+	stt.quantization = "default"
 	add_child(stt)
 
 	stt.worker_failed.connect(func(err: String):

--- a/nobodywho/models.nix
+++ b/nobodywho/models.nix
@@ -27,22 +27,22 @@
   };
 
   # onnx-community/whisper-base — multi-file ONNX repo assembled into a local dir.
-  # The Rust backend expects (q4 is DEFAULT_QUANTIZATION in
-  # nobodywho/core/src/stt/backends/whisper.rs — keep these in sync):
-  # onnx/encoder_model_q4.onnx, onnx/decoder_model_merged_q4.onnx,
+  # The STT tests request quantization="default" (fp32), so the local dir
+  # must contain the unsuffixed ONNX files:
+  # onnx/encoder_model.onnx, onnx/decoder_model_merged.onnx,
   # tokenizer.json, config.json, generation_config.json.
   TEST_WHISPER_MODEL = runCommand "whisper-base-model" { } ''
     mkdir -p $out/onnx
     cp ${fetchurl {
-      name = "encoder_model_q4.onnx";
-      url = "https://huggingface.co/onnx-community/whisper-base/resolve/main/onnx/encoder_model_q4.onnx";
-      sha256 = "sha256-nU6cMehVnnHePg5J1guDCVFIRpnvU3R6SgYmG7vIy4g=";
-    }} $out/onnx/encoder_model_q4.onnx
+      name = "encoder_model.onnx";
+      url = "https://huggingface.co/onnx-community/whisper-base/resolve/main/onnx/encoder_model.onnx";
+      sha256 = "sha256-qfO3UoM7SeiA3ske5bbZNhEr58PqB8IhAkukk0OfRv4=";
+    }} $out/onnx/encoder_model.onnx
     cp ${fetchurl {
-      name = "decoder_model_merged_q4.onnx";
-      url = "https://huggingface.co/onnx-community/whisper-base/resolve/main/onnx/decoder_model_merged_q4.onnx";
-      sha256 = "sha256-Cfg7cc7tyX2rHZC5FHFdxTKmRqFHq9oR2Dxkhnt8MZw=";
-    }} $out/onnx/decoder_model_merged_q4.onnx
+      name = "decoder_model_merged.onnx";
+      url = "https://huggingface.co/onnx-community/whisper-base/resolve/main/onnx/decoder_model_merged.onnx";
+      sha256 = "sha256-UUkDdEuxtFgD7Fca+ZsxEQSRxvd7ChVIJYZplfsSS3M=";
+    }} $out/onnx/decoder_model_merged.onnx
     cp ${fetchurl {
       name = "tokenizer.json";
       url = "https://huggingface.co/onnx-community/whisper-base/resolve/main/tokenizer.json";

--- a/nobodywho/models.nix
+++ b/nobodywho/models.nix
@@ -1,4 +1,4 @@
-{ fetchurl, runCommand }:
+{ fetchurl, runCommand, fetchgit }:
 {
   TEST_MODEL = fetchurl {
     name = "Qwen_Qwen3-0.6B-Q4_K_M.gguf";
@@ -59,4 +59,27 @@
       sha256 = "sha256-YQcM+N4lseklbo4QLe1J2NJKg2ntNu+E/fIVSeaBJaA=";
     }} $out/generation_config.json
   '';
+
+  # The whole whisper-base repo laid out as the HF download cache expects
+  # (see `OnnxSource` in core/src/huggingface.rs): $out/onnx-community/whisper-base/
+  # with a `.nobodywho-complete` marker so it resolves offline, no network.
+  TEST_WHISPER_HF_CACHE = runCommand "whisper-base-hf-cache"
+    {
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+      outputHash = "sha256-FfrrlOafv++1nqhhvXhfUi2jJ5jr6llC+9ALR9GWiIk=";
+    }
+    ''
+      dir=$out/onnx-community/whisper-base
+      mkdir -p "$out/onnx-community"
+      cp -r ${fetchgit {
+        name = "whisper-base";
+        url = "https://huggingface.co/onnx-community/whisper-base";
+        rev = "1846881b6b3a3024392c1eea3ad983695bc23925";
+        fetchLFS = true;
+        hash = "sha256-UDkez1Ix3HR7IE9g6WqG8Fuwd9w0VBP9/7yt6bbG7y4=";
+      }} $dir
+      chmod -R u+w $dir
+      (cd $dir && find . -type f -printf '%P\n' | sort) > $dir/.nobodywho-complete
+    '';
 }

--- a/nobodywho/python/tests/test_stt.py
+++ b/nobodywho/python/tests/test_stt.py
@@ -6,6 +6,10 @@ or local directory path.  Defaults to "onnx-community/whisper-base" so the model
 downloaded automatically on first run (cached after).
 
 The test audio contains the phrase "Hey Ron. Hey Billy."
+
+Uses the fp32 (`"default"`) ONNX quantization rather than the library default
+(`"q4"`): the q4 `whisper-base` encoder mis-transcribes "Billy" as "Bailey",
+while fp32 transcribes it correctly, which is what the assertions below check.
 """
 
 import array
@@ -29,7 +33,7 @@ AUDIO_WAV = os.environ.get(
 
 @pytest.fixture(scope="module")
 def stt():
-    return nobodywho.STT(MODEL)
+    return nobodywho.STT(MODEL, quantization="default")
 
 
 def _read_wav_mono_i16(path):

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -156,7 +156,9 @@ final class NobodyWhoTests: XCTestCase {
         // Audio: "Hey Ron. Hey Billy." — shared asset in assets/.
         let audioFile = "../../../../assets/sound.mp3"
 
-        let stt = try STT(source: model)
+        // Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
+        // "Billy" as "Bailey", while fp32 gets it right.
+        let stt = try STT(source: model, quantization: "default")
         let text = try await stt.transcribeFile(path: audioFile).completed()
         XCTAssertTrue(text.lowercased().contains("ron"))
         XCTAssertTrue(text.lowercased().contains("billy"))

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -154,7 +154,10 @@ final class NobodyWhoTests: XCTestCase {
             ?? "onnx-community/whisper-base"
 
         // Audio: "Hey Ron. Hey Billy." — shared asset in assets/.
-        let audioFile = "../../../../assets/sound.mp3"
+        // TEST_AUDIO_FILE is set in CI to an absolute path; fall back to the
+        // relative path for local runs from nobodywho/swift/.
+        let audioFile = ProcessInfo.processInfo.environment["TEST_AUDIO_FILE"]
+            ?? "../../assets/sound.mp3"
 
         // Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
         // "Billy" as "Bailey", while fp32 gets it right.


### PR DESCRIPTION
Tests are broken on main. Here's why:

After changing the defautl quantization level for onnx stt models, the "hey ron, hey billy" test mis-transcribed to "hey ron, hey bailey". Small error, I just fixed it by upping the quantization level we use in tests.

Some of the model download setups for CI downloaded the wrong quantizations. I changed these download paths.

The nix sandbox does not have access to the network, so downloading an onnx whisper model on the fly doesn't work. I passed in a onnx whisper repo to the sandbox as we do with other models.

The int8 test from the flutter doc tests doesn't run on CPU (kernel just not implemented in the onnxruntime), so we change that to be a different quant

Flutter stt tests never ran NobodyWho.init(). Moved the setup job up inn scope so it applies to all tests. 
(I'm a bit confused about why this is even it's own job. it seems like this is super covered by other tests already. But refactoring tests will be out-of-scope for this PR).

Additionally, the pre-push hooks didn't work on nixos because it used the `#!/bin/bash` shebang. The proper posix-compliant shebang is doing `#!/usr/bin/env bash`, to support bash locations not necessarily at `/bin/bash`.