### PR TITLE
React native: take named object parameters in stt constructor

### DIFF
--- a/docs/docs-react-native/speech-to-text.md
+++ b/docs/docs-react-native/speech-to-text.md
@@ -9,7 +9,9 @@ To transcribe audio into text, NobodyWho provides an integration with the Whispe
 ```typescript
 import { STT } from "react-native-nobodywho";
 
-const stt = new STT("hf://onnx-community/whisper-base");
+const stt = new STT({
+  source: "hf://onnx-community/whisper-base",
+});
 
 const text = await stt.transcribeFile("recording.mp3").completed();
 console.log(text);
@@ -38,7 +40,10 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```typescript
-const stt = new STT("hf://onnx-community/whisper-base", undefined, "int8");
+const stt = new STT({
+  source: "hf://onnx-community/whisper-base",
+  quantization: "int8",
+});
 ```
 
 ## Improving performance
@@ -46,5 +51,8 @@ const stt = new STT("hf://onnx-community/whisper-base", undefined, "int8");
 By default, Whisper auto-detects the spoken language, which costs a bit of extra processing. If you already know the language, pass its ISO 639-1 code as `language` to skip detection and improve performance:
 
 ```typescript
-const stt = new STT("hf://onnx-community/whisper-base", "en");
+const stt = new STT({
+  source: "hf://onnx-community/whisper-base",
+  language: "en",
+});
 ```

--- a/nobodywho/react-native/src/stt.ts
+++ b/nobodywho/react-native/src/stt.ts
@@ -1,13 +1,22 @@
-import type { RustSTTInterface } from "../generated/ts/nobodywho";
+import type { RustSttInterface } from "../generated/ts/nobodywho";
 import * as nobodywho from "../generated/ts/nobodywho";
 import { TokenStream } from "./streaming";
+
+export type SttOptions = {
+  source: string;
+  language?: string;
+  quantization?: string;
+};
 
 /**
  * Speech-to-text using a local Whisper ONNX model.
  *
  * @example
  * ```typescript
- * const stt = new STT("hf://onnx-community/whisper-base");
+ * const stt = new STT({
+ *   source: "hf://onnx-community/whisper-base",
+ *   language: "en",
+ * });
  * for await (const piece of stt.transcribeFile("recording.mp3")) {
  *   process.stdout.write(piece);
  * }
@@ -19,22 +28,16 @@ import { TokenStream } from "./streaming";
  */
 export class STT {
   /** @internal */
-  private readonly _inner: RustSTTInterface;
+  private readonly _inner: RustSttInterface;
 
   /**
-   * @param source - HuggingFace repo (`hf://owner/repo`, e.g. `"hf://onnx-community/whisper-base"`)
-   *   or a local directory path. The model is downloaded on first use.
-   * @param language - ISO 639-1 language code (e.g. `"en"`).
-   *   Omit or pass `undefined` for automatic language detection.
-   * @param quantization - ONNX precision variant to download and load: one of
-   *   `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`.
-   *   Omit or pass `undefined` to use `"default"`.
+   * @param opts - See {@link SttOptions}.
    */
-  constructor(source: string, language?: string, quantization?: string) {
-    this._inner = new nobodywho.RustSTT(
-      source,
-      language ?? undefined,
-      quantization ?? undefined,
+  constructor(opts: SttOptions) {
+    this._inner = new nobodywho.RustStt(
+      opts.source,
+      opts.language,
+      opts.quantization,
     );
   }
 

--- a/nobodywho/react-native/src/wrapper.ts
+++ b/nobodywho/react-native/src/wrapper.ts
@@ -86,6 +86,7 @@ export type {
   ChatStats,
 } from "../generated/ts/nobodywho";
 export type { TtsArchitecture, TtsDevice, TtsOptions } from "./tts";
+export type { SttOptions } from "./stt";
 
 // Ergonomic wrapper additions.
 export { SamplerPresets } from "./sampler_presets";


### PR DESCRIPTION
Before this PR, the `Stt` constructor took named parameters, which make examples less legible and is inconsistent with other constructor functions.