### PR TITLE
Restore TTS setup docs and flatten media docs

### DIFF
--- a/docs/docs-flutter/text-to-speech.md
+++ b/docs/docs-flutter/text-to-speech.md
@@ -11,9 +11,15 @@ import 'dart:io';
 import 'package:nobodywho/nobodywho.dart' as nobodywho;
 
 // ... after NobodyWho.init().
-final tts = await nobodywho.Tts.load(source: 'NobodyWho/Kokoro-82M');
+final tts = await nobodywho.Tts.load(
+  source: 'NobodyWho/Kokoro-82M', // Hugging Face repo ID or local folder with the model files.
+  voice: 'bf_emma', // Voice to use from the model.
+  language: 'en-gb', // Language code for the input text.
+);
 
+// Generate WAV bytes for this sentence.
 final wav = await tts.synthesize(text: 'Hello from NobodyWho!');
+// Save the audio to a file.
 await File('out.wav').writeAsBytes(wav);
 ```
 
@@ -24,9 +30,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, pass `backend: 'kokoro'` or `backend: 'supertonic'` explicitly to tell it which engine to use.
+`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -66,3 +70,42 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Defaults to `1.05`.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Must be greater than `0`; defaults to `8`.
 - `silenceDuration`: seconds of silence between long text chunks. Higher values add longer pauses. Must be `0` or higher; defaults to `0.3`.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory or a custom source that NobodyWho cannot recognize:
+
+```dart
+// ... after NobodyWho.init().
+final tts = await nobodywho.Tts.load(
+  source: '/path/to/local/kokoro-folder',
+  backend: 'kokoro',
+);
+```
+
+Supported backend values are `kokoro` and `supertonic`.
+
+## GPU
+
+TTS uses GPU acceleration by default when available. Disable it with `useGpu: false`:
+
+```dart
+// ... after NobodyWho.init().
+final tts = await nobodywho.Tts.load(
+  source: 'Supertone/supertonic-3',
+  useGpu: false,
+);
+```
+
+## Local model folder format
+
+When `source` is a local directory, point it at the top-level model folder and pass the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/docs-godot/text-to-speech.md
+++ b/docs/docs-godot/text-to-speech.md
@@ -16,16 +16,20 @@ extends Node
 @onready var tts: NobodyWhoTts = $NobodyWhoTts
 
 func _ready():
-    tts.source = "NobodyWho/Kokoro-82M"
+    tts.source = "NobodyWho/Kokoro-82M" # Hugging Face repo ID or local folder with the model files.
+    tts.voice = "bf_emma" # Voice to use from the model.
+    tts.language = "en-gb" # Language code for the input text.
 
     tts.start_worker()
     await tts.worker_started
 
+    # Generate WAV bytes for this sentence.
     var result: Dictionary = await tts.synthesize("Hello from NobodyWho!")
     if not result.ok:
         push_error(result.error)
         return
 
+    # Save the audio to a file.
     var file = FileAccess.open("user://out.wav", FileAccess.WRITE)
     file.store_buffer(result.wav)
 ```
@@ -37,16 +41,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, a Godot path (`res://` or `user://`), or a local filesystem directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, set `backend` explicitly to tell it which engine to use:
-
-```gdscript
-tts.source = "res://models/kokoro-folder"
-tts.backend = "kokoro"
-```
-
-Supported `backend` values are `kokoro` and `supertonic`.
+`source` can be a Hugging Face repo ID as shown above, a Godot path (`res://` or `user://`), or a local filesystem directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -80,3 +75,37 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Set `0` to use the backend default.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Set `0` to use the backend default.
 - `silence_duration`: seconds of silence between long text chunks. Higher values add longer pauses. Set `-1` to use the backend default.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory, Godot path, or a custom source that NobodyWho cannot recognize:
+
+```gdscript
+tts.source = "res://models/kokoro-folder"
+tts.backend = "kokoro"
+```
+
+Supported backend values are `kokoro` and `supertonic`.
+
+## GPU
+
+TTS uses GPU acceleration by default when available. Disable it with `device = "cpu"`:
+
+```gdscript
+tts.source = "Supertone/supertonic-3"
+tts.device = "cpu"
+tts.start_worker()
+```
+
+## Local model folder format
+
+When `source` is a local directory or Godot path, point it at the top-level model folder and set the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/docs-kotlin/text-to-speech.md
+++ b/docs/docs-kotlin/text-to-speech.md
@@ -12,9 +12,15 @@ import java.io.File
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val tts = Tts.load(source = "NobodyWho/Kokoro-82M")
+    val tts = Tts.load(
+        source = "NobodyWho/Kokoro-82M", // Hugging Face repo ID or local folder with the model files.
+        voice = "bf_emma", // Voice to use from the model.
+        language = "en-gb", // Language code for the input text.
+    )
 
+    // Generate WAV bytes for this sentence.
     val wav = tts.synthesize(text = "Hello from NobodyWho!")
+    // Save the audio to a file.
     File("out.wav").writeBytes(wav)
 }
 ```
@@ -26,18 +32,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, pass a `backend` param (`TtsBackend.KOKORO` or `TtsBackend.SUPERTONIC`) explicitly to tell it which engine to use:
-
-```kotlin
-import ai.nobodywho.TtsBackend
-
-val tts = Tts.load(
-    source = "/path/to/local/kokoro-folder",
-    backend = TtsBackend.KOKORO,
-)
-```
+`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -75,3 +70,44 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Defaults to `1.05`.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Must be greater than `0`; defaults to `8`.
 - `silenceDuration`: seconds of silence between long text chunks. Higher values add longer pauses. Must be `0` or higher; defaults to `0.3`.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory or a custom source that NobodyWho cannot recognize:
+
+```kotlin
+import ai.nobodywho.TtsBackend
+
+val tts = Tts.load(
+    source = "/path/to/local/kokoro-folder",
+    backend = TtsBackend.KOKORO,
+)
+```
+
+Supported backend values are `TtsBackend.KOKORO` and `TtsBackend.SUPERTONIC`.
+
+## GPU
+
+TTS uses GPU acceleration by default when available. Disable it with `device = TtsDevice.CPU`:
+
+```kotlin
+import ai.nobodywho.TtsDevice
+
+val tts = Tts.load(
+    source = "Supertone/supertonic-3",
+    device = TtsDevice.CPU,
+)
+```
+
+## Local model folder format
+
+When `source` is a local directory, point it at the top-level model folder and pass the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/docs-python/text-to-speech.md
+++ b/docs/docs-python/text-to-speech.md
@@ -10,9 +10,15 @@ Generate natural-sounding speech from text, ready to save as a WAV file or play 
 from pathlib import Path
 from nobodywho import Tts
 
-tts = Tts(source="NobodyWho/Kokoro-82M")
+tts = Tts(
+    source="NobodyWho/Kokoro-82M",  # Hugging Face repo ID or local folder with the model files.
+    voice="bf_emma",  # Voice to use from the model.
+    language="en-gb",  # Language code for the input text.
+)
 
+# Generate WAV bytes for this sentence.
 wav = tts.synthesize("Hello from NobodyWho!")
+# Save the audio to a file.
 Path("out.wav").write_bytes(wav)
 ```
 
@@ -23,9 +29,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, pass `backend="kokoro"` or `backend="supertonic"` explicitly to tell it which engine to use.
+`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -63,3 +67,40 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Defaults to `1.05`.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Must be greater than `0`; defaults to `8`.
 - `silence_duration`: seconds of silence between long text chunks. Higher values add longer pauses. Must be `0` or higher; defaults to `0.3`.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory or a custom source that NobodyWho cannot recognize:
+
+```python notest
+tts = Tts(
+    source="/path/to/local/kokoro-folder",
+    backend="kokoro",
+)
+```
+
+Supported backend values are `kokoro` and `supertonic`.
+
+## GPU
+
+TTS uses GPU acceleration by default when available. Disable it with `device="cpu"`:
+
+```python notest
+tts = Tts(
+    source="Supertone/supertonic-3",
+    device="cpu",
+)
+```
+
+## Local model folder format
+
+When `source` is a local directory, point it at the top-level model folder and pass the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/docs-react-native/text-to-speech.md
+++ b/docs/docs-react-native/text-to-speech.md
@@ -9,9 +9,15 @@ Generate natural-sounding speech from text, ready to save as a WAV file or play 
 ```typescript
 import { Tts } from "react-native-nobodywho";
 
-const tts = await Tts.load({ source: "NobodyWho/Kokoro-82M" });
+const tts = await Tts.load({
+  source: "NobodyWho/Kokoro-82M", // Hugging Face repo ID or local folder with the model files.
+  voice: "bf_emma", // Voice to use from the model.
+  language: "en-gb", // Language code for the input text.
+});
 
+// Generate WAV bytes for this sentence.
 const wav = await tts.synthesize("Hello from NobodyWho!");
+// wav is a Uint8Array containing WAV bytes.
 ```
 
 ## Models and sources
@@ -21,16 +27,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, pass a `backend` option (`"kokoro"` or `"supertonic"`) explicitly to tell it which engine to use:
-
-```typescript
-const tts = await Tts.load({
-  source: "/path/to/local/kokoro-folder",
-  backend: "kokoro",
-});
-```
+`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -68,3 +65,40 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Defaults to `1.05`.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Must be greater than `0`; defaults to `8`.
 - `silenceDuration`: seconds of silence between long text chunks. Higher values add longer pauses. Must be `0` or higher; defaults to `0.3`.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory or a custom source that NobodyWho cannot recognize:
+
+```typescript
+const tts = await Tts.load({
+  source: "/path/to/local/kokoro-folder",
+  backend: "kokoro",
+});
+```
+
+Supported backend values are `kokoro` and `supertonic`.
+
+## GPU
+
+TTS uses GPU acceleration by default when available. Disable it with `device: "cpu"`:
+
+```typescript
+const tts = await Tts.load({
+  source: "Supertone/supertonic-3",
+  device: "cpu",
+});
+```
+
+## Local model folder format
+
+When `source` is a local directory, point it at the top-level model folder and pass the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/docs-swift/text-to-speech.md
+++ b/docs/docs-swift/text-to-speech.md
@@ -10,9 +10,15 @@ Generate natural-sounding speech from text, ready to save as a WAV file or play 
 import Foundation
 import NobodyWho
 
-let tts = try await Tts.load(source: "NobodyWho/Kokoro-82M")
+let tts = try await Tts.load(
+    source: "NobodyWho/Kokoro-82M", // Hugging Face repo ID or local folder with the model files.
+    voice: "bf_emma", // Voice to use from the model.
+    language: "en-gb" // Language code for the input text.
+)
 
+// Generate WAV bytes for this sentence.
 let wav = try await tts.synthesize("Hello from NobodyWho!")
+// Save the audio to a file.
 try wav.write(to: URL(fileURLWithPath: "out.wav"))
 ```
 
@@ -23,16 +29,7 @@ NobodyWho supports two speech synthesis backends, both in ONNX format:
 - [Kokoro](https://github.com/hexgrad/kokoro), a lightweight 24 kHz speech synthesis model. Model page: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M).
 - [Supertonic](https://github.com/supertone-inc/supertonic), a multi-stage speech synthesis model with voice styles. Model page: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
 
-`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. For Supertonic, that directory must have both the `onnx/` and `voice_styles/` folders at its root.
-
-If you point `source` at a local directory NobodyWho doesn't recognize, pass a `backend` param (`.kokoro` or `.supertonic`) explicitly to tell it which engine to use:
-
-```swift
-let tts = try await Tts.load(
-    source: "/path/to/local/kokoro-folder",
-    backend: .kokoro
-)
-```
+`source` can be a Hugging Face repo ID as shown above, or a local directory laid out the same way as that repo. See [Local model folder format](#local-model-folder-format) and [Backend](#backend) for setup details.
 
 ## Kokoro
 
@@ -70,3 +67,42 @@ Optional settings include:
 - `speed`: speech speed multiplier. `1.0` is normal speed, lower values are slower, higher values are faster. Defaults to `1.05`.
 - `steps`: denoising steps. Higher values can improve quality but are slower. Lower values are faster but can sound rougher. Must be greater than `0`; defaults to `8`.
 - `silenceDuration`: seconds of silence between long text chunks. Higher values add longer pauses. Must be `0` or higher; defaults to `0.3`.
+
+## Backend
+
+`backend` is the TTS engine/model family behind a source. In most cases, you do not need to set it because NobodyWho can infer it from `source`.
+
+Set `backend` when you use a local directory or a custom source that NobodyWho cannot recognize:
+
+```swift
+let tts = try await Tts.load(
+    source: "/path/to/local/kokoro-folder",
+    backend: .kokoro
+)
+```
+
+Supported backend values are `.kokoro` and `.supertonic`.
+
+## GPU
+
+TTS runs on CPU only on Apple platforms for now. Metal/CoreML acceleration may be added in the future.
+
+Most apps should keep the default `device: .auto`. If you want to force CPU explicitly, pass `device: .cpu`:
+
+```swift
+let tts = try await Tts.load(
+    source: "Supertone/supertonic-3",
+    device: .cpu
+)
+```
+
+## Local model folder format
+
+When `source` is a local directory, point it at the top-level model folder and pass the matching `backend`.
+
+Use the Hugging Face file browsers as the reference layouts:
+
+- Kokoro: [`NobodyWho/Kokoro-82M`](https://huggingface.co/NobodyWho/Kokoro-82M/tree/main)
+- Supertonic: [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3/tree/main)
+
+For Supertonic, that top-level folder must include both the `onnx/` and `voice_styles/` directories. Download the model files with the same relative paths, then pass that folder as `source`.

--- a/docs/sidebars/flutter.ts
+++ b/docs/sidebars/flutter.ts
@@ -6,18 +6,9 @@ const sidebars: SidebarsConfig = {
     'downloading-models',
     'chat',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'embeddings-and-rag',
   ],

--- a/docs/sidebars/godot.ts
+++ b/docs/sidebars/godot.ts
@@ -8,18 +8,9 @@ const sidebars: SidebarsConfig = {
     'chat',
     'structured-output',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'embeddings-and-rag',
     'faq',

--- a/docs/sidebars/kotlin.ts
+++ b/docs/sidebars/kotlin.ts
@@ -5,18 +5,9 @@ const sidebars: SidebarsConfig = {
     'index',
     'chat',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'embeddings-and-rag',
     'downloading-models',

--- a/docs/sidebars/python.ts
+++ b/docs/sidebars/python.ts
@@ -6,18 +6,9 @@ const sidebars: SidebarsConfig = {
     'downloading-models',
     'chat',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'streaming-and-async-api',
     'embeddings-and-rag',

--- a/docs/sidebars/react-native.ts
+++ b/docs/sidebars/react-native.ts
@@ -6,18 +6,9 @@ const sidebars: SidebarsConfig = {
     'downloading-models',
     'chat',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'embeddings-and-rag',
   ],

--- a/docs/sidebars/swift.ts
+++ b/docs/sidebars/swift.ts
@@ -6,18 +6,9 @@ const sidebars: SidebarsConfig = {
     'downloading-models',
     'chat',
     'tool-calling',
-    {
-      type: 'category',
-      label: 'Vision & Audio',
-      link: {
-        type: 'generated-index',
-        title: 'Vision & Audio',
-        description:
-          'Multimodal Models cover LLMs that can natively consume images and audio directly, without a separate transcription step. ' +
-          'For converting spoken audio into text, see Speech-to-Text. For generating natural-sounding voice from text, see Text-to-Speech.',
-      },
-      items: ['vision', 'speech-to-text', 'text-to-speech'],
-    },
+    'vision',
+    'speech-to-text',
+    'text-to-speech',
     'sampling',
     'embeddings-and-rag',
   ],


### PR DESCRIPTION
- Put back relevant parts of the doc about speech to text (local model format, what we expect) 
- Nested visuals are hard to see in docs, this goes back to flat structure (for now)