### PR TITLE
feat/Lark grammar and llguidance for tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 - `CrossEncoder.rank()` now batches documents internally making re-raking faster. Affects all bindings.
 - Tool calling now uses Lark grammars with the llguidance sampler instead of GBNF, making tool-constrained generation noticeably faster — especially on large-vocabulary models — and pre-builds the tool-call sampler so the first tool-enabled response no longer stalls while the grammar compiles. No API changes. Available for all bindings.
+- **Behavior change:** creating a chat with tools on a model whose tool-call format cannot be detected now fails at setup instead of silently falling back to unconstrained (unreliable) tool calling. Chats created without tools are unaffected. Available for all bindings.
 
 ## [Python v1.7.0, Flutter v2.5.0, Godot v9.6.0, Kotlin v2.2.0, React Native v2.5.0, Swift v2.3.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 ### Changed
 
 - `CrossEncoder.rank()` now batches documents internally making re-raking faster. Affects all bindings.
+- Tool calling now uses Lark grammars with the llguidance sampler instead of GBNF, making tool-constrained generation noticeably faster — especially on large-vocabulary models — and pre-builds the tool-call sampler so the first tool-enabled response no longer stalls while the grammar compiles. No API changes. Available for all bindings.
 
 ## [Python v1.7.0, Flutter v2.5.0, Godot v9.6.0, Kotlin v2.2.0, React Native v2.5.0, Swift v2.3.0] - 2026-07-30
 

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.152"
-source = "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
+source = "git+https://github.com/jona605a/llama-cpp-rs?rev=7ffc9a92362d4e9ebb4bfa4437b076867acdc955#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.152"
-source = "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
+source = "git+https://github.com/jona605a/llama-cpp-rs?rev=7ffc9a92362d4e9ebb4bfa4437b076867acdc955#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
 dependencies = [
  "bindgen",
  "cc",
@@ -5998,7 +5998,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.152"
-source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#223f5f1b1525ebd3cd04d28454e4a00a6d52ae70"
+source = "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.152"
-source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#223f5f1b1525ebd3cd04d28454e4a00a6d52ae70"
+source = "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#7ffc9a92362d4e9ebb4bfa4437b076867acdc955"
 dependencies = [
  "bindgen",
  "cc",
@@ -3042,13 +3042,13 @@ dependencies = [
  "espeak-ng",
  "futures",
  "gbnf",
- "gbnf-macro",
  "hound",
  "indexmap",
  "indicatif",
  "lazy_static",
  "libc",
  "llama-cpp-2",
+ "llguidance",
  "mel_spec",
  "miette",
  "minijinja",

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -8283,7 +8283,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/jona605a/llama-cpp-rs";
           rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955";
-          sha256 = "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh";
+          sha256 = "0ccwj9azblc6xyl0xnkh24si3qnvgcaybnbhrydfw1wkqy4jssw5";
         };
         libName = "llama_cpp_2";
         dependencies = [
@@ -8367,7 +8367,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/jona605a/llama-cpp-rs";
           rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955";
-          sha256 = "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh";
+          sha256 = "0ccwj9azblc6xyl0xnkh24si3qnvgcaybnbhrydfw1wkqy4jssw5";
         };
         libName = "llama_cpp_sys_2";
         buildDependencies = [
@@ -19225,7 +19225,7 @@ rec {
         dependencies = [
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.48.0";
+            packageId = "windows-sys 0.52.0";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" "Win32_System_Console" "Win32_System_SystemInformation" ];
           }
@@ -19672,7 +19672,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_SystemInformation" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
       };
       "windows-sys 0.52.0" = rec {
         crateName = "windows-sys";
@@ -19920,7 +19920,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_System" "Win32_System_Threading" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_SystemInformation" "Win32_System_Threading" "default" ];
       };
       "windows-sys 0.61.2" = rec {
         crateName = "windows-sys";

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -8281,8 +8281,8 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/utilityai/llama-cpp-rs";
-          rev = "223f5f1b1525ebd3cd04d28454e4a00a6d52ae70";
+          url = "https://github.com/jona605a/llama-cpp-rs";
+          rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955";
           sha256 = "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh";
         };
         libName = "llama_cpp_2";
@@ -8365,8 +8365,8 @@ rec {
         links = "llama";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/utilityai/llama-cpp-rs";
-          rev = "223f5f1b1525ebd3cd04d28454e4a00a6d52ae70";
+          url = "https://github.com/jona605a/llama-cpp-rs";
+          rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955";
           sha256 = "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh";
         };
         libName = "llama_cpp_sys_2";
@@ -9615,10 +9615,6 @@ rec {
             packageId = "gbnf";
           }
           {
-            name = "gbnf-macro";
-            packageId = "gbnf-macro";
-          }
-          {
             name = "hound";
             packageId = "hound";
           }
@@ -9658,6 +9654,10 @@ rec {
             usesDefaultFeatures = false;
             target = { target, features }: ("android" == target."os" or null);
             features = [ "android-static-stdcxx" ];
+          }
+          {
+            name = "llguidance";
+            packageId = "llguidance";
           }
           {
             name = "mel_spec";
@@ -21633,15 +21633,7 @@ rec {
                 )
                 crateConfigs;
               target = makeTarget pkgs.stdenv.hostPlatform;
-              # Build-time dependency graph (for proc-macros and build
-              # dependencies). When not cross-compiling it equals the host
-              # graph, so reuse `self`; otherwise build it for
-              # `pkgs.buildPackages`.
-              build =
-                if pkgs.stdenv.buildPlatform.config == pkgs.stdenv.hostPlatform.config then
-                  self
-                else
-                  mkBuiltByPackageIdByPkgs pkgs.buildPackages;
+              build = mkBuiltByPackageIdByPkgs pkgs.buildPackages;
             };
           in
           self;
@@ -21657,35 +21649,38 @@ rec {
             devDependencies = lib.optionals (runTests && packageId == rootPackageId) (
               crateConfig'.devDependencies or [ ]
             );
-            # Enabled (platform- and feature-filtered) dependency lists, reused
-            # for both derivation wiring and the crate renames below.
-            enabledDependencies = filterEnabledDependencies {
+            dependencies = dependencyDerivations {
               inherit features;
               inherit (self) target;
+              buildByPackageId =
+                depPackageId:
+                # proc_macro crates must be compiled for the build architecture
+                if crateConfigs.${depPackageId}.procMacro or false then
+                  self.build.crates.${depPackageId}
+                else
+                  self.crates.${depPackageId};
               dependencies = (crateConfig.dependencies or [ ]) ++ devDependencies;
             };
-            enabledBuildDependencies = filterEnabledDependencies {
+            buildDependencies = dependencyDerivations {
               inherit features;
               inherit (self.build) target;
+              buildByPackageId = depPackageId: self.build.crates.${depPackageId};
               dependencies = crateConfig.buildDependencies or [ ];
             };
-            dependencies = map
-              (
-                dependency:
-                # proc_macro crates must be compiled for the build architecture
-                if crateConfigs.${dependency.packageId}.procMacro or false then
-                  self.build.crates.${dependency.packageId}
-                else
-                  self.crates.${dependency.packageId}
-              )
-              enabledDependencies;
-            buildDependencies = map
-              (dependency: self.build.crates.${dependency.packageId})
-              enabledBuildDependencies;
-            # Order (build dependencies, then normal dependencies) feeds the
-            # crateRenames grouping below.
             dependenciesWithRenames =
-              lib.filter (d: d ? "rename") (enabledBuildDependencies ++ enabledDependencies);
+              let
+                buildDeps = filterEnabledDependencies {
+                  inherit features;
+                  inherit (self) target;
+                  dependencies = crateConfig.dependencies or [ ] ++ devDependencies;
+                };
+                hostDeps = filterEnabledDependencies {
+                  inherit features;
+                  inherit (self.build) target;
+                  dependencies = crateConfig.buildDependencies or [ ];
+                };
+              in
+              lib.filter (d: d ? "rename") (hostDeps ++ buildDeps);
             # Crate renames have the form:
             #
             # {
@@ -21857,17 +21852,6 @@ rec {
     corresponding feature sets are merged. Features in rust are additive.
   */
   mergePackageFeatures =
-    args: builtins.mapAttrs (_packageId: builtins.attrNames) (mergePackageFeaturesImpl args);
-
-  /*
-    Core of the feature-resolution fixpoint. The cache (`featuresByPackageId`)
-    maps each packageId to a feature *set* (an attrset `feature -> 1`) rather
-    than a sorted list, so the fold merges with `//` and detects convergence
-    with attrset equality instead of re-concatenating and re-sorting the
-    accumulated feature list on every step. `mergePackageFeatures` projects the
-    result back to canonical sorted lists.
-  */
-  mergePackageFeaturesImpl =
     { crateConfigs ? crates
     , packageId
     , rootPackageId ? packageId
@@ -21916,15 +21900,14 @@ rec {
               cache:
               { packageId, features }:
               let
-                cacheFeatures = cache.${packageId} or { };
-                # `features` is the (small) incoming list; merge it into the set.
-                combinedFeatures = cacheFeatures // listToSet features;
+                cacheFeatures = cache.${packageId} or [ ];
+                combinedFeatures = sortedUnique (cacheFeatures ++ features);
               in
-              if cache ? ${packageId} && cacheFeatures == combinedFeatures then
+              if cache ? ${packageId} && cache.${packageId} == combinedFeatures then
                 cache
               else
-                mergePackageFeaturesImpl {
-                  features = builtins.attrNames combinedFeatures;
+                mergePackageFeatures {
+                  features = combinedFeatures;
                   featuresByPackageId = cache;
                   inherit
                     crateConfigs
@@ -21937,8 +21920,8 @@ rec {
             );
         cacheWithSelf =
           let
-            cacheFeatures = featuresByPackageId.${packageId} or { };
-            combinedFeatures = cacheFeatures // listToSet enabledFeatures;
+            cacheFeatures = featuresByPackageId.${packageId} or [ ];
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId
           // {
@@ -21965,31 +21948,27 @@ rec {
       assert (builtins.isList features);
       assert (builtins.isAttrs target);
 
-      let
-        # Identical for every dep in this call; build the predicate arg once.
-        targetArgs = { inherit features target; };
-      in
       lib.filter
         (
           dep:
-          (dep.target or (features: true)) targetArgs
+          let
+            targetFunc = dep.target or (features: true);
+          in
+          targetFunc { inherit features target; }
           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features)
         )
         dependencies;
 
   # Returns whether the given feature should enable the given dependency.
   doesFeatureEnableDependency =
-    dependency:
-    # Callers partially apply this once per dependency, then test every feature,
-    # so hoist the dep-invariant strings out of the per-feature comparison.
+    dependency: feature:
     let
       name = dependency.rename or dependency.name;
-      depName = "dep:" + name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
+      startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    feature:
-    feature == name || feature == depName || builtins.substring 0 len feature == prefix;
+    feature == name || feature == "dep:" + name || startsWithPrefix;
 
   /*
     Returns the expanded features for the given inputFeatures by applying the
@@ -22003,24 +21982,29 @@ rec {
       assert (builtins.isAttrs featureMap);
       assert (builtins.isList inputFeatures);
       let
-        # Transitive closure of `inputFeatures` under `featureMap`. `seen`
-        # tracks already-expanded features so each is visited at most once;
-        # this also breaks feature cycles (issue #209).
         expandFeaturesNoCycle =
-          seen: features:
-          builtins.foldl'
-            (
-              acc: feature:
-              if acc ? ${feature} then
-                acc
-              else
-                expandFeaturesNoCycle (acc // { ${feature} = 1; }) (featureMap.${feature} or [ ])
-            )
-            seen
-            features;
-        seen = expandFeaturesNoCycle { } inputFeatures;
+          oldSeen: inputFeatures:
+          if inputFeatures != [ ] then
+            let
+              # The feature we're currently expanding.
+              feature = builtins.head inputFeatures;
+              # All the features we've seen/expanded so far, including the one
+              # we're currently processing.
+              seen = oldSeen // {
+                ${feature} = 1;
+              };
+              # Expand the feature but be careful to not re-introduce a feature
+              # that we've already seen: this can easily cause a cycle, see issue
+              # #209.
+              enables = builtins.filter (f: !(seen ? "${f}")) (featureMap."${feature}" or [ ]);
+            in
+            [ feature ] ++ (expandFeaturesNoCycle seen (builtins.tail inputFeatures ++ enables))
+          # No more features left, nothing to expand to.
+          else
+            [ ];
+        outFeatures = expandFeaturesNoCycle { } inputFeatures;
       in
-      sortedUnique (builtins.attrNames seen);
+      sortedUnique outFeatures;
 
   /*
     This function adds optional dependencies as features if they are enabled
@@ -22079,19 +22063,16 @@ rec {
       in
       defaultOrNil ++ explicitFeatures ++ additionalDependencyFeatures;
 
-  # Builds a feature set (attrset `feature -> 1`) from a list of feature names.
-  listToSet =
-    features:
-    builtins.listToAttrs (map (feature: { name = feature; value = 1; }) features);
-
   # Sorts and removes duplicates from a list of strings.
   sortedUnique =
     features:
       assert (builtins.isList features);
-      # attrNames returns keys in ascending string order, so the result is
-      # sorted and deduplicated. The feature-merge fixpoint relies on this
-      # canonical order to detect convergence.
-      builtins.attrNames (listToSet features);
+      assert (builtins.all builtins.isString features);
+      let
+        outFeaturesSet = lib.foldl (set: feature: set // { "${feature}" = 1; }) { } features;
+        outFeaturesUnique = builtins.attrNames outFeaturesSet;
+      in
+      builtins.sort (a: b: a < b) outFeaturesUnique;
 
   deprecationWarning =
     message: value:

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -14,8 +14,10 @@ monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.7" }
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
 serde = { version = "1.0.215", features = ["derive"] }
 chrono = "0.4.39"
+gbnf = { path = "../grammar/gbnf" }
+llguidance = "1.7.5"
 
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
     "openmp",
     "mtmd",
     "llguidance",
@@ -33,8 +35,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = "0.3.19"
 regex = "1.11.1"
 serde_json = "1.0.140"
-gbnf = { path = "../grammar/gbnf" }
-gbnf-macro = { path = "../grammar/gbnf-macro" }
 nom = "8.0.0"
 rand = "0.9.3"
 futures = "0.3.31"
@@ -71,7 +71,7 @@ libc = "0.2"
 # search path, which then resolves `-lgomp` to the non-PIC `libgomp.a` and
 # breaks linking the cdylib ("relocation R_X86_64_TPOFF32 against hidden symbol
 # `gomp_tls_data`"). Desktop keeps the dynamic libstdc++ it has always used.
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
     "android-static-stdcxx",
 ] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-rustls", "copy-dylibs", "api-20"] }
@@ -101,7 +101,7 @@ features = [
 # Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
 # (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4.39"
 gbnf = { path = "../grammar/gbnf" }
 llguidance = "1.7.5"
 
-llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955", default-features = false, features = [
     "openmp",
     "mtmd",
     "llguidance",
@@ -71,7 +71,7 @@ libc = "0.2"
 # search path, which then resolves `-lgomp` to the non-PIC `libgomp.a` and
 # breaks linking the cdylib ("relocation R_X86_64_TPOFF32 against hidden symbol
 # `gomp_tls_data`"). Desktop keeps the dynamic libstdc++ it has always used.
-llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955", default-features = false, features = [
     "android-static-stdcxx",
 ] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-rustls", "copy-dylibs", "api-20"] }
@@ -101,7 +101,7 @@ features = [
 # Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
 # (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", branch = "feat/full-eog-set-in-tok-env", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/jona605a/llama-cpp-rs", rev = "7ffc9a92362d4e9ebb4bfa4437b076867acdc955", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -38,6 +38,7 @@ use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat, ToolFo
 use ahash::AHasher;
 use indexmap::IndexMap;
 use llama_cpp_2::mtmd::MtmdBitmap;
+use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::min;
@@ -1380,14 +1381,15 @@ impl ChatContext {
 
 /// Builds the tool-call grammar sampler for an already-detected `tool_format`
 /// (detection happens once, in `new_chat_worker` — see the `tool_format`
-/// field doc). `Ok(None)` if `tools` is empty. `Err(DetectionFailed)` if
-/// tools are requested but no format was ever detected for this model.
+/// field doc), along with the begin-token sequence that triggers the switch to
+/// it. `Ok(None)` if `tools` is empty. `Err(DetectionFailed)` if tools are
+/// requested but no format was ever detected for this model.
 fn build_tool_sampler(
     model: &llama_cpp_2::model::LlamaModel,
     tools: &[Tool],
     sampler_config: &SamplerConfig,
     tool_format: Option<&ToolFormat>,
-) -> Result<Option<llama_cpp_2::sampling::LlamaSampler>, ToolCallingSetupError> {
+) -> Result<Option<(LlamaSampler, Vec<LlamaToken>)>, ToolCallingSetupError> {
     if tools.is_empty() {
         return Ok(None);
     }
@@ -1401,7 +1403,110 @@ fn build_tool_sampler(
     let slices = tool_format.slice_regexes();
     let tool_sampler = sampler_config.build_sampler_with_grammar(model, &lark, slices)?;
 
-    Ok(Some(tool_sampler))
+    let begin_tokens =
+        model.str_to_token(tool_format.begin_token(), llama_cpp_2::model::AddBos::Never)?;
+
+    Ok(Some((tool_sampler, begin_tokens)))
+}
+
+/// The samplers a chat response can draw from: `base` for free generation,
+/// `tool` (grammar-constrained) once the model emits the tool-call begin token.
+/// The switch is driven token-by-token via [`ChatSampler::observe`].
+pub(crate) struct ChatSampler {
+    base: LlamaSampler,
+    tool: Option<LlamaSampler>,
+    /// Sequence whose completion switches to `tool`. Empty when `tool` is None.
+    begin_tokens: Vec<LlamaToken>,
+    /// How many leading `begin_tokens` the emitted stream has matched so far.
+    begin_match_len: usize,
+    grammar_activated: bool,
+}
+
+impl ChatSampler {
+    fn new(base: LlamaSampler, tool: Option<(LlamaSampler, Vec<LlamaToken>)>) -> Self {
+        let mut sampler = Self {
+            base,
+            tool: None,
+            begin_tokens: Vec::new(),
+            begin_match_len: 0,
+            grammar_activated: false,
+        };
+        sampler.set_tool(tool);
+        sampler
+    }
+
+    /// The sampler that should produce the next token.
+    pub(crate) fn active(&mut self) -> &mut LlamaSampler {
+        if self.grammar_activated {
+            self.tool
+                .as_mut()
+                .expect("tool sampler must exist once the grammar is activated")
+        } else {
+            &mut self.base
+        }
+    }
+
+    /// Feed an emitted token back in so the begin sequence can be tracked, and
+    /// switch to the tool sampler once it completes. Must be called on each
+    /// emitted token, in order, before its successor is sampled. Returns whether
+    /// the switch just happened.
+    pub(crate) fn observe(&mut self, token: LlamaToken) -> bool {
+        if self.grammar_activated || self.begin_tokens.is_empty() {
+            return false;
+        }
+
+        // Rolling match: extend on a hit, else restart from this token.
+        self.begin_match_len = if token == self.begin_tokens[self.begin_match_len] {
+            self.begin_match_len + 1
+        } else if token == self.begin_tokens[0] {
+            1
+        } else {
+            0
+        };
+
+        if self.begin_match_len < self.begin_tokens.len() {
+            return false;
+        }
+        self.begin_match_len = 0;
+
+        // Fast-forward the grammar matcher past the begin tokens.
+        let ts = self
+            .tool
+            .as_mut()
+            .expect("begin_tokens is non-empty only when a tool sampler exists");
+        ts.accept_many(self.begin_tokens.iter());
+        self.grammar_activated = true;
+        true
+    }
+
+    fn set_base(&mut self, base: LlamaSampler) {
+        self.base = base;
+    }
+
+    fn set_tool(&mut self, tool: Option<(LlamaSampler, Vec<LlamaToken>)>) {
+        match tool {
+            Some((sampler, begin_tokens)) => {
+                self.tool = Some(sampler);
+                self.begin_tokens = begin_tokens;
+            }
+            None => {
+                self.tool = None;
+                self.begin_tokens = Vec::new();
+            }
+        }
+        self.begin_match_len = 0;
+    }
+
+    /// Reset per-response state (RNG, penalty/DRY history, grammar matcher) and
+    /// return to free generation.
+    fn reset(&mut self) {
+        self.base.reset();
+        if let Some(ts) = self.tool.as_mut() {
+            ts.reset();
+        }
+        self.grammar_activated = false;
+        self.begin_match_len = 0;
+    }
 }
 
 /// A chat session: owns an [`InferenceEngine`] plus all the conversational state
@@ -1409,16 +1514,8 @@ fn build_tool_sampler(
 struct Chat<'a> {
     engine: InferenceEngine<'a>,
     should_stop: Arc<AtomicBool>,
-    /// Is read from the model, used to control lark generation. None when
-    /// model detection fails.
     tool_format: Option<ToolFormat>,
-    /// Built once on new chat worker. Used for free (unconstrained)
-    /// generation. Rebuilt whenever `sampler_config` changes.
-    base_sampler: llama_cpp_2::sampling::LlamaSampler,
-    /// Build once on new chat worker, if tools are given. Enforces tool-call
-    /// grammar and is switched for the rest of generation when the model's
-    /// begin tool token appears mid-stream.
-    tool_sampler: Option<llama_cpp_2::sampling::LlamaSampler>,
+    sampler: ChatSampler,
     sampler_config: SamplerConfig,
     messages: Vec<Message>,
     template_variables: std::collections::HashMap<String, bool>,
@@ -1448,8 +1545,8 @@ impl<'a> Chat<'a> {
             None => read_sampler_from_metadata(&model.language_model).unwrap_or_default(),
         };
 
-        // Pre-build the base sampler for `sampler_config`, reused for every
-        // response (see the `base_sampler` field doc).
+        // Pre-build the base sampler for `sampler_config`, reused (via
+        // `ChatSampler`) for every response.
         let base_sampler = sampler_config.build_sampler(&model.language_model)?;
 
         // Depends only on the model's chat template, not on `config.tools`,
@@ -1474,31 +1571,16 @@ impl<'a> Chat<'a> {
             tool_format.as_ref(),
         )?;
 
-        // Tool calling and MTP can't be combined yet, so force solo decode when
-        // tools are enabled. Temporary limitation: dynamic tool-grammar
-        // activation needs single-token decoding (MTP's one-token lookahead
-        // would sample the first tool-call body token unconstrained). Lifting
-        // this means rolling back the speculative lookahead on activation.
-        let mtp = if config.tools.is_empty() {
-            config.mtp
-        } else {
-            if config.mtp.is_some() {
-                warn!("Tool calling is enabled; disabling MTP for this chat. Combining them is planned but not yet supported.");
-            }
-            None
-        };
-
         // Build the low-level inference engine via the shared Worker constructor,
         // then take ownership of just the engine for the chat session.
         let Worker { engine, extra: () } =
-            Worker::new_with_type(model, config.n_ctx, false, mtp, config.n_threads, ())?;
+            Worker::new_with_type(model, config.n_ctx, false, config.mtp, config.n_threads, ())?;
 
         Ok(Chat {
             engine,
             should_stop,
             tool_format,
-            tool_sampler,
-            base_sampler,
+            sampler: ChatSampler::new(base_sampler, tool_sampler),
             sampler_config,
             messages: match config.system_prompt {
                 Some(msg) => vec![Message::System { content: msg }],
@@ -1678,16 +1760,7 @@ impl<'a> Chat<'a> {
         let mut full_response: String = String::with_capacity(4096);
         let mut tokens_written_until_now = TokenizerChunks::new();
 
-        // Reset stateful sub-sampler state (RNG, penalty/DRY history, grammar
-        // matcher, etc.) for this run — see `base_sampler` field doc.
-        self.base_sampler.reset();
-        if let Some(ts) = self.tool_sampler.as_mut() {
-            ts.reset();
-        }
-
-        // Set once the begin token is seen, never reset within this call —
-        // the Lark grammar ends generation via EOS on its own.
-        let mut grammar_activated = false;
+        self.sampler.reset();
 
         // init statefull decoder for split up tokens like emojis
         let mut decoder = encoding_rs::UTF_8.new_decoder();
@@ -1708,16 +1781,9 @@ impl<'a> Chat<'a> {
             // Sample next token(s), no need to use sampler.accept as sample already accepts the token.
             // using sampler.accept() will cause the sampler to crash when using grammar sampling.
             // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let new_tokens = if grammar_activated {
-                let ts = self
-                    .tool_sampler
-                    .as_mut()
-                    .expect("tool_sampler must exist when grammar_activated is true");
-                self.engine.sample_and_decode_next_tokens(ts)?
-            } else {
-                self.engine
-                    .sample_and_decode_next_tokens(&mut self.base_sampler)?
-            };
+            let new_tokens = self
+                .engine
+                .sample_and_decode_next_tokens(&mut self.sampler)?;
 
             tokens_written_until_now.append(TokenizerChunk::new_text(new_tokens.clone()));
 
@@ -1772,28 +1838,6 @@ impl<'a> Chat<'a> {
                 if has_eog {
                     hit_eog = true;
                     break;
-                }
-            }
-
-            // Activate the tool-call grammar once the model finishes emitting
-            // the format's begin token: fast-forward the pre-built tool_sampler's
-            // matcher past those tokens so it constrains the rest of the
-            // response. Only tool-enabled sessions have a tool_sampler.
-            if !grammar_activated {
-                if let (Some(format), Some(ts)) =
-                    (self.tool_format.as_ref(), self.tool_sampler.as_mut())
-                {
-                    let begin_token = format.begin_token();
-                    if full_response.ends_with(begin_token) {
-                        let begin_tokens = self
-                            .engine
-                            .ctx
-                            .model
-                            .str_to_token(begin_token, llama_cpp_2::model::AddBos::Never)?;
-                        ts.accept_many(begin_tokens.iter());
-                        grammar_activated = true;
-                        info!(begin_token, "Activated tool-call grammar");
-                    }
                 }
             }
 
@@ -1951,7 +1995,6 @@ impl<'a> Chat<'a> {
         let inference_lock_token = acquire_inference_lock();
         self.sync_context_with_render(&inference_lock_token)?;
 
-        // Get the tool call begin token from the format if tools are configured
         let tool_call_begin_token = self
             .tool_format
             .as_ref()
@@ -1982,7 +2025,7 @@ impl<'a> Chat<'a> {
         )?;
 
         self.engine.reset_context();
-        self.tool_sampler = tool_sampler;
+        self.sampler.set_tool(tool_sampler);
         self.tools = tools;
         self.messages = Vec::new();
         self.context = ChatContext::new();
@@ -2029,8 +2072,8 @@ impl<'a> Chat<'a> {
             self.tool_format.as_ref(),
         )?;
         self.sampler_config = sampler_config;
-        self.base_sampler = base_sampler;
-        self.tool_sampler = tool_sampler;
+        self.sampler.set_base(base_sampler);
+        self.sampler.set_tool(tool_sampler);
         Ok(())
     }
 
@@ -2078,7 +2121,7 @@ impl<'a> Chat<'a> {
             self.tool_format.as_ref(),
         )?;
         let chat_template = select_template(self.engine.ctx.model, !tools.is_empty())?;
-        self.tool_sampler = tool_sampler;
+        self.sampler.set_tool(tool_sampler);
         self.tools = tools;
         self.chat_template = chat_template;
         Ok(())

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -25,17 +25,16 @@
 
 use crate::errors::{
     ChatWorkerError, ContextSyncError, GenerateResponseError, InitWorkerError, MultimodalError,
-    RenderError, SayError, SelectTemplateError, SetToolsError, ShiftError, TokenizeError,
-    WrappedResponseError,
+    RenderError, SayError, ShiftError, TokenizeError, ToolCallingSetupError, WrappedResponseError,
 };
 use crate::inference::{acquire_inference_lock, InferenceEngine};
 use crate::llm;
 use crate::llm::{GlobalInferenceLockToken, Worker, WorkerGuard, WriteOutput};
 use crate::sampler::read_sampler_from_metadata;
-use crate::sampler::{SamplerConfig, ShiftStep};
+use crate::sampler::SamplerConfig;
 use crate::template::{select_template, ChatTemplate, ChatTemplateContext};
 use crate::tokenizer::{ChunkId, Prompt, PromptPart, Promptable, TokenizerChunk, TokenizerChunks};
-use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat};
+use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat, ToolFormatError};
 use ahash::AHasher;
 use indexmap::IndexMap;
 use llama_cpp_2::mtmd::MtmdBitmap;
@@ -1265,7 +1264,7 @@ fn process_worker_msg(worker_state: &mut Chat<'_>, msg: ChatMsg) -> Result<(), C
             sampler_config,
             output_tx,
         } => {
-            worker_state.set_sampler_config(sampler_config);
+            worker_state.set_sampler_config(sampler_config)?;
             let _ = output_tx.blocking_send(());
         }
         ChatMsg::GetChatHistory { output_tx } => {
@@ -1379,13 +1378,47 @@ impl ChatContext {
     }
 }
 
+/// Builds the tool-call grammar sampler for an already-detected `tool_format`
+/// (detection happens once, in `new_chat_worker` — see the `tool_format`
+/// field doc). `Ok(None)` if `tools` is empty. `Err(DetectionFailed)` if
+/// tools are requested but no format was ever detected for this model.
+fn build_tool_sampler(
+    model: &llama_cpp_2::model::LlamaModel,
+    tools: &[Tool],
+    sampler_config: &SamplerConfig,
+    tool_format: Option<&ToolFormat>,
+) -> Result<Option<llama_cpp_2::sampling::LlamaSampler>, ToolCallingSetupError> {
+    if tools.is_empty() {
+        return Ok(None);
+    }
+
+    let tool_format = tool_format.ok_or(ToolFormatError::DetectionFailed)?;
+
+    let lark = tool_format.to_lark(tools, Some(model))?;
+    debug!(grammar = %lark, "Generated tool calling grammar (Lark)");
+
+    // ~400ms llguidance init cost, paid here once instead of per activation.
+    let slices = tool_format.slice_regexes();
+    let tool_sampler = sampler_config.build_sampler_with_grammar(model, &lark, slices)?;
+
+    Ok(Some(tool_sampler))
+}
+
 /// A chat session: owns an [`InferenceEngine`] plus all the conversational state
 /// (messages, tools, template, sampler config).
 struct Chat<'a> {
     engine: InferenceEngine<'a>,
     should_stop: Arc<AtomicBool>,
-    tool_grammar: Option<gbnf::GbnfGrammar>,
+    /// Is read from the model, used to control lark generation. None when
+    /// model detection fails.
     tool_format: Option<ToolFormat>,
+    /// Built once on new chat worker. Used for free (unconstrained)
+    /// generation. Rebuilt whenever `sampler_config` changes.
+    base_sampler: llama_cpp_2::sampling::LlamaSampler,
+    /// Build once on new chat worker, if tools are given. Enforces tool-call
+    /// grammar and is switched for the rest of generation when the model's
+    /// begin tool token appears mid-stream.
+    tool_sampler: Option<llama_cpp_2::sampling::LlamaSampler>,
     sampler_config: SamplerConfig,
     messages: Vec<Message>,
     template_variables: std::collections::HashMap<String, bool>,
@@ -1410,37 +1443,36 @@ impl<'a> Chat<'a> {
 
         let template = select_template(&model.language_model, !config.tools.is_empty())?;
 
-        // Only detect tool calling format if tools are provided
-        let (tool_format, grammar) = if !config.tools.is_empty() {
-            match detect_tool_format(&model.language_model) {
-                Ok(format) => {
-                    debug!(format = ?format, "Detected tool calling format");
-
-                    let grammar = match format.generate_grammar(&config.tools) {
-                        Ok(g) => {
-                            debug!(grammar = %g.as_str(), root = %g.root_name, "Generated tool calling grammar");
-                            Some(g)
-                        }
-                        Err(e) => {
-                            debug!(error = %e, "Failed to generate grammar from tools");
-                            None
-                        }
-                    };
-
-                    (Some(format), grammar)
-                }
-                Err(e) => {
-                    debug!(error = %e, "Failed to detect tool format, tools will not work");
-                    (None, None)
-                }
-            }
-        } else {
-            (None, None)
-        };
         let sampler_config = match config.sampler_config {
             Some(sc) => sc,
             None => read_sampler_from_metadata(&model.language_model).unwrap_or_default(),
         };
+
+        // Pre-build the base sampler for `sampler_config`, reused for every
+        // response (see the `base_sampler` field doc).
+        let base_sampler = sampler_config.build_sampler(&model.language_model)?;
+
+        // Depends only on the model's chat template, not on `config.tools`,
+        // so detect it once here regardless (cheap — see `tool_format` field
+        // doc). Only a hard error if tools were actually requested.
+        let tool_format = match detect_tool_format(&model.language_model) {
+            Ok(format) => {
+                debug!(?format, "Detected tool calling format");
+                Some(format)
+            }
+            Err(e) if config.tools.is_empty() => {
+                debug!(error = %e, "Failed to detect tool calling format");
+                None
+            }
+            Err(e) => return Err(InitWorkerError::ToolCallingSetup(e.into())),
+        };
+
+        let tool_sampler = build_tool_sampler(
+            &model.language_model,
+            &config.tools,
+            &sampler_config,
+            tool_format.as_ref(),
+        )?;
 
         // Build the low-level inference engine via the shared Worker constructor,
         // then take ownership of just the engine for the chat session.
@@ -1450,8 +1482,9 @@ impl<'a> Chat<'a> {
         Ok(Chat {
             engine,
             should_stop,
-            tool_grammar: grammar,
             tool_format,
+            tool_sampler,
+            base_sampler,
             sampler_config,
             messages: match config.system_prompt {
                 Some(msg) => vec![Message::System { content: msg }],
@@ -1615,7 +1648,6 @@ impl<'a> Chat<'a> {
     // but assume it is.
     pub fn generate_response_until_done<F>(
         &mut self,
-        sampler_config: SamplerConfig,
         mut respond: F,
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<&mut Self, GenerateResponseError>
@@ -1632,9 +1664,16 @@ impl<'a> Chat<'a> {
         let mut full_response: String = String::with_capacity(4096);
         let mut tokens_written_until_now = TokenizerChunks::new();
 
-        // initialize sampler
-        // stateful samplers only live for one response
-        let mut sampler = sampler_config.to_stateful(self.engine.ctx.model)?;
+        // Reset stateful sub-sampler state (RNG, penalty/DRY history, grammar
+        // matcher, etc.) for this run — see `base_sampler` field doc.
+        self.base_sampler.reset();
+        if let Some(ts) = self.tool_sampler.as_mut() {
+            ts.reset();
+        }
+
+        // Set once the begin token is seen, never reset within this call —
+        // the Lark grammar ends generation via EOS on its own.
+        let mut grammar_activated = false;
 
         // init statefull decoder for split up tokens like emojis
         let mut decoder = encoding_rs::UTF_8.new_decoder();
@@ -1655,7 +1694,16 @@ impl<'a> Chat<'a> {
             // Sample next token(s), no need to use sampler.accept as sample already accepts the token.
             // using sampler.accept() will cause the sampler to crash when using grammar sampling.
             // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let new_tokens = self.engine.sample_and_decode_next_tokens(&mut sampler)?;
+            let new_tokens = if grammar_activated {
+                let ts = self
+                    .tool_sampler
+                    .as_mut()
+                    .expect("tool_sampler must exist when grammar_activated is true");
+                self.engine.sample_and_decode_next_tokens(ts)?
+            } else {
+                self.engine
+                    .sample_and_decode_next_tokens(&mut self.base_sampler)?
+            };
 
             tokens_written_until_now.append(TokenizerChunk::new_text(new_tokens.clone()));
 
@@ -1713,6 +1761,28 @@ impl<'a> Chat<'a> {
                 }
             }
 
+            // Activate the tool-call grammar once the model finishes emitting
+            // the format's begin token: fast-forward the pre-built tool_sampler's
+            // matcher past those tokens so it constrains the rest of the
+            // response. Only tool-enabled sessions have a tool_sampler.
+            if !grammar_activated {
+                if let (Some(format), Some(ts)) =
+                    (self.tool_format.as_ref(), self.tool_sampler.as_mut())
+                {
+                    let begin_token = format.begin_token();
+                    if full_response.ends_with(begin_token) {
+                        let begin_tokens = self
+                            .engine
+                            .ctx
+                            .model
+                            .str_to_token(begin_token, llama_cpp_2::model::AddBos::Never)?;
+                        ts.accept_many(begin_tokens.iter());
+                        grammar_activated = true;
+                        info!(begin_token, "Activated tool-call grammar");
+                    }
+                }
+            }
+
             if hit_eog {
                 break;
             }
@@ -1731,12 +1801,6 @@ impl<'a> Chat<'a> {
         // reset the stop flag
         self.should_stop
             .store(false, std::sync::atomic::Ordering::Relaxed);
-
-        // Get the tool call begin token from the format if tools are configured
-        let tool_call_begin = self
-            .tool_format
-            .as_ref()
-            .map(|fmt| fmt.begin_token().to_string());
 
         let prompt_text = prompt.to_string();
 
@@ -1771,33 +1835,15 @@ impl<'a> Chat<'a> {
         };
         self.add_user_message(content, assets);
 
-        // Modify sampler with tool grammar if we have tools
-        let sampler =
-            self.tool_grammar
-                .as_ref()
-                .map_or(self.sampler_config.clone(), |tool_grammar| {
-                    let mut steps = self.sampler_config.steps.clone();
-                    steps.insert(
-                        0,
-                        ShiftStep::Grammar {
-                            trigger_on: tool_call_begin.clone(),
-                            root: tool_grammar.root_name.to_string(),
-                            grammar: tool_grammar.as_str().into(),
-                        },
-                    );
-                    SamplerConfig::new(
-                        steps,
-                        self.sampler_config.sample_step.clone(),
-                        self.sampler_config.seed,
-                    )
-                });
+        // The tool-call grammar is NOT pre-injected into the chain. Lark/
+        // llguidance has no "trigger word" mechanism, so an always-on grammar
+        // would block EOS when the model just wants to chat. Instead the
+        // grammar is added dynamically inside `generate_response_until_done`
+        // the moment the begin token appears in the streamed output.
 
         // get the finished response
-        let mut response: String = self.wrapped_update_context_and_generate_response(
-            sampler.clone(),
-            respond.clone(),
-            tool_call_begin.clone(),
-        )?;
+        let mut response: String =
+            self.wrapped_update_context_and_generate_response(respond.clone())?;
 
         // Process tool calls if tool format is configured
         // Clone to avoid borrow issues in the loop
@@ -1835,17 +1881,14 @@ impl<'a> Chat<'a> {
                 }
 
                 // get the finished response
-                response = self.wrapped_update_context_and_generate_response(
-                    sampler.clone(),
-                    respond.clone(),
-                    tool_call_begin.clone(),
-                )?;
+                response = self.wrapped_update_context_and_generate_response(respond.clone())?;
             }
         } // Close if let Some(tool_format)
 
-        debug_assert!(tool_call_begin
+        debug_assert!(self
+            .tool_format
             .as_ref()
-            .is_none_or(|t| !response.contains(t.as_str())));
+            .is_none_or(|fmt| !response.contains(fmt.begin_token())));
         self.add_assistant_message(response);
 
         self.context.chunks = self.render_as_chunks(true)?;
@@ -1885,9 +1928,7 @@ impl<'a> Chat<'a> {
 
     fn wrapped_update_context_and_generate_response<F>(
         &mut self,
-        sampler: SamplerConfig,
         respond: F,
-        tool_call_begin_token: Option<String>,
     ) -> Result<String, WrappedResponseError>
     where
         F: Fn(llm::WriteOutput) + Clone,
@@ -1896,13 +1937,19 @@ impl<'a> Chat<'a> {
         let inference_lock_token = acquire_inference_lock();
         self.sync_context_with_render(&inference_lock_token)?;
 
+        // Get the tool call begin token from the format if tools are configured
+        let tool_call_begin_token = self
+            .tool_format
+            .as_ref()
+            .map(|fmt| fmt.begin_token().to_string());
+
         // wrap the response callback to keep a copy of the completed response
         // and to avoid emitting tool calls
         let (wrapped_respond, resp_receiver) =
             crate::inference::wrap_respond(respond.clone(), tool_call_begin_token);
 
         // llm go brrr
-        self.generate_response_until_done(sampler, wrapped_respond, &inference_lock_token)?;
+        self.generate_response_until_done(wrapped_respond, &inference_lock_token)?;
 
         Ok(resp_receiver.recv()?)
     }
@@ -1911,37 +1958,15 @@ impl<'a> Chat<'a> {
         &mut self,
         system_prompt: Option<String>,
         tools: Vec<Tool>,
-    ) -> Result<(), SelectTemplateError> {
+    ) -> Result<(), ChatWorkerError> {
         self.engine.reset_context();
 
-        // Detect tool format if not already detected and tools are provided
-        if !tools.is_empty() && self.tool_format.is_none() {
-            match detect_tool_format(self.engine.ctx.model) {
-                Ok(format) => {
-                    debug!(format = ?format, "Detected tool calling format");
-                    self.tool_format = Some(format);
-                }
-                Err(e) => {
-                    debug!(error = %e, "Failed to detect tool format, tools will not work");
-                }
-            }
-        }
-
-        self.tool_grammar = if !tools.is_empty() {
-            if let Some(ref format) = self.tool_format {
-                match format.generate_grammar(&tools) {
-                    Ok(g) => Some(g),
-                    Err(e) => {
-                        debug!(error = %e, "Failed to generate grammar from tools");
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        self.tool_sampler = build_tool_sampler(
+            self.engine.ctx.model,
+            &tools,
+            &self.sampler_config,
+            self.tool_format.as_ref(),
+        )?;
         self.tools = tools;
         self.messages = Vec::new();
         self.context = ChatContext::new();
@@ -1975,8 +2000,20 @@ impl<'a> Chat<'a> {
         self.template_variables.clone()
     }
 
-    pub fn set_sampler_config(&mut self, sampler_config: SamplerConfig) {
+    pub fn set_sampler_config(
+        &mut self,
+        sampler_config: SamplerConfig,
+    ) -> Result<(), ChatWorkerError> {
         self.sampler_config = sampler_config;
+        // The pre-built base and tool samplers embed the previous config — rebuild them.
+        self.base_sampler = self.sampler_config.build_sampler(self.engine.ctx.model)?;
+        self.tool_sampler = build_tool_sampler(
+            self.engine.ctx.model,
+            &self.tools,
+            &self.sampler_config,
+            self.tool_format.as_ref(),
+        )?;
+        Ok(())
     }
 
     pub fn set_system_prompt(
@@ -2014,35 +2051,13 @@ impl<'a> Chat<'a> {
         }
     }
 
-    pub fn set_tools(&mut self, tools: Vec<Tool>) -> Result<(), SetToolsError> {
-        // Detect tool format if not already detected and tools are provided
-        if !tools.is_empty() && self.tool_format.is_none() {
-            match detect_tool_format(self.engine.ctx.model) {
-                Ok(format) => {
-                    debug!(format = ?format, "Detected tool calling format");
-                    self.tool_format = Some(format);
-                }
-                Err(e) => {
-                    debug!(error = %e, "Failed to detect tool format, tools will not work");
-                }
-            }
-        }
-
-        self.tool_grammar = if !tools.is_empty() {
-            if let Some(ref format) = self.tool_format {
-                match format.generate_grammar(&tools) {
-                    Ok(g) => Some(g),
-                    Err(e) => {
-                        debug!(error = %e, "Failed to generate grammar from tools");
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+    pub fn set_tools(&mut self, tools: Vec<Tool>) -> Result<(), ChatWorkerError> {
+        self.tool_sampler = build_tool_sampler(
+            self.engine.ctx.model,
+            &tools,
+            &self.sampler_config,
+            self.tool_format.as_ref(),
+        )?;
         self.tools = tools;
 
         self.chat_template = select_template(self.engine.ctx.model, !self.tools.is_empty())?;
@@ -2394,6 +2409,68 @@ mod tests {
         }
     }
 
+    /// Time three sequential tool-calling turns on the same worker to confirm the
+    /// pre-built tool sampler amortizes the llguidance init cost at worker creation.
+    /// The one-time llguidance build appears in `setup_ms`; all three turns run at
+    /// similar speed. Turns 2 and 3 are slightly slower than turn 1 due to KV cache
+    /// growth, not grammar overhead.
+    #[test]
+    #[ignore = "manual perf benchmark — run with `cargo test bench_pre_built_sampler_amortization -- --ignored --nocapture`"]
+    fn bench_pre_built_sampler_amortization() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+        let setup_start = std::time::Instant::now();
+        let mut worker = Chat::new_chat_worker(
+            &model,
+            ChatConfig {
+                system_prompt: Some("You're a helpful assistant.".into()),
+                n_ctx: 4096,
+                tools: vec![test_tool()],
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("Failed making worker");
+        let setup_ms = setup_start.elapsed().as_millis();
+        eprintln!("[bench] worker setup: {setup_ms} ms");
+
+        // Warmup: one discarded turn to put GPU pipeline in steady state.
+        let (warmup_tx, warmup_rx) = std::sync::mpsc::channel::<String>();
+        worker
+            .ask("Hello.".into(), move |x| {
+                if let llm::WriteOutput::Done(r) = x {
+                    let _ = warmup_tx.send(r);
+                }
+            })
+            .expect("warmup failed");
+        let _ = warmup_rx.recv();
+
+        // Three distinct prompts that should each elicit a tool call.
+        let prompts = [
+            "What's the temperature in Copenhagen?",
+            "Now check the temperature in Beijing.",
+            "And one more: temperature in Copenhagen again, please.",
+        ];
+
+        for (i, prompt) in prompts.iter().enumerate() {
+            let (sender, receiver) = std::sync::mpsc::channel();
+            let f = move |x| {
+                if let llm::WriteOutput::Done(resp) = x {
+                    sender.send(resp).unwrap();
+                }
+            };
+            let turn_start = std::time::Instant::now();
+            worker.ask((*prompt).into(), f).expect("ask failed");
+            let _ = receiver.recv().unwrap();
+            eprintln!(
+                "[bench] turn {} ({} chars): {} ms",
+                i + 1,
+                prompt.len(),
+                turn_start.elapsed().as_millis()
+            );
+        }
+    }
+
     #[test]
     fn test_tool_chat() {
         test_utils::init_test_tracing();
@@ -2427,7 +2504,6 @@ mod tests {
 
         let result = receiver.recv().unwrap();
         println!("{}", result);
-        println!("{}", worker.tool_grammar.unwrap().as_str());
         assert!(result.contains("13.37"));
         assert!(result.contains("42.69"));
     }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2018,15 +2018,17 @@ impl<'a> Chat<'a> {
         &mut self,
         sampler_config: SamplerConfig,
     ) -> Result<(), ChatWorkerError> {
-        self.sampler_config = sampler_config;
-        // The pre-built base and tool samplers embed the previous config — rebuild them.
-        self.base_sampler = self.sampler_config.build_sampler(self.engine.ctx.model)?;
-        self.tool_sampler = build_tool_sampler(
+        let base_sampler = sampler_config.build_sampler(self.engine.ctx.model)?;
+        let tool_sampler = build_tool_sampler(
             self.engine.ctx.model,
             &self.tools,
-            &self.sampler_config,
+            &sampler_config,
             self.tool_format.as_ref(),
         )?;
+        // No error, commit the change.
+        self.sampler_config = sampler_config;
+        self.base_sampler = base_sampler;
+        self.tool_sampler = tool_sampler;
         Ok(())
     }
 

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -47,7 +47,7 @@ use std::hash::Hasher;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, MutexGuard};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Asset {
@@ -1474,10 +1474,24 @@ impl<'a> Chat<'a> {
             tool_format.as_ref(),
         )?;
 
+        // Tool calling and MTP can't be combined yet, so force solo decode when
+        // tools are enabled. Temporary limitation: dynamic tool-grammar
+        // activation needs single-token decoding (MTP's one-token lookahead
+        // would sample the first tool-call body token unconstrained). Lifting
+        // this means rolling back the speculative lookahead on activation.
+        let mtp = if config.tools.is_empty() {
+            config.mtp
+        } else {
+            if config.mtp.is_some() {
+                warn!("Tool calling is enabled; disabling MTP for this chat. Combining them is planned but not yet supported.");
+            }
+            None
+        };
+
         // Build the low-level inference engine via the shared Worker constructor,
         // then take ownership of just the engine for the chat session.
         let Worker { engine, extra: () } =
-            Worker::new_with_type(model, config.n_ctx, false, config.mtp, config.n_threads, ())?;
+            Worker::new_with_type(model, config.n_ctx, false, mtp, config.n_threads, ())?;
 
         Ok(Chat {
             engine,

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1973,14 +1973,16 @@ impl<'a> Chat<'a> {
         system_prompt: Option<String>,
         tools: Vec<Tool>,
     ) -> Result<(), ChatWorkerError> {
-        self.engine.reset_context();
-
-        self.tool_sampler = build_tool_sampler(
+        // Run fallible functions before committing to state.
+        let tool_sampler = build_tool_sampler(
             self.engine.ctx.model,
             &tools,
             &self.sampler_config,
             self.tool_format.as_ref(),
         )?;
+
+        self.engine.reset_context();
+        self.tool_sampler = tool_sampler;
         self.tools = tools;
         self.messages = Vec::new();
         self.context = ChatContext::new();
@@ -2018,6 +2020,7 @@ impl<'a> Chat<'a> {
         &mut self,
         sampler_config: SamplerConfig,
     ) -> Result<(), ChatWorkerError> {
+        // Run fallible functions before committing to state.
         let base_sampler = sampler_config.build_sampler(self.engine.ctx.model)?;
         let tool_sampler = build_tool_sampler(
             self.engine.ctx.model,
@@ -2025,7 +2028,6 @@ impl<'a> Chat<'a> {
             &sampler_config,
             self.tool_format.as_ref(),
         )?;
-        // No error, commit the change.
         self.sampler_config = sampler_config;
         self.base_sampler = base_sampler;
         self.tool_sampler = tool_sampler;
@@ -2068,16 +2070,17 @@ impl<'a> Chat<'a> {
     }
 
     pub fn set_tools(&mut self, tools: Vec<Tool>) -> Result<(), ChatWorkerError> {
-        self.tool_sampler = build_tool_sampler(
+        // Run fallible functions before committing to state.
+        let tool_sampler = build_tool_sampler(
             self.engine.ctx.model,
             &tools,
             &self.sampler_config,
             self.tool_format.as_ref(),
         )?;
+        let chat_template = select_template(self.engine.ctx.model, !tools.is_empty())?;
+        self.tool_sampler = tool_sampler;
         self.tools = tools;
-
-        self.chat_template = select_template(self.engine.ctx.model, !self.tools.is_empty())?;
-
+        self.chat_template = chat_template;
         Ok(())
     }
 

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -1154,6 +1154,9 @@ pub enum ToolCallingSetupError {
 
     #[error("Failed to build tool-call sampler: {0}")]
     Sampler(#[from] SamplerError),
+
+    #[error("Failed to tokenize the tool-call begin token: {0}")]
+    StringToToken(#[from] llama_cpp_2::StringToTokenError),
 }
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -419,6 +419,12 @@ pub enum InitWorkerError {
         )
     )]
     MtpDraftModelNotLoaded,
+
+    #[error("Invalid sampler configuration: {0}")]
+    InvalidSamplerConfig(#[from] SamplerError),
+
+    #[error("Failed setting up tool calling: {0}")]
+    ToolCallingSetup(#[from] ToolCallingSetupError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -844,8 +850,11 @@ pub(crate) enum ChatWorkerError {
     #[error("Error during context syncing: {0}")]
     ContextSyncError(#[from] ContextSyncError),
 
-    #[error("Error setting tools: {0}")]
-    SetTools(#[from] SetToolsError),
+    #[error("Invalid sampler configuration: {0}")]
+    InvalidSamplerConfig(#[from] SamplerError),
+
+    #[error("Failed setting up tool calling: {0}")]
+    ToolCallingSetup(#[from] ToolCallingSetupError),
 }
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
@@ -907,6 +916,9 @@ pub enum GenerateResponseError {
     #[error("Error converting token to bytes: {0}")]
     TokenToString(#[from] llama_cpp_2::TokenToStringError),
 
+    #[error("Error tokenizing tool-call begin token: {0}")]
+    StringToToken(#[from] llama_cpp_2::StringToTokenError),
+
     #[error("Error while decoding next token: {0}")]
     Decoding(#[from] DecodingError),
 
@@ -931,7 +943,7 @@ pub enum SamplerError {
     LazyGrammarError(#[from] llama_cpp_2::GrammarError),
 
     #[error("Could not initialize llguidance grammar: {0}")]
-    LlguidanceGrammarError(llama_cpp_2::GrammarError),
+    LlguidanceGrammarError(String),
 
     #[error("Could not convert GBNF grammar to Lark: {0}")]
     GbnfConversionError(String),
@@ -1132,14 +1144,16 @@ impl From<llama_cpp_2::ChatTemplateError> for SelectTemplateError {
     }
 }
 
+/// Errors building the tool-calling state (format detection, Lark grammar
+/// generation, and pre-building the tool-call sampler) for a non-empty set
+/// of tools.
 #[derive(Debug, thiserror::Error)]
-pub enum SetToolsError {
-    #[error("Failed syncing context to include the new tools: {0}")]
-    ContextSync(#[from] ContextSyncError),
-    #[error("Failed selecting chat template for the new tools: {0}")]
-    SelectTemplate(#[from] SelectTemplateError),
-    #[error("Failed rendering chat template with the new tools: {0}")]
-    Render(#[from] RenderError),
+pub enum ToolCallingSetupError {
+    #[error("Failed to detect or apply tool calling format: {0}")]
+    ToolFormat(#[from] crate::tool_calling::ToolFormatError),
+
+    #[error("Failed to build tool-call sampler: {0}")]
+    Sampler(#[from] SamplerError),
 }
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,5 +1,6 @@
 //! Generic inference pipeline, independent of chat history.
 
+use crate::chat::ChatSampler;
 use crate::errors::{ContextSyncError, DecodingError, MultimodalError, ReadError};
 use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
 use crate::tokenizer::{
@@ -10,7 +11,6 @@ use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::mtmd::MtmdBitmap;
 use llama_cpp_2::mtmd::MtmdInputChunks;
-use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::speculative::MtpSpeculative;
 use llama_cpp_2::token::LlamaToken;
 use std::ops::Range;
@@ -452,7 +452,7 @@ impl<'a> InferenceEngine<'a> {
 
     pub(crate) fn sample_and_decode_next_tokens(
         &mut self,
-        sampler: &mut LlamaSampler,
+        sampler: &mut ChatSampler,
     ) -> Result<Vec<LlamaToken>, DecodingError> {
         match &self.ctx {
             EngineContext::Solo(_) => self.sample_and_decode_solo(sampler),
@@ -462,10 +462,11 @@ impl<'a> InferenceEngine<'a> {
 
     fn sample_and_decode_solo(
         &mut self,
-        sampler: &mut LlamaSampler,
+        sampler: &mut ChatSampler,
     ) -> Result<Vec<LlamaToken>, DecodingError> {
         trace!("Applying sampler (solo)");
-        let new_token: LlamaToken = sampler.sample(&self.ctx, -1);
+        let new_token: LlamaToken = sampler.active().sample(&self.ctx, -1);
+        sampler.observe(new_token);
 
         self.small_batch.clear();
         self.small_batch.add(new_token, self.n_past, &[0], true)?;
@@ -481,12 +482,12 @@ impl<'a> InferenceEngine<'a> {
 
     fn sample_and_decode_speculative(
         &mut self,
-        sampler: &mut LlamaSampler,
+        sampler: &mut ChatSampler,
     ) -> Result<Vec<LlamaToken>, DecodingError> {
         trace!("Applying sampler (MTP speculative, deferred)");
         let pending = match self.pending {
             Some(p) => p,
-            None => sampler.sample(&self.ctx, -1),
+            None => sampler.active().sample(&self.ctx, -1),
         };
 
         if self.ctx.model.is_eog_token(pending) {
@@ -494,6 +495,8 @@ impl<'a> InferenceEngine<'a> {
             self.pending = None;
             return Ok(vec![pending]);
         }
+
+        sampler.observe(pending);
 
         let mut drafts = {
             let EngineContext::Speculative(spec) = &mut self.ctx else {
@@ -521,7 +524,7 @@ impl<'a> InferenceEngine<'a> {
                 };
                 spec.accept(0)?;
             }
-            let new_pending = sampler.sample(&self.ctx, -1);
+            let new_pending = sampler.active().sample(&self.ctx, -1);
             self.n_past += 1;
             self.pending = Some(new_pending);
             return Ok(vec![pending]);
@@ -543,7 +546,7 @@ impl<'a> InferenceEngine<'a> {
         let mut accepted_drafts: Vec<LlamaToken> = Vec::with_capacity(k_max);
         let mut new_pending = None;
         for (i, &draft) in drafts.iter().enumerate() {
-            let ti = sampler.sample(&self.ctx, i as i32);
+            let ti = sampler.active().sample(&self.ctx, i as i32);
             if self.ctx.model.is_eog_token(ti) {
                 trace!(?ti, "MTP: target sampled EOG during verify, stopping");
                 new_pending = Some(ti);
@@ -554,8 +557,10 @@ impl<'a> InferenceEngine<'a> {
                 break;
             }
             accepted_drafts.push(draft);
+            sampler.observe(draft); // detects switch to grammar-constrained sampling
         }
-        let new_pending = new_pending.unwrap_or_else(|| sampler.sample(&self.ctx, k_max as i32));
+        let new_pending =
+            new_pending.unwrap_or_else(|| sampler.active().sample(&self.ctx, k_max as i32));
         let j = accepted_drafts.len();
 
         if j < k_max {

--- a/nobodywho/core/src/sampler.rs
+++ b/nobodywho/core/src/sampler.rs
@@ -139,16 +139,38 @@ impl SamplerConfig {
         }
     }
 
-    pub fn to_stateful(&self, model: &LlamaModel) -> Result<LlamaSampler, SamplerError> {
-        let sample_step = self.sample_step.clone();
+    pub fn build_sampler(&self, model: &LlamaModel) -> Result<LlamaSampler, SamplerError> {
+        self.build_sampler_with_prepended_step(model, None)
+    }
 
-        let mut shift_steps = self
-            .steps
-            .iter()
-            .map(|step| self.build_step(model, step.clone()))
+    /// Builds a sampler chain with a `LarkWithSlices` grammar step prepended.
+    /// `slices` are vocabulary hint regexes llguidance uses as bitmask
+    /// shortcuts instead of a full vocab walk (see [`llguidance_sampler`]).
+    pub fn build_sampler_with_grammar(
+        &self,
+        model: &LlamaModel,
+        lark: &str,
+        slices: Vec<String>,
+    ) -> Result<LlamaSampler, SamplerError> {
+        self.build_sampler_with_prepended_step(
+            model,
+            Some(ShiftStep::LarkWithSlices(lark.to_string(), slices)),
+        )
+    }
+
+    fn build_sampler_with_prepended_step(
+        &self,
+        model: &LlamaModel,
+        extra_step: Option<ShiftStep>,
+    ) -> Result<LlamaSampler, SamplerError> {
+        // Grammar step goes first, so it constrains before anything else runs.
+        let mut shift_steps = extra_step
+            .into_iter()
+            .chain(self.steps.iter().cloned())
+            .map(|step| self.build_step(model, step))
             .collect::<Result<Vec<_>, SamplerError>>()?;
 
-        let final_sampler = match sample_step {
+        let final_sampler = match self.sample_step.clone() {
             SampleStep::Dist => LlamaSampler::dist(self.seed),
             SampleStep::Greedy => LlamaSampler::greedy(),
             SampleStep::MirostatV1 { tau, eta, m } => {
@@ -222,17 +244,15 @@ impl SamplerConfig {
                 penalty_present,
             )),
             ShiftStep::Temperature { temperature } => Ok(LlamaSampler::temp(temperature)),
-            ShiftStep::JsonSchema(schema) => {
-                LlamaSampler::llguidance(model, "json_schema", &schema)
-                    .map_err(SamplerError::LlguidanceGrammarError)
-            }
-            ShiftStep::Regex(pattern) => LlamaSampler::llguidance(model, "regex", &pattern)
-                .map_err(SamplerError::LlguidanceGrammarError),
+            ShiftStep::JsonSchema(schema) => llguidance_sampler(model, "json_schema", &schema, &[]),
+            ShiftStep::Regex(pattern) => llguidance_sampler(model, "regex", &pattern, &[]),
             ShiftStep::Lark(lark) => {
                 let lark = gbnf::gbnf_to_lark::any_to_lark(&lark)
                     .map_err(|e| SamplerError::GbnfConversionError(e.to_string()))?;
-                LlamaSampler::llguidance(model, "lark", &lark)
-                    .map_err(SamplerError::LlguidanceGrammarError)
+                llguidance_sampler(model, "lark", &lark, &[])
+            }
+            ShiftStep::LarkWithSlices(lark, slices) => {
+                llguidance_sampler(model, "lark", &lark, &slices)
             }
         }
     }
@@ -272,6 +292,28 @@ impl SamplerConfig {
     ) -> Result<LlamaSampler, SamplerError> {
         Ok(LlamaSampler::grammar(model, grammar, root)?)
     }
+}
+
+/// Builds an llguidance [`LlamaSampler`] for a `json_schema`/`regex`/`lark`
+/// `tag` + `grammar` content string. `slices` are optional vocabulary hints
+/// (see [`crate::tool_calling::ToolFormatHandler::slice_regexes`]), `&[]` for none.
+pub fn llguidance_sampler(
+    model: &LlamaModel,
+    tag: &str,
+    grammar: &str,
+    slices: &[String],
+) -> Result<LlamaSampler, SamplerError> {
+    use llguidance::toktrie::InferenceCapabilities;
+    use llguidance::{api::TopLevelGrammar, Matcher, ParserFactory};
+    let tok_env = LlamaSampler::llguidance_tok_env(model);
+    let factory = ParserFactory::new(&tok_env, InferenceCapabilities::default(), slices)
+        .map_err(|e| SamplerError::LlguidanceGrammarError(e.to_string()))?;
+    let tlg = TopLevelGrammar::from_tagged_str(tag, grammar)
+        .map_err(|e| SamplerError::LlguidanceGrammarError(e.to_string()))?;
+    let parser = factory
+        .create_parser(tlg)
+        .map_err(|e| SamplerError::LlguidanceGrammarError(e.to_string()))?;
+    Ok(LlamaSampler::from(Matcher::new(Ok(parser))))
 }
 
 impl Default for SamplerConfig {
@@ -398,6 +440,9 @@ pub enum ShiftStep {
     Regex(String),
     /// Constrain output using a Lark context-free grammar via llguidance.
     Lark(String),
+    /// Like [`Lark`][ShiftStep::Lark] but with custom slice regexes passed to the `ParserFactory`.
+    /// See [`llguidance_sampler`] for how slices speed up per-token constraint evaluation.
+    LarkWithSlices(String, Vec<String>),
     #[serde(rename = "dry")]
     DRY {
         multiplier: f32,

--- a/nobodywho/core/src/sampler.rs
+++ b/nobodywho/core/src/sampler.rs
@@ -620,7 +620,7 @@ mod tests {
         let path = std::env::var("TEST_MODEL").expect("set TEST_MODEL to a gguf path");
         let model = crate::llm::get_model(&path, false, None, None, None).expect("load model");
 
-        let res = SamplerPresets::json().to_stateful(&model.language_model);
+        let res = SamplerPresets::json().build_sampler(&model.language_model);
         assert!(res.is_ok(), "json preset failed: {:?}", res.err());
     }
 

--- a/nobodywho/core/src/tool_calling/functiongemma.rs
+++ b/nobodywho/core/src/tool_calling/functiongemma.rs
@@ -1,6 +1,4 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{not_chars, nt, seq, t, t_star, GrammarBuilder};
-use gbnf::GbnfGrammar;
 use serde_json::json;
 use tracing::debug;
 
@@ -16,84 +14,55 @@ impl ToolFormatHandler for FunctionGemmaHandler {
         "<end_function_call>"
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
-        // FunctionGemma format: call:tool_name{param1:<escape>value<escape>, param2:<escape>value<escape>}
-        let mut builder = GrammarBuilder::new().rule("ws", t_star(" ")).rule(
-            "value",
-            seq(&[
-                t("<escape>"),
-                not_chars(&['<', '>', '{', '}', ',', ':']),
-                t("<escape>"),
-            ]),
-        );
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let mut lark = String::from("%llguidance {}\n");
+        let begin = super::lark_delimiter(model, "<start_function_call>");
+        let end = super::lark_delimiter(model, "<end_function_call>");
+        lark.push_str(&format!("start: {begin} ws? functioncall ws? {end} ws?\n"));
 
-        let tool_rules: Vec<_> = tools
-            .iter()
-            .map(|tool| {
-                // Sanitize the tool name for GBNF (only alphanumeric allowed, no underscores)
-                tool.name
-                    .chars()
-                    .filter(|c| c.is_alphanumeric())
-                    .collect::<String>()
-            })
-            .collect();
+        let alts: Vec<String> = (0..tools.len()).map(|i| format!("tool_{i}")).collect();
+        lark.push_str(&format!("functioncall: {}\n", alts.join(" | ")));
 
-        for (tool_name, tool) in tool_rules.iter().zip(tools.iter()) {
+        for (i, tool) in tools.iter().enumerate() {
             let properties = tool
                 .json_schema
                 .get("properties")
                 .and_then(|p| p.as_object());
-
-            let mut items = vec![t("call:"), t(&tool.name), t("{")];
+            let name = super::escape_lark_string(&tool.name);
+            let mut rule = format!("tool_{i}: \"call:{name}{{\"");
 
             if let Some(props) = properties {
                 if !props.is_empty() {
-                    let params_rule = format!("{}params", tool_name);
-                    items.push(nt(&params_rule));
-
-                    let params: Vec<Vec<_>> = props
-                        .keys()
-                        .map(|name| vec![t(name), t(":"), nt("value")])
-                        .collect();
-
-                    // Join parameters with ", " separator
-                    let mut param_items = Vec::new();
-                    for (i, param) in params.iter().enumerate() {
-                        if i > 0 {
-                            param_items.push(t(", "));
+                    let mut first = true;
+                    for param_name in props.keys() {
+                        if !first {
+                            rule.push_str(" \", \"");
                         }
-                        param_items.extend_from_slice(param);
+                        let param_name = super::escape_lark_string(param_name);
+                        rule.push_str(&format!(" \"{param_name}:\" value"));
+                        first = false;
                     }
-
-                    builder = builder.rule(&params_rule, seq(&param_items));
                 }
             }
 
-            items.push(t("}"));
-            builder = builder.rule(tool_name, seq(&items));
+            rule.push_str(" \"}\"");
+            lark.push_str(&rule);
+            lark.push('\n');
         }
 
-        for tool_rule in &tool_rules {
-            builder = builder.rule("functioncall", nt(tool_rule));
-        }
+        let escape = super::lark_delimiter(model, "<escape>");
+        lark.push_str(&format!("value: {escape} /[^<>{{}},:]+/ {escape}\n"));
+        lark.push_str("ws: / */\n");
+        Ok(lark)
+    }
 
-        let grammar = builder
-            .rule(
-                "toolcall",
-                seq(&[
-                    t(self.begin_token()),
-                    nt("ws"),
-                    nt("functioncall"),
-                    nt("ws"),
-                    t(self.end_token()),
-                    nt("ws"),
-                ]),
-            )
-            .rule("root", nt("toolcall"))
-            .root("root")
-            .build();
-
-        Ok(grammar)
+    /// Vocabulary hint: value bytes that aren't structural delimiters (`< > { } , :`).
+    fn slice_regexes(&self) -> Vec<String> {
+        vec![r"[^<>{},:]+".to_string()]
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {

--- a/nobodywho/core/src/tool_calling/gemma4.rs
+++ b/nobodywho/core/src/tool_calling/gemma4.rs
@@ -1,7 +1,4 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{alt, nt, nt_plus, seq, t, GrammarBuilder};
-use gbnf::{Expr, GbnfGrammar, Quantifier, TokenRef};
-use gbnf_macro::gbnf;
 use nom::{
     branch::alt as nom_alt,
     bytes::complete::{tag, take_until, take_while1},
@@ -131,40 +128,21 @@ fn single_tool_call(input: &str) -> IResult<&str, ToolCall> {
 }
 
 // ============================================================================
-// Grammar generation helpers
+// Grammar generation (Lark)
 // ============================================================================
 
-/// Create the Expr for the <|"|> special token
-fn quote_token_expr() -> Expr {
-    Expr::Token(TokenRef::ByString {
-        name: r#"|"|"#.to_string(),
-        negated: false,
-    })
-}
+// Gemma4's delimiters are registered in the tokenizer with the angle brackets
+// as part of the special-token name (e.g. the vocab entry is `<|"|>`). In Lark
+// string literals, `"<|\"|>"` emits those bytes directly — the model still
+// produces a single vocab token because that is the canonical tokenization.
 
-/// Create the Expr for the <|tool_call> special token
-fn begin_token_expr() -> Expr {
-    Expr::Token(TokenRef::ByString {
-        name: "|tool_call".to_string(),
-        negated: false,
-    })
-}
-
-/// Create the Expr for the <tool_call|> special token
-fn end_token_expr() -> Expr {
-    Expr::Token(TokenRef::ByString {
-        name: "tool_call|".to_string(),
-        negated: false,
-    })
-}
-
-/// Walk a JSON schema and add grammar rules to the builder.
-/// Returns the rule name to reference and the updated builder.
-fn schema_to_rule(
+/// Recursively emit Lark rules for one JSON schema node.
+/// Appends new rules to `rules` and returns the rule name to reference.
+fn schema_to_lark(
     schema: &Value,
-    mut builder: GrammarBuilder<gbnf::builder::NoRoot>,
+    rules: &mut Vec<String>,
     prefix: &str,
-) -> Result<(String, GrammarBuilder<gbnf::builder::NoRoot>), ToolFormatError> {
+) -> Result<String, ToolFormatError> {
     debug!(json_schema = %schema);
 
     let type_str = schema
@@ -175,131 +153,101 @@ fn schema_to_rule(
     match type_str {
         "string" => {
             if let Some(enum_values) = schema.get("enum").and_then(|e| e.as_array()) {
-                // enum: alternation of literal string values
-                let rule_name = format!("{}-enum", prefix);
-                let alts: Vec<Expr> = enum_values
+                let rule_name = format!("{prefix}_enum");
+                let alts: Vec<String> = enum_values
                     .iter()
                     .filter_map(|v| v.as_str())
-                    .map(|s| seq(&[quote_token_expr(), t(s), quote_token_expr()]))
+                    .map(|s| {
+                        let esc = super::escape_lark_string(s);
+                        format!(r#""<|\"|>" "{esc}" "<|\"|>""#)
+                    })
                     .collect();
-                builder = builder.rule(&rule_name, alt(&alts));
-                Ok((rule_name, builder))
-            } else {
-                Ok(("gemmafour-string".to_string(), builder))
+                if !alts.is_empty() {
+                    rules.push(format!("{rule_name}: {}", alts.join(" | ")));
+                    return Ok(rule_name);
+                }
             }
+            Ok("gemmafour_string".to_string())
         }
-        "number" => Ok(("gemmafour-number".to_string(), builder)),
-        "integer" => Ok(("gemmafour-integer".to_string(), builder)),
-        "boolean" => Ok(("gemmafour-boolean".to_string(), builder)),
-        "null" => Ok(("gemmafour-null".to_string(), builder)),
+        "number" => Ok("gemmafour_number".to_string()),
+        "integer" => Ok("gemmafour_integer".to_string()),
+        "boolean" => Ok("gemmafour_bool".to_string()),
+        "null" => Ok("gemmafour_null".to_string()),
         "object" => {
-            let rule_name = format!("{}-obj", prefix);
+            let rule_name = format!("{prefix}_obj");
             let props = schema
                 .get("properties")
                 .and_then(|p| p.as_object())
                 .filter(|p| !p.is_empty());
 
             if let Some(props) = props {
-                // Known properties: fixed key:value pairs
-                let mut items: Vec<Expr> = vec![t("{")];
+                // Known properties: emit fixed key:value sequence
+                let mut parts = vec!["\"{\"".to_string()];
                 for (i, (key, prop_schema)) in props.iter().enumerate() {
                     if i > 0 {
-                        items.push(t(","));
+                        parts.push("\",\"".to_string());
                     }
-                    let prop_prefix = format!("{}-{}", prefix, key.replace('_', "-"));
-                    let (prop_rule, new_builder) =
-                        schema_to_rule(prop_schema, builder, &prop_prefix)?;
-                    builder = new_builder;
-                    items.push(t(key));
-                    items.push(t(":"));
-                    items.push(nt(&prop_rule));
+                    let prop_rule = schema_to_lark(
+                        prop_schema,
+                        rules,
+                        &format!("{prefix}_{i}_{}", super::sanitize_lark(key)),
+                    )?;
+                    parts.push(format!("\"{}\"", super::escape_lark_string(key)));
+                    parts.push("\":\"".to_string());
+                    parts.push(prop_rule);
                 }
-                items.push(t("}"));
-                builder = builder.rule(&rule_name, seq(&items));
+                parts.push("\"}\"".to_string());
+                rules.push(format!("{rule_name}: {}", parts.join(" ")));
             } else {
-                // Free-form object: arbitrary key:value pairs
-                let default_val = Value::Object(serde_json::Map::from_iter([(
-                    "type".to_string(),
-                    Value::String("string".to_string()),
-                )]));
-                let val_schema = schema.get("additionalProperties").unwrap_or(&default_val);
-                let val_prefix = format!("{}-val", prefix);
-                let (val_rule, new_builder) = schema_to_rule(val_schema, builder, &val_prefix)?;
-                builder = new_builder;
+                // Free-form object: arbitrary key:value pairs, or empty
+                let default_str = serde_json::json!({"type": "string"});
+                let val_schema = schema.get("additionalProperties").unwrap_or(&default_str);
+                let val_rule = schema_to_lark(val_schema, rules, &format!("{prefix}_val"))?;
 
-                let kv_rule = format!("{}-kv", prefix);
-                builder =
-                    builder.rule(&kv_rule, seq(&[nt("gemmafour-key"), t(":"), nt(&val_rule)]));
-                let repeat_rule = format!("{}-repeat", prefix);
-                builder = builder.rule(&repeat_rule, seq(&[t(","), nt(&kv_rule)]));
-                builder = builder.rule(
-                    &rule_name,
-                    alt(&[
-                        seq(&[
-                            t("{"),
-                            nt(&kv_rule),
-                            Expr::Quantified {
-                                expr: Box::new(nt(&repeat_rule)),
-                                quantifier: Quantifier::ZeroOrMore,
-                            },
-                            t("}"),
-                        ]),
-                        seq(&[t("{"), t("}")]),
-                    ]),
-                );
+                let kv_rule = format!("{prefix}_kv");
+                rules.push(format!("{kv_rule}: gemmafour_key \":\" {val_rule}"));
+
+                let repeat_rule = format!("{prefix}_repeat");
+                rules.push(format!("{repeat_rule}: \",\" {kv_rule}"));
+
+                rules.push(format!(
+                    "{rule_name}: \"{{\" {kv_rule} {repeat_rule}* \"}}\" | \"{{}}\""
+                ));
             }
-            Ok((rule_name, builder))
+            Ok(rule_name)
         }
         "array" if schema.get("prefixItems").is_some() => {
-            // Tuple: fixed positional types, e.g. [string, integer]
-            let rule_name = format!("{}-arr", prefix);
+            // Tuple: fixed positional types
+            let rule_name = format!("{prefix}_arr");
             let prefix_items = schema["prefixItems"].as_array().ok_or_else(|| {
                 ToolFormatError::GrammarGenerationFailed("prefixItems is not an array".into())
             })?;
-            let mut elems: Vec<Expr> = vec![t("[")];
+            let mut parts = vec!["\"[\"".to_string()];
             for (i, item_schema) in prefix_items.iter().enumerate() {
                 if i > 0 {
-                    elems.push(t(","));
+                    parts.push("\",\"".to_string());
                 }
-                let (item_rule, b) =
-                    schema_to_rule(item_schema, builder, &format!("{}-{}", prefix, i))?;
-                builder = b;
-                elems.push(nt(&item_rule));
+                let item_rule = schema_to_lark(item_schema, rules, &format!("{prefix}_{i}"))?;
+                parts.push(item_rule);
             }
-            elems.push(t("]"));
-            builder = builder.rule(&rule_name, seq(&elems));
-            Ok((rule_name, builder))
+            parts.push("\"]\"".to_string());
+            rules.push(format!("{rule_name}: {}", parts.join(" ")));
+            Ok(rule_name)
         }
         "array" => {
-            let rule_name = format!("{}-arr", prefix);
-            let default_items = Value::Object(serde_json::Map::from_iter([(
-                "type".to_string(),
-                Value::String("string".to_string()),
-            )]));
-            let item_schema = schema.get("items").unwrap_or(&default_items);
-            let (item_rule, b) = schema_to_rule(item_schema, builder, &format!("{}-item", prefix))?;
-            builder = b;
+            let rule_name = format!("{prefix}_arr");
+            let default_str = serde_json::json!({"type": "string"});
+            let item_schema = schema.get("items").unwrap_or(&default_str);
+            let item_rule = schema_to_lark(item_schema, rules, &format!("{prefix}_item"))?;
 
-            let repeat_rule = format!("{}-repeat", prefix);
-            builder = builder.rule(&repeat_rule, seq(&[t(","), nt(&item_rule)]));
-            builder = builder.rule(
-                &rule_name,
-                alt(&[
-                    seq(&[
-                        t("["),
-                        nt(&item_rule),
-                        Expr::Quantified {
-                            expr: Box::new(nt(&repeat_rule)),
-                            quantifier: Quantifier::ZeroOrMore,
-                        },
-                        t("]"),
-                    ]),
-                    seq(&[t("["), t("]")]),
-                ]),
-            );
-            Ok((rule_name, builder))
+            let repeat_rule = format!("{prefix}_repeat");
+            rules.push(format!("{repeat_rule}: \",\" {item_rule}"));
+            rules.push(format!(
+                "{rule_name}: \"[\" {item_rule} {repeat_rule}* \"]\" | \"[]\""
+            ));
+            Ok(rule_name)
         }
-        _ => Ok(("gemmafour-string".to_string(), builder)),
+        _ => Ok("gemmafour_string".to_string()),
     }
 }
 
@@ -319,95 +267,55 @@ impl ToolFormatHandler for Gemma4Handler {
         END_TOKEN
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
-        // Step 1: Static primitives via gbnf! macro
-        let primitives = gbnf! {
-            gemmafour-boolean ::= "true" | "false"
-            gemmafour-null ::= "null"
-            gemmafour-digit ::= [0-9]
-            gemmafour-integer ::= "-"? gemmafour-digit+
-            gemmafour-number ::= gemmafour-integer ("." gemmafour-digit+)?
-            root ::= gemmafour-number
-        };
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let mut lark = String::from("%llguidance {}\n");
+        lark.push_str("start: toolcall+\n");
+        let begin = super::lark_delimiter(model, BEGIN_TOKEN);
+        let end = super::lark_delimiter(model, END_TOKEN);
+        lark.push_str(&format!("toolcall: {begin} tool_alt {end}\n"));
 
-        // Step 2: Extend with gemmafour-string via builder.
-        // Strings are delimited by <|"|>, so a string char is anything that isn't that token.
-        let mut builder = GrammarBuilder::from_existing(primitives)
-            .rule(
-                "gemmafour-strchar",
-                Expr::Token(TokenRef::ByString {
-                    name: r#"|"|"#.to_string(),
-                    negated: true,
-                }),
-            )
-            .rule(
-                "gemmafour-string",
-                seq(&[
-                    quote_token_expr(),
-                    Expr::Quantified {
-                        expr: Box::new(nt("gemmafour-strchar")),
-                        quantifier: Quantifier::ZeroOrMore,
-                    },
-                    quote_token_expr(),
-                ]),
-            )
-            .rule(
-                "gemmafour-keychar",
-                alt(&[
-                    Expr::CharacterRange(gbnf::CharacterRange::Range {
-                        begin: 'a',
-                        end: 'z',
-                        negated: false,
-                    }),
-                    Expr::CharacterRange(gbnf::CharacterRange::Range {
-                        begin: 'A',
-                        end: 'Z',
-                        negated: false,
-                    }),
-                    Expr::CharacterRange(gbnf::CharacterRange::Range {
-                        begin: '0',
-                        end: '9',
-                        negated: false,
-                    }),
-                    t("_"),
-                ]),
-            )
-            .rule(
-                "gemmafour-key",
-                Expr::Quantified {
-                    expr: Box::new(nt("gemmafour-keychar")),
-                    quantifier: Quantifier::OneOrMore,
-                },
-            );
+        let mut tool_rules: Vec<String> = Vec::new();
+        let mut tool_call_names: Vec<String> = Vec::new();
 
-        // Step 3: Per-tool rules from JSON schema
-        let mut tool_rule_names = Vec::new();
         for (i, tool) in tools.iter().enumerate() {
-            let prefix = format!("tool{}", i);
-            let (params_rule, new_builder) = schema_to_rule(&tool.json_schema, builder, &prefix)?;
-            builder = new_builder;
-
-            let tool_rule = format!("tool{}-call", i);
-            builder = builder.rule(
-                &tool_rule,
-                seq(&[t("call:"), t(&tool.name), nt(&params_rule)]),
-            );
-            tool_rule_names.push(tool_rule);
+            let prefix = format!("tool{i}");
+            let params_rule = schema_to_lark(&tool.json_schema, &mut tool_rules, &prefix)?;
+            let tool_rule = format!("{prefix}_call");
+            tool_rules.push(format!(
+                "{tool_rule}: \"call:{}\" {params_rule}",
+                super::escape_lark_string(&tool.name)
+            ));
+            tool_call_names.push(tool_rule);
         }
 
-        // Step 4: Combine tools
-        let tool_alts: Vec<Expr> = tool_rule_names.iter().map(|n| nt(n)).collect();
-        let grammar = builder
-            .rule("tool-alt", alt(&tool_alts))
-            .rule(
-                "toolcall",
-                seq(&[begin_token_expr(), nt("tool-alt"), end_token_expr()]),
-            )
-            .rule("superroot", nt_plus("toolcall"))
-            .root("superroot")
-            .build();
+        lark.push_str(&format!("tool_alt: {}\n", tool_call_names.join(" | ")));
 
-        Ok(grammar)
+        // Shared primitive rules referenced by schema_to_lark output.
+        // The string body matches any text up to the closing `<|"|>` delimiter,
+        // which the lazy `suffix` consumes. This allows values containing `<`;
+        // the old `/[^<]*/` banned every `<`, not just the delimiter.
+        lark.push_str(r#"gemmafour_string: "<|\"|>" gemmafour_strbody"#);
+        lark.push('\n');
+        lark.push_str(r#"gemmafour_strbody[suffix=/<\|"\|>/]: /(?s:.*)/"#);
+        lark.push('\n');
+        lark.push_str("gemmafour_key: /[a-zA-Z0-9_]+/\n");
+        lark.push_str(r#"gemmafour_bool: "true" | "false""#);
+        lark.push('\n');
+        lark.push_str(r#"gemmafour_null: "null""#);
+        lark.push('\n');
+        lark.push_str("gemmafour_integer: /-?[0-9]+/\n");
+        lark.push_str("gemmafour_number: /-?[0-9]+(\\.[0-9]+)?/\n");
+
+        for rule in &tool_rules {
+            lark.push_str(rule);
+            lark.push('\n');
+        }
+
+        Ok(lark)
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
@@ -421,6 +329,11 @@ impl ToolFormatHandler for Gemma4Handler {
         };
 
         Some(calls)
+    }
+
+    /// Vocabulary hint: value bytes that aren't structural delimiters (`< > { } , :`).
+    fn slice_regexes(&self) -> Vec<String> {
+        vec![r"[^<>{},:]+".to_string()]
     }
 }
 
@@ -489,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_grammar_smoke() {
+    fn test_lark_smoke() {
         let handler = Gemma4Handler;
         let tools = vec![
             Tool::new(
@@ -512,11 +425,38 @@ mod tests {
             ),
         ];
 
-        let result = handler.generate_grammar(&tools);
-        assert!(
-            result.is_ok(),
-            "Grammar generation failed: {:?}",
-            result.err()
+        let lark = handler.to_lark(&tools, None).expect("lark should build");
+        assert!(lark.contains("%llguidance"));
+        assert!(lark.contains("<|tool_call>"));
+        assert!(lark.contains("<tool_call|>"));
+        assert!(lark.contains("call:get_weather"));
+        assert!(lark.contains("call:get_time"));
+        assert!(lark.contains("gemmafour_string"));
+    }
+
+    #[test]
+    fn test_lark_scalar_types() {
+        let handler = Gemma4Handler;
+        let tool = Tool::new(
+            "f",
+            "test",
+            json!({
+                "type": "object",
+                "properties": {
+                    "n": { "type": "integer" },
+                    "x": { "type": "number" },
+                    "b": { "type": "boolean" },
+                    "z": { "type": "null" },
+                    "s": { "type": "string" }
+                }
+            }),
+            std::sync::Arc::new(|_| String::new()),
         );
+        let lark = handler.to_lark(&[tool], None).expect("lark should build");
+        assert!(lark.contains("gemmafour_integer"));
+        assert!(lark.contains("gemmafour_number"));
+        assert!(lark.contains("gemmafour_bool"));
+        assert!(lark.contains("gemmafour_null"));
+        assert!(lark.contains("gemmafour_string"));
     }
 }

--- a/nobodywho/core/src/tool_calling/gemma4.rs
+++ b/nobodywho/core/src/tool_calling/gemma4.rs
@@ -62,7 +62,7 @@ fn gemma4_number(input: &str) -> IResult<&str, Value> {
 
 /// Parse a bare key (alphanumeric + underscore)
 fn gemma4_key(input: &str) -> IResult<&str, &str> {
-    take_while1(|c: char| c.is_alphanumeric() || c == '_').parse(input)
+    take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '-').parse(input)
 }
 
 /// Parse a key:value pair
@@ -302,7 +302,7 @@ impl ToolFormatHandler for Gemma4Handler {
         lark.push('\n');
         lark.push_str(r#"gemmafour_strbody[suffix=/<\|"\|>/]: /(?s:.*)/"#);
         lark.push('\n');
-        lark.push_str("gemmafour_key: /[a-zA-Z0-9_]+/\n");
+        lark.push_str("gemmafour_key: /[a-zA-Z0-9_-]+/\n");
         lark.push_str(r#"gemmafour_bool: "true" | "false""#);
         lark.push('\n');
         lark.push_str(r#"gemmafour_null: "null""#);

--- a/nobodywho/core/src/tool_calling/lfm2.rs
+++ b/nobodywho/core/src/tool_calling/lfm2.rs
@@ -24,6 +24,10 @@ impl ToolFormatHandler for Lfm2Handler {
         END_TOKEN
     }
 
+    fn slice_regexes(&self) -> Vec<String> {
+        super::json_body_slice_regexes()
+    }
+
     fn to_lark(
         &self,
         tools: &[Tool],

--- a/nobodywho/core/src/tool_calling/lfm2.rs
+++ b/nobodywho/core/src/tool_calling/lfm2.rs
@@ -144,8 +144,7 @@ fn lark_tool_rule(
             let pprefix = format!("{tprefix}_p{pi}_{}", super::sanitize_lark(pname));
 
             let val_rule = format!("{pprefix}_val");
-            let schema_str = serde_json::to_string(pschema)
-                .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+            let schema_str = super::json_schema_for_llguidance(pschema)?;
             lark.push_str(&format!("{val_rule}: %json {schema_str}\n"));
 
             let kv_rule = format!("{pprefix}_kv");

--- a/nobodywho/core/src/tool_calling/lfm2.rs
+++ b/nobodywho/core/src/tool_calling/lfm2.rs
@@ -5,17 +5,12 @@
 //! (also tolerating Python `True`/`False`/`None`).
 
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{alt, nt, seq, t, GrammarBuilder, NoRoot};
-use gbnf::json::json_schema_to_grammar;
-use gbnf::{Expr, GbnfGrammar};
 use serde_json::{Map, Value};
 use std::collections::HashSet;
 use tracing::debug;
 
 const BEGIN_TOKEN: &str = "<|tool_call_start|>";
 const END_TOKEN: &str = "<|tool_call_end|>";
-
-type Builder = GrammarBuilder<NoRoot>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Lfm2Handler;
@@ -29,42 +24,29 @@ impl ToolFormatHandler for Lfm2Handler {
         END_TOKEN
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
-        let mut builder = GrammarBuilder::new();
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let mut lark = String::from("%llguidance {}\n");
 
         let mut tool_rule_names = Vec::with_capacity(tools.len());
         for (ti, tool) in tools.iter().enumerate() {
-            let (tool_rule, next) = add_tool_rule(tool, ti, builder)?;
-            builder = next;
+            let tool_rule = lark_tool_rule(tool, ti, &mut lark)?;
             tool_rule_names.push(tool_rule);
         }
 
-        let tool_alts: Vec<Expr> = tool_rule_names.iter().map(|n| nt(n)).collect();
+        let tool_alt_str = tool_rule_names.join(" | ");
+        lark.push_str(&format!("lfm2_tool_alt: {tool_alt_str}\n"));
+        lark.push_str("lfm2_calllist: lfm2_tool_alt | lfm2_tool_alt \", \" lfm2_calllist\n");
+        // Delimiters are control tokens; `lark_delimiter` references them by id
+        // (`<[id]>`) so they match the single control token the model emits.
+        let begin = super::lark_delimiter(model, BEGIN_TOKEN);
+        let end = super::lark_delimiter(model, END_TOKEN);
+        lark.push_str(&format!("start: {begin} \"[\" lfm2_calllist \"]\" {end}\n"));
 
-        Ok(builder
-            .rule("lfm2-tool-alt", alt(&tool_alts))
-            // A call list is one or more calls separated by ", ".
-            // calllist ::= tool-alt | tool-alt ", " calllist
-            .rule(
-                "lfm2-calllist",
-                alt(&[
-                    nt("lfm2-tool-alt"),
-                    seq(&[nt("lfm2-tool-alt"), t(", "), nt("lfm2-calllist")]),
-                ]),
-            )
-            .rule(
-                "lfm2-toolcall",
-                seq(&[
-                    t(BEGIN_TOKEN),
-                    t("["),
-                    nt("lfm2-calllist"),
-                    t("]"),
-                    t(END_TOKEN),
-                ]),
-            )
-            .rule("superroot", nt("lfm2-toolcall"))
-            .root("superroot")
-            .build())
+        Ok(lark)
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
@@ -94,10 +76,6 @@ impl ToolFormatHandler for Lfm2Handler {
 // ============================================================================
 // Grammar construction
 // ============================================================================
-//
-// Mirrors the per-tool / per-parameter approach in `qwen35_36.rs`: each helper
-// appends rules to the in-progress `Builder` and returns the new `Builder`
-// together with the name of the rule the caller should reference.
 
 fn required_params(tool: &Tool) -> HashSet<&str> {
     tool.json_schema
@@ -107,82 +85,52 @@ fn required_params(tool: &Tool) -> HashSet<&str> {
         .unwrap_or_default()
 }
 
-/// llama.cpp's grammar parser only accepts `[a-zA-Z0-9-]` in rule names, so any
-/// other character in a parameter name is mapped to `-` (same as qwen35_36).
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
-}
-
-/// Add a rule matching a single argument value. LFM2 quotes strings and renders
-/// everything else JSON-style, so the JSON value grammar covers every type
-/// (string, number, boolean, enum, object, array).
-fn add_value_rule(
-    schema: &Value,
-    prefix: &str,
-    b: Builder,
-) -> Result<(String, Builder), ToolFormatError> {
-    let alias = format!("{prefix}-val");
-    let json_gram = json_schema_to_grammar(schema.clone(), "root")?;
-    Ok((alias.clone(), b.include_grammar_as(&json_gram, &alias)))
-}
-
-/// Build the ordered, comma-separated `key=value` argument list. Required
-/// params must appear, optional params may be skipped, and commas are placed
-/// only *between* emitted params (no leading/trailing/double commas).
+/// Build the `from-i`/`more-i` rule families for ordered optional params.
 ///
-/// Encoded with two rule families over the parameter suffix `i..n`:
-/// - `from-i`: nothing emitted yet (the first emitted param has no comma)
-/// - `more-i`: a param was already emitted (every further param gets ", ")
+/// - `from-i`: nothing emitted yet; the first emitted param has no leading comma.
+/// - `more-i`: a param was already emitted; every further param gets `", "`.
 ///
-/// Returns the entry rule (`from-0`), which also matches the empty list.
-fn add_arglist_rules(
-    tprefix: &str,
-    params: &[(String, bool)],
-    mut b: Builder,
-) -> (String, Builder) {
+/// Returns the entry rule name (`{tprefix}_from_0`).
+fn lark_arglist_rules(tprefix: &str, params: &[(String, bool)], lark: &mut String) -> String {
     let n = params.len();
 
     // Base cases: nothing left to emit.
-    b = b.rule(&format!("{tprefix}-from-{n}"), t(""));
-    b = b.rule(&format!("{tprefix}-more-{n}"), t(""));
+    lark.push_str(&format!("{tprefix}_from_{n}: \"\"\n"));
+    lark.push_str(&format!("{tprefix}_more_{n}: \"\"\n"));
 
     for i in (0..n).rev() {
         let (kv_rule, required) = &params[i];
-        let from_i = format!("{tprefix}-from-{i}");
-        let more_i = format!("{tprefix}-more-{i}");
-        let from_next = format!("{tprefix}-from-{}", i + 1);
-        let more_next = format!("{tprefix}-more-{}", i + 1);
+        let from_i = format!("{tprefix}_from_{i}");
+        let more_i = format!("{tprefix}_more_{i}");
+        let from_next = format!("{tprefix}_from_{}", i + 1);
+        let more_next = format!("{tprefix}_more_{}", i + 1);
 
         if *required {
             // from-i  ::= kv more-(i+1)
             // more-i  ::= ", " kv more-(i+1)
-            b = b.rule(&from_i, seq(&[nt(kv_rule), nt(&more_next)]));
-            b = b.rule(&more_i, seq(&[t(", "), nt(kv_rule), nt(&more_next)]));
+            lark.push_str(&format!("{from_i}: {kv_rule} {more_next}\n"));
+            lark.push_str(&format!("{more_i}: \", \" {kv_rule} {more_next}\n"));
         } else {
             // from-i  ::= (kv more-(i+1)) | from-(i+1)
             // more-i  ::= (", " kv more-(i+1)) | more-(i+1)
-            b = b.rule(
-                &from_i,
-                alt(&[seq(&[nt(kv_rule), nt(&more_next)]), nt(&from_next)]),
-            );
-            b = b.rule(
-                &more_i,
-                alt(&[seq(&[t(", "), nt(kv_rule), nt(&more_next)]), nt(&more_next)]),
-            );
+            lark.push_str(&format!(
+                "{from_i}: ({kv_rule} {more_next}) | {from_next}\n"
+            ));
+            lark.push_str(&format!(
+                "{more_i}: (\", \" {kv_rule} {more_next}) | {more_next}\n"
+            ));
         }
     }
 
-    (format!("{tprefix}-from-0"), b)
+    format!("{tprefix}_from_0")
 }
 
-fn add_tool_rule(
+fn lark_tool_rule(
     tool: &Tool,
     tool_index: usize,
-    mut builder: Builder,
-) -> Result<(String, Builder), ToolFormatError> {
-    let tprefix = format!("lfm2-t{tool_index}");
+    lark: &mut String,
+) -> Result<String, ToolFormatError> {
+    let tprefix = format!("lfm2_t{tool_index}");
     let required = required_params(tool);
 
     // (kv-rule-name, is-required) per property, preserving declaration order.
@@ -192,27 +140,31 @@ fn add_tool_rule(
         .get("properties")
         .and_then(|p| p.as_object())
     {
-        for (pname, pschema) in props {
-            let pprefix = format!("{tprefix}-p-{}", sanitize(pname));
-            let (value_rule, next) = add_value_rule(pschema, &pprefix, builder)?;
-            builder = next;
+        for (pi, (pname, pschema)) in props.iter().enumerate() {
+            let pprefix = format!("{tprefix}_p{pi}_{}", super::sanitize_lark(pname));
 
-            let kv_rule = format!("{pprefix}-kv");
-            builder = builder.rule(&kv_rule, seq(&[t(&format!("{pname}=")), nt(&value_rule)]));
+            let val_rule = format!("{pprefix}_val");
+            let schema_str = serde_json::to_string(pschema)
+                .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+            lark.push_str(&format!("{val_rule}: %json {schema_str}\n"));
+
+            let kv_rule = format!("{pprefix}_kv");
+            let pname_esc = super::escape_lark_string(pname);
+            lark.push_str(&format!("{kv_rule}: \"{pname_esc}=\" {val_rule}\n"));
+
             params.push((kv_rule, required.contains(pname.as_str())));
         }
     }
 
-    let (arglist_rule, next) = add_arglist_rules(&tprefix, &params, builder);
-    builder = next;
+    let arglist_rule = lark_arglist_rules(&tprefix, &params, lark);
 
-    let tool_rule = format!("{tprefix}-call");
-    let builder = builder.rule(
-        &tool_rule,
-        seq(&[t(&format!("{}(", tool.name)), nt(&arglist_rule), t(")")]),
-    );
+    let tool_rule = format!("{tprefix}_call");
+    lark.push_str(&format!(
+        "{tool_rule}: \"{}(\" {arglist_rule} \")\"\n",
+        super::escape_lark_string(&tool.name)
+    ));
 
-    Ok((tool_rule, builder))
+    Ok(tool_rule)
 }
 
 // ============================================================================
@@ -404,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn grammar_builds() {
+    fn lark_builds() {
         let h = Lfm2Handler;
         let make = |schema| Tool {
             name: "get_weather".to_string(),
@@ -413,26 +365,29 @@ mod tests {
             function: std::sync::Arc::new(|_| String::new()),
         };
 
-        let g = h
-            .generate_grammar(&[make(json!({
-                "type": "object",
-                "properties": {
-                    "city": {"type": "string"},
-                    "units": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                    "verbose": {"type": "boolean"}
-                },
-                "required": ["city"]
-            }))])
+        let s = h
+            .to_lark(
+                &[make(json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "units": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        "verbose": {"type": "boolean"}
+                    },
+                    "required": ["city"]
+                }))],
+                None,
+            )
             .unwrap();
-        let s = g.as_str();
+        assert!(s.contains("%llguidance"));
         assert!(s.contains("<|tool_call_start|>") && s.contains("<|tool_call_end|>"));
         assert!(s.contains("get_weather("));
         assert!(s.contains("city=") && s.contains("units=") && s.contains("verbose="));
 
         // empty-params schema still builds
-        let g = h
-            .generate_grammar(&[make(json!({"type": "object", "properties": {}}))])
+        let s = h
+            .to_lark(&[make(json!({"type": "object", "properties": {}}))], None)
             .unwrap();
-        assert!(g.as_str().contains("get_weather("));
+        assert!(s.contains("get_weather("));
     }
 }

--- a/nobodywho/core/src/tool_calling/ministral3.rs
+++ b/nobodywho/core/src/tool_calling/ministral3.rs
@@ -33,6 +33,10 @@ impl ToolFormatHandler for Ministral3Handler {
         ""
     }
 
+    fn slice_regexes(&self) -> Vec<String> {
+        super::json_body_slice_regexes()
+    }
+
     fn to_lark(
         &self,
         tools: &[Tool],

--- a/nobodywho/core/src/tool_calling/ministral3.rs
+++ b/nobodywho/core/src/tool_calling/ministral3.rs
@@ -1,7 +1,4 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{alt, nt, nt_plus, GrammarBuilder};
-use gbnf::json::json_schema_to_grammar;
-use gbnf_macro::gbnf;
 use nom::{
     bytes::complete::{tag, take_till, take_until},
     combinator::rest,
@@ -36,35 +33,31 @@ impl ToolFormatHandler for Ministral3Handler {
         ""
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {
-        // Build a per-tool grammar: "[TOOL_CALLS]" "toolname" "[ARGS]" {json-args}
-        let tool_grammars: Vec<gbnf::GbnfGrammar> = tools
-            .iter()
-            .map(|tool| {
-                let args_grammar = json_schema_to_grammar(&tool.json_schema, "root")?;
-                let tool_call_grammar = gbnf! {
-                    root ::= "[TOOL_CALLS]" {&tool.name} "[ARGS]" @{args_grammar}
-                };
-                Ok(tool_call_grammar)
-            })
-            .collect::<Result<_, gbnf::json::JsonSchemaError>>()?;
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let mut lark = String::from("%llguidance {}\n");
+        lark.push_str("start: toolcall+\n");
 
-        // Combine: each tool grammar is an alternative, allow one or more calls
-        let mut builder = GrammarBuilder::new();
-        let mut tool_refs = Vec::new();
-        for (i, grammar) in tool_grammars.iter().enumerate() {
-            let alias = format!("tool-{}", i);
-            builder = builder.include_grammar_as(grammar, &alias);
-            tool_refs.push(nt(&alias));
+        let alts: Vec<String> = (0..tools.len()).map(|i| format!("tool_{i}")).collect();
+        lark.push_str(&format!("toolcall: {}\n", alts.join(" | ")));
+
+        // `[TOOL_CALLS]` and `[ARGS]` are control tokens; reference them by id
+        // (see `lark_delimiter`) rather than as literal bytes.
+        let begin = super::lark_delimiter(model, "[TOOL_CALLS]");
+        let args = super::lark_delimiter(model, "[ARGS]");
+        for (i, tool) in tools.iter().enumerate() {
+            let schema_str = serde_json::to_string(&tool.json_schema)
+                .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+            let name = super::escape_lark_string(&tool.name);
+            lark.push_str(&format!(
+                "tool_{i}: {begin} \"{name}\" {args} %json {schema_str}\n"
+            ));
         }
 
-        let grammar = builder
-            .rule("toolcall", alt(&tool_refs))
-            .rule("root", nt_plus("toolcall"))
-            .root("root")
-            .build();
-
-        Ok(grammar)
+        Ok(lark)
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {

--- a/nobodywho/core/src/tool_calling/ministral3.rs
+++ b/nobodywho/core/src/tool_calling/ministral3.rs
@@ -49,8 +49,7 @@ impl ToolFormatHandler for Ministral3Handler {
         let begin = super::lark_delimiter(model, "[TOOL_CALLS]");
         let args = super::lark_delimiter(model, "[ARGS]");
         for (i, tool) in tools.iter().enumerate() {
-            let schema_str = serde_json::to_string(&tool.json_schema)
-                .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+            let schema_str = super::json_schema_for_llguidance(&tool.json_schema)?;
             let name = super::escape_lark_string(&tool.name);
             lark.push_str(&format!(
                 "tool_{i}: {begin} \"{name}\" {args} %json {schema_str}\n"

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -345,39 +345,29 @@ pub trait ToolFormatHandler {
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>>;
 
     /// Build a Lark grammar describing the tool call shape, for use with
-    /// [`crate::sampler::llguidance_sampler`].
-    ///
-    /// The grammar starts at the tool-call body — i.e., its entry rule
-    /// includes the begin token as its first literal. It does **not** include
-    /// a lazy preamble: Lark/llguidance has no equivalent of llama.cpp's
-    /// `grammar_lazy` external trigger words, and a `[suffix=...]` preamble
-    /// would block EOS while waiting for the trigger to appear. Optional
-    /// activation is instead handled by the chat layer, which only inserts
-    /// this grammar into the sampler chain after detecting the begin token
-    /// in the streamed output.
+    /// [`crate::sampler::llguidance_sampler`]. The grammar's entry rule starts
+    /// with the begin token; activation is handled by the chat layer once that
+    /// token is seen (there is no lazy-trigger equivalent in Lark/llguidance).
     fn to_lark(
         &self,
         tools: &[Tool],
         model: Option<&LlamaModel>,
     ) -> Result<String, ToolFormatError>;
 
-    /// Vocabulary hints that speed up grammar-constrained token selection.
-    ///
-    /// Each regex describes a set of tokens that are commonly allowed at some
-    /// position in this format. llguidance pre-computes a bitmask for each
-    /// pattern at startup. At generation time, when every valid token at the
-    /// current grammar position matches a pattern, llguidance uses the bitmask
-    /// directly instead of scanning the full vocabulary — cutting per-token
-    /// constraint cost significantly on large vocabularies.
-    ///
-    /// The default is a JSON string-value body regex (excludes `"`, `\`,
-    /// control chars), suitable for JSON-formatted tool calls (e.g. Qwen3).
-    /// Handlers whose format is not JSON should override this with patterns
-    /// matched to their actual delimiter structure (see `FunctionGemmaHandler`
-    /// for an example with `[^<>{},:]+`).
+    /// Regexes hinting which tokens are allowed at hot grammar positions;
+    /// llguidance precomputes a bitmask per pattern to skip full-vocab scans.
+    /// Empty by default — a bitmask that never applies is pure startup cost.
+    /// Opt in via `json_body_slice_regexes` (`%json` bodies) or a custom pattern
+    /// (see `FunctionGemmaHandler`'s `[^<>{},:]+`).
     fn slice_regexes(&self) -> Vec<String> {
-        vec![r#"[^"\\\x00-\x1F\x7F]+"#.to_string()]
+        vec![]
     }
+}
+
+/// Slice for a JSON string-value body (excludes `"`, `\`, control chars). The
+/// `slice_regexes` opt-in for formats whose tool-call body is `%json`-constrained.
+pub(crate) fn json_body_slice_regexes() -> Vec<String> {
+    vec![r#"[^"\\\x00-\x1F\x7F]+"#.to_string()]
 }
 
 /// Enum representing different tool calling formats.

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -621,7 +621,10 @@ mod tests {
         let embedded = json_schema_for_llguidance(&tool.json_schema).unwrap();
         assert!(embedded.contains("x-guidance"), "missing tag: {embedded}");
         assert!(embedded.contains("lenient"), "missing lenient: {embedded}");
-        assert!(embedded.contains("uniqueItems"), "keyword dropped: {embedded}");
+        assert!(
+            embedded.contains("uniqueItems"),
+            "keyword dropped: {embedded}"
+        );
         assert!(embedded.contains("maximum"), "keyword dropped: {embedded}");
 
         // Grammar generation (string level) still succeeds.

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -698,7 +698,7 @@ mod tests {
 
         for (fmt, trigger) in cases {
             let lark = fmt
-                .to_lark(&[tool.clone()], None)
+                .to_lark(std::slice::from_ref(&tool), None)
                 .unwrap_or_else(|e| panic!("to_lark failed for {:?}: {}", fmt, e));
             assert!(
                 lark.starts_with("%llguidance {}"),

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -847,7 +847,7 @@ mod tests {
             eprintln!("skipping: set GEMMA4_MODEL to a Gemma4 GGUF to run this test");
             return;
         };
-        let model = crate::llm::get_model(&path, true, None, None)
+        let model = crate::llm::get_model(&path, true, None, None, None)
             .unwrap_or_else(|e| panic!("failed to load Gemma4 model from {path}: {e:?}"));
         let grammar = ToolFormat::Gemma4(Gemma4Handler)
             .to_lark(&[weather_tool()], Some(&model.language_model))

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -59,13 +59,9 @@ impl std::fmt::Debug for Tool {
 /// Tags the schema with `x-guidance: { "lenient": true }`, which tells
 /// llguidance's `%json` compiler to *ignore* (with a warning) any schema
 /// keyword it doesn't implement — e.g. `uniqueItems`, `dependencies` — instead
-/// of failing the whole grammar build. Every keyword llguidance *does*
-/// implement is still enforced: `minimum`/`maximum`, `exclusiveMinimum`/
-/// `exclusiveMaximum`, `multipleOf`, `minLength`/`maxLength`, `pattern`,
-/// `minItems`/`maxItems`, `minProperties`/`maxProperties`, `patternProperties`,
-/// `$ref`, `format`, and the structural keywords. This keeps as much constraint
-/// as the sampler can enforce, rather than the previous whitelist that dropped
-/// every constraint keyword outright.
+/// of failing the whole grammar build. Keywords it does implement are still
+/// enforced, so this keeps as much constraint as the sampler can, rather than
+/// the previous whitelist that dropped every constraint keyword outright.
 ///
 /// The `x-guidance` tag is only honored at the root of the schema handed to a
 /// single `%json` node (its effect is global to that compile), so it is applied
@@ -284,9 +280,8 @@ pub enum ToolFormatError {
 // Trait & Format Enum
 // ============================================================================
 
-/// Escape a string for embedding inside a Lark double-quoted string literal.
-///
 /// Escape user-controlled input for splicing into a double-quoted Lark literal.
+///
 /// Besides `"` and `\`, raw newline/tab/carriage-return make the literal
 /// malformed, so map them to their C-style escapes too. `\\` is replaced first
 /// so the backslashes introduced below are not re-escaped.

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -54,6 +54,56 @@ impl std::fmt::Debug for Tool {
     }
 }
 
+/// Project a JSON schema down to the keys we support, dropping everything else.
+/// llguidance's `%json` compiler rejects keys it hasn't implemented (e.g.
+/// `uniqueItems`) rather than ignoring them, so anything we don't explicitly
+/// keep must go. Recurses only into schema-valued positions; `const`/`enum`/
+/// `required` hold literal data and are copied verbatim.
+pub(crate) fn project_supported_schema(schema: &serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    let Some(obj) = schema.as_object() else {
+        // Bool schemas (`items: false`, `additionalProperties: false`) and any
+        // scalar pass through unchanged.
+        return schema.clone();
+    };
+    let mut out = serde_json::Map::new();
+    for (k, v) in obj {
+        match k.as_str() {
+            // single nested schema (may also be a bool)
+            "items" | "additionalProperties" | "not" | "contains" => {
+                out.insert(k.clone(), project_supported_schema(v));
+            }
+            // array of schemas
+            "oneOf" | "anyOf" | "allOf" | "prefixItems" => {
+                if let Some(arr) = v.as_array() {
+                    out.insert(
+                        k.clone(),
+                        Value::Array(arr.iter().map(project_supported_schema).collect()),
+                    );
+                }
+            }
+            // map of schemas
+            "properties" | "$defs" | "definitions" | "patternProperties" => {
+                if let Some(m) = v.as_object() {
+                    let mm = m
+                        .iter()
+                        .map(|(pk, pv)| (pk.clone(), project_supported_schema(pv)))
+                        .collect();
+                    out.insert(k.clone(), Value::Object(mm));
+                }
+            }
+            // data / annotations kept verbatim (NOT recursed into)
+            "type" | "required" | "const" | "enum" | "$ref" | "description" | "title"
+            | "format" => {
+                out.insert(k.clone(), v.clone());
+            }
+            // everything else (uniqueItems, examples, $schema, ...) dropped
+            _ => {}
+        }
+    }
+    Value::Object(out)
+}
+
 impl Tool {
     pub fn new<S: Into<String>>(
         name: S,
@@ -64,7 +114,7 @@ impl Tool {
         Self {
             name: name.into(),
             description: description.into(),
-            json_schema,
+            json_schema: project_supported_schema(&json_schema),
             function,
         }
     }
@@ -240,9 +290,6 @@ pub enum ToolFormatError {
     #[error("Failed to generate grammar: {0}")]
     GrammarGenerationFailed(String),
 
-    #[error("JSON schema error: {0}")]
-    JsonSchemaError(#[from] gbnf::json::JsonSchemaError),
-
     #[error("Lama.cpp failed fetching chat template from the model file. This is likely because you're using an older GGUF file, which might not include a chat template. For example, this is the case for most LLaMA2-based GGUF files. Try using a more recent GGUF model file. {0}")]
     ChatTemplateError(#[from] llama_cpp_2::ChatTemplateError),
 }
@@ -250,6 +297,60 @@ pub enum ToolFormatError {
 // ============================================================================
 // Trait & Format Enum
 // ============================================================================
+
+/// Escape a string for embedding inside a Lark double-quoted string literal.
+///
+/// Escape user-controlled input for splicing into a double-quoted Lark literal.
+/// Besides `"` and `\`, raw newline/tab/carriage-return make the literal
+/// malformed, so map them to their C-style escapes too. `\\` is replaced first
+/// so the backslashes introduced below are not re-escaped.
+pub(crate) fn escape_lark_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+/// Render a tool-call delimiter for embedding in a Lark grammar.
+///
+/// A delimiter that is a single **control token** (e.g. Ministral's
+/// `[TOOL_CALLS]`, LFM2's `<|tool_call_start|>`) is referenced as a Lark special
+/// token by id — `<[id]>` — so it matches the single control token the model
+/// emits. A quoted literal would instead match the token's text bytes, which
+/// never correspond to the control token. Ordinary text delimiters are emitted
+/// as an escaped quoted literal. With `model = None` (structure-only tests) the
+/// literal form is always used.
+pub(crate) fn lark_delimiter(model: Option<&LlamaModel>, s: &str) -> String {
+    if let Some(model) = model {
+        if let Ok(tokens) = model.str_to_token(s, llama_cpp_2::model::AddBos::Never) {
+            if tokens.len() == 1 {
+                let tok = tokens[0];
+                // A control token has no plaintext rendering: `special=false`
+                // yields empty bytes or errors. Anything else is ordinary text.
+                let is_control = model
+                    .token_to_piece_bytes(tok, 32, false, None)
+                    .map(|b| b.is_empty())
+                    .unwrap_or(true);
+                if is_control {
+                    return format!("<[{}]>", tok.0);
+                }
+            }
+        }
+    }
+    format!("\"{}\"", escape_lark_string(s))
+}
+
+/// Map any non-alphanumeric character to `_` for use in Lark rule names.
+///
+/// Tool/property names come from user-controlled input and are spliced into
+/// generated Lark rule names, which only allow a restricted identifier
+/// charset.
+pub(crate) fn sanitize_lark(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
 
 /// Trait for handling different tool calling formats.
 pub trait ToolFormatHandler {
@@ -259,11 +360,43 @@ pub trait ToolFormatHandler {
     /// Returns the token that ends a tool call (e.g., "</tool_call>")
     fn end_token(&self) -> &str;
 
-    /// Generates a GBNF grammar for constrained sampling of tool calls.
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError>;
-
     /// Extracts tool calls from the given text.
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>>;
+
+    /// Build a Lark grammar describing the tool call shape, for use with
+    /// [`crate::sampler::llguidance_sampler`].
+    ///
+    /// The grammar starts at the tool-call body — i.e., its entry rule
+    /// includes the begin token as its first literal. It does **not** include
+    /// a lazy preamble: Lark/llguidance has no equivalent of llama.cpp's
+    /// `grammar_lazy` external trigger words, and a `[suffix=...]` preamble
+    /// would block EOS while waiting for the trigger to appear. Optional
+    /// activation is instead handled by the chat layer, which only inserts
+    /// this grammar into the sampler chain after detecting the begin token
+    /// in the streamed output.
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&LlamaModel>,
+    ) -> Result<String, ToolFormatError>;
+
+    /// Vocabulary hints that speed up grammar-constrained token selection.
+    ///
+    /// Each regex describes a set of tokens that are commonly allowed at some
+    /// position in this format. llguidance pre-computes a bitmask for each
+    /// pattern at startup. At generation time, when every valid token at the
+    /// current grammar position matches a pattern, llguidance uses the bitmask
+    /// directly instead of scanning the full vocabulary — cutting per-token
+    /// constraint cost significantly on large vocabularies.
+    ///
+    /// The default is a JSON string-value body regex (excludes `"`, `\`,
+    /// control chars), suitable for JSON-formatted tool calls (e.g. Qwen3).
+    /// Handlers whose format is not JSON should override this with patterns
+    /// matched to their actual delimiter structure (see `FunctionGemmaHandler`
+    /// for an example with `[^<>{},:]+`).
+    fn slice_regexes(&self) -> Vec<String> {
+        vec![r#"[^"\\\x00-\x1F\x7F]+"#.to_string()]
+    }
 }
 
 /// Enum representing different tool calling formats.
@@ -297,12 +430,20 @@ impl ToolFormat {
         self.handler().end_token()
     }
 
-    pub fn generate_grammar(&self, tools: &[Tool]) -> Result<gbnf::GbnfGrammar, ToolFormatError> {
-        self.handler().generate_grammar(tools)
+    pub fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        self.handler().to_lark(tools, model)
     }
 
     pub fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
         self.handler().extract_tool_calls(input)
+    }
+
+    pub fn slice_regexes(&self) -> Vec<String> {
+        self.handler().slice_regexes()
     }
 }
 
@@ -445,6 +586,358 @@ mod tests {
         let format = ToolFormat::Qwen3(Qwen3Handler);
         assert_eq!(format.begin_token(), "<tool_call>");
         assert_eq!(format.end_token(), "</tool_call>");
+    }
+
+    fn weather_tool() -> Tool {
+        Tool {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            json_schema: json!({
+                "type": "object",
+                "properties": { "city": {"type": "string"} },
+                "required": ["city"]
+            }),
+            function: Arc::new(|_| String::new()),
+        }
+    }
+
+    #[test]
+    fn tool_new_projects_unsupported_schema_keys() {
+        // A `set`-typed parameter carries `uniqueItems`, which llguidance's
+        // `%json` compiler rejects. `Tool::new` must strip it (and any other
+        // unsupported key) while preserving the structural schema, so the
+        // per-format grammars compile.
+        let tool = Tool::new(
+            "set_intersection",
+            "intersect two sets",
+            json!({
+                "type": "object",
+                "properties": {
+                    "set1": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "uniqueItems": true
+                    },
+                    // `const` holds literal data, not a schema: a key that
+                    // collides with a dropped keyword must survive untouched.
+                    "mode": {"const": {"uniqueItems": 5}}
+                },
+                "required": ["set1"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+
+        let schema_str = serde_json::to_string(&tool.json_schema).unwrap();
+
+        // The unsupported keyword is gone from every schema position...
+        assert!(
+            !schema_str.contains("\"uniqueItems\":true"),
+            "uniqueItems keyword should be stripped: {schema_str}"
+        );
+        // ...but structural keys survive.
+        let props = &tool.json_schema["properties"];
+        assert_eq!(props["set1"]["type"], "array");
+        assert_eq!(props["set1"]["items"]["type"], "integer");
+        assert_eq!(tool.json_schema["required"][0], "set1");
+        // ...and literal `const` data is NOT filtered (recursion stops at data).
+        assert_eq!(props["mode"]["const"]["uniqueItems"], 5);
+
+        // The projected schema compiles into a `%json`-embedding grammar.
+        ToolFormat::Qwen3(Qwen3Handler)
+            .to_lark(&[tool], None)
+            .expect("projected schema should produce valid lark");
+    }
+
+    #[test]
+    fn escape_lark_string_escapes_quotes_backslashes_and_control_chars() {
+        assert_eq!(escape_lark_string("a\"b\\c"), "a\\\"b\\\\c");
+        assert_eq!(escape_lark_string("l1\nl2\tx\r"), "l1\\nl2\\tx\\r");
+        // A literal backslash-n in the input must not collide with the newline
+        // escape: `\\` is replaced first, so `\n` (two chars) becomes `\\n`.
+        assert_eq!(escape_lark_string("a\\nb"), "a\\\\nb");
+    }
+
+    #[test]
+    fn to_lark_produces_valid_lark_for_all_handlers() {
+        // For each handler, to_lark() should produce a Lark grammar starting
+        // with the `%llguidance` header and a `start:` rule whose body
+        // contains a reference to the format's begin token (either as a Lark
+        // string literal or as a `<...>` special-token reference, depending
+        // on how the per-handler grammar represents it).
+        let tool = weather_tool();
+        let cases: &[(ToolFormat, &str)] = &[
+            (ToolFormat::Qwen3(Qwen3Handler), "<tool_call>"),
+            (ToolFormat::Qwen35_36(Qwen35_36Handler), "<tool_call>"),
+            (
+                ToolFormat::FunctionGemma(FunctionGemmaHandler),
+                "<start_function_call>",
+            ),
+            (ToolFormat::Gemma4(Gemma4Handler), "<|tool_call>"),
+            (ToolFormat::Ministral3(Ministral3Handler), "[TOOL_CALLS]"),
+            (ToolFormat::Lfm2(Lfm2Handler), "<|tool_call_start|>"),
+        ];
+
+        for (fmt, trigger) in cases {
+            let lark = fmt
+                .to_lark(&[tool.clone()], None)
+                .unwrap_or_else(|e| panic!("to_lark failed for {:?}: {}", fmt, e));
+            assert!(
+                lark.starts_with("%llguidance {}"),
+                "{:?}: missing llguidance header:\n{}",
+                fmt,
+                lark
+            );
+            assert!(
+                lark.contains("\nstart:"),
+                "{:?}: missing start: rule:\n{}",
+                fmt,
+                lark
+            );
+            // The begin token should appear somewhere in the grammar body —
+            // either as a literal (`"..."`) or as a special-token reference
+            // (`<...>`). For literal handlers we check the quoted form; for
+            // Gemma4 (which uses TokenRef::ByString) the converter emits the
+            // bare `<...>` form.
+            let token_in_lark =
+                lark.contains(&format!("\"{}\"", trigger)) || lark.contains(trigger);
+            assert!(
+                token_in_lark,
+                "{:?}: trigger {:?} not found in grammar:\n{}",
+                fmt, trigger, lark
+            );
+        }
+    }
+
+    /// Does the model's tokenizer + `grammar` accept `input` as a COMPLETE
+    /// match? A real tokenizer is required: the free-form-string rules use
+    /// multi-character `suffix` stops, which a single-byte tokenizer can't
+    /// resolve. True only if every token is consumed and the parser ends
+    /// accepting.
+    /// Regression: LFM2's tool-call delimiters `<|tool_call_start|>` /
+    /// `<|tool_call_end|>` are control tokens, which the model emits as single
+    /// special tokens. The grammar must reference them as Lark special tokens
+    /// (`<...>`), not quoted literals — otherwise the special token (0xFF-marked
+    /// in the toktrie) fails the literal-bytes rule the moment the grammar
+    /// activates (`byte 'ÿ' fails parse`). Self-gated: skips unless the loaded
+    /// TEST_MODEL actually has these control tokens.
+    #[test]
+    fn lfm2_control_token_delimiters_accepted() {
+        use llguidance::toktrie::InferenceCapabilities;
+        use llguidance::{api::TopLevelGrammar, Matcher, ParserFactory};
+
+        let model = crate::test_utils::load_test_model();
+        let tok_env =
+            llama_cpp_2::sampling::LlamaSampler::llguidance_tok_env(&model.language_model);
+        if tok_env
+            .tok_trie()
+            .get_special_token("<|tool_call_start|>")
+            .is_none()
+        {
+            eprintln!("skipping: TEST_MODEL is not an LFM2 model (no <|tool_call_start|> token)");
+            return;
+        }
+
+        let grammar = ToolFormat::Lfm2(Lfm2Handler)
+            .to_lark(&[weather_tool()], Some(&model.language_model))
+            .unwrap();
+
+        let factory = ParserFactory::new(&tok_env, InferenceCapabilities::default(), &[])
+            .expect("build ParserFactory");
+        let grm = TopLevelGrammar::from_tagged_str("lark", &grammar).expect("parse Lark grammar");
+        let parser = factory.create_parser(grm).expect("create parser");
+        let mut matcher = Matcher::new(Ok(parser));
+
+        // Tokenize the way real generation does (parse_special=true) so the
+        // delimiters become the single control tokens, not spelled-out text —
+        // this is the case the toktrie's `tokenize_special` can't reproduce.
+        let tokens: Vec<u32> = model
+            .language_model
+            .str_to_token(
+                "<|tool_call_start|>[get_weather(city=\"Paris\")]<|tool_call_end|>",
+                llama_cpp_2::model::AddBos::Never,
+            )
+            .unwrap()
+            .iter()
+            .map(|t| t.0 as u32)
+            .collect();
+        let consumed = matcher.try_consume_tokens(&tokens).unwrap_or(0);
+        assert!(
+            consumed == tokens.len() && matcher.is_accepting().unwrap_or(false),
+            "LFM2 call with control-token delimiters should be accepted \
+             (consumed {consumed}/{}):\n{grammar}",
+            tokens.len()
+        );
+    }
+
+    /// Regression: Ministral3's `[TOOL_CALLS]` / `[ARGS]` delimiters are control
+    /// tokens, so the grammar must reference them by id (`<[id]>`); as quoted
+    /// literals the grammar fails to constrain the control token the model emits.
+    /// Self-gated: skips unless the loaded TEST_MODEL has these control tokens.
+    #[test]
+    fn ministral3_control_token_delimiters_accepted() {
+        use llguidance::toktrie::InferenceCapabilities;
+        use llguidance::{api::TopLevelGrammar, Matcher, ParserFactory};
+
+        let model = crate::test_utils::load_test_model();
+        let tok_env =
+            llama_cpp_2::sampling::LlamaSampler::llguidance_tok_env(&model.language_model);
+        if tok_env
+            .tok_trie()
+            .get_special_token("[TOOL_CALLS]")
+            .is_none()
+        {
+            eprintln!("skipping: TEST_MODEL is not a Ministral model (no [TOOL_CALLS] token)");
+            return;
+        }
+
+        let grammar = ToolFormat::Ministral3(Ministral3Handler)
+            .to_lark(&[weather_tool()], Some(&model.language_model))
+            .unwrap();
+
+        let factory = ParserFactory::new(&tok_env, InferenceCapabilities::default(), &[])
+            .expect("build ParserFactory");
+        let grm = TopLevelGrammar::from_tagged_str("lark", &grammar).expect("parse Lark grammar");
+        let parser = factory.create_parser(grm).expect("create parser");
+        let mut matcher = Matcher::new(Ok(parser));
+
+        let tokens: Vec<u32> = model
+            .language_model
+            .str_to_token(
+                "[TOOL_CALLS]get_weather[ARGS]{\"city\": \"Paris\"}",
+                llama_cpp_2::model::AddBos::Never,
+            )
+            .unwrap()
+            .iter()
+            .map(|t| t.0 as u32)
+            .collect();
+        let consumed = matcher.try_consume_tokens(&tokens).unwrap_or(0);
+        assert!(
+            consumed == tokens.len() && matcher.is_accepting().unwrap_or(false),
+            "Ministral call with control-token delimiters should be accepted \
+             (consumed {consumed}/{}):\n{grammar}",
+            tokens.len()
+        );
+    }
+
+    fn grammar_accepts_tok(model: &crate::llm::Model, grammar: &str, input: &str) -> bool {
+        use llguidance::toktrie::InferenceCapabilities;
+        use llguidance::{api::TopLevelGrammar, Matcher, ParserFactory};
+
+        let tok_env =
+            llama_cpp_2::sampling::LlamaSampler::llguidance_tok_env(&model.language_model);
+        let factory = ParserFactory::new(&tok_env, InferenceCapabilities::default(), &[])
+            .expect("build ParserFactory");
+        let grm = TopLevelGrammar::from_tagged_str("lark", grammar).expect("parse Lark grammar");
+        let parser = factory.create_parser(grm).expect("create parser");
+        let mut matcher = Matcher::new(Ok(parser));
+
+        let tokens = tok_env.tokenize_special(input);
+        let consumed = matcher.try_consume_tokens(&tokens).unwrap_or(0);
+        consumed == tokens.len() && matcher.is_accepting().unwrap_or(false)
+    }
+
+    /// Regression: Gemma4 free-form string values must allow a literal `<`
+    /// (e.g. "count < 5", HTML, generics). The old body rule `/[^<]*/` banned
+    /// every `<`, not just the closing `<|"|>` delimiter, so such values could
+    /// not be generated; the `gemmafour_strbody[suffix=...]` rule fixes it.
+    /// Requires a Gemma4 GGUF — set `GEMMA4_MODEL`; skipped otherwise.
+    #[test]
+    fn gemma4_string_value_allows_left_angle_bracket() {
+        let Ok(path) = std::env::var("GEMMA4_MODEL") else {
+            eprintln!("skipping: set GEMMA4_MODEL to a Gemma4 GGUF to run this test");
+            return;
+        };
+        let model = crate::llm::get_model(&path, true, None, None)
+            .unwrap_or_else(|e| panic!("failed to load Gemma4 model from {path}: {e:?}"));
+        let grammar = ToolFormat::Gemma4(Gemma4Handler)
+            .to_lark(&[weather_tool()], Some(&model.language_model))
+            .unwrap();
+
+        // Baseline: a plain value is accepted.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<|tool_call>call:get_weather{city:<|\"|>hello<|\"|>}<tool_call|>"
+            ),
+            "plain string value should be accepted:\n{grammar}"
+        );
+        // The regression: a value containing '<' is valid content.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<|tool_call>call:get_weather{city:<|\"|>count < 5<|\"|>}<tool_call|>"
+            ),
+            "string value containing '<' should be accepted:\n{grammar}"
+        );
+    }
+
+    /// Regression: Qwen3.5/3.6 free-form string values must be able to end in a
+    /// trailing newline. The old body rule `/([^\n]|\n[^<])*/` could not match a
+    /// value ending in `\n` before the `\n</parameter>\n` terminator (no valid
+    /// split of the bytes); the `..._body[suffix=...]` rule fixes it. Uses the
+    /// TEST_MODEL tokenizer to validate the generated grammar's byte language.
+    #[test]
+    fn qwen35_36_string_value_allows_trailing_newline() {
+        let model = crate::test_utils::load_test_model();
+        let grammar = ToolFormat::Qwen35_36(Qwen35_36Handler)
+            .to_lark(&[weather_tool()], Some(&model.language_model))
+            .unwrap();
+
+        // Baseline: a plain value is accepted.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<tool_call>\n<function=get_weather>\n<parameter=city>\nsunny\n</parameter>\n</function>\n</tool_call>"
+            ),
+            "plain string value should be accepted:\n{grammar}"
+        );
+        // The regression: value "sunny\n" ends in a newline.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<tool_call>\n<function=get_weather>\n<parameter=city>\nsunny\n\n</parameter>\n</function>\n</tool_call>"
+            ),
+            "string value ending in a newline should be accepted:\n{grammar}"
+        );
+    }
+
+    /// Regression: enum string values containing control characters (here a
+    /// newline) must be escaped when spliced into Lark literals, or the grammar
+    /// is malformed and `create_parser` fails at worker init. See
+    /// [`escape_lark_string`]. Uses the TEST_MODEL tokenizer.
+    #[test]
+    fn qwen35_36_enum_value_with_newline_produces_valid_grammar() {
+        let model = crate::test_utils::load_test_model();
+        let tool = Tool::new(
+            "set_mode",
+            "set the mode",
+            json!({
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["plain", "with\nnewline"]}
+                },
+                "required": ["mode"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+        let grammar = ToolFormat::Qwen35_36(Qwen35_36Handler)
+            .to_lark(&[tool], Some(&model.language_model))
+            .unwrap();
+
+        // Accepting the escaped-newline variant also proves the grammar parsed:
+        // a raw newline in the literal would make `create_parser` fail.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<tool_call>\n<function=set_mode>\n<parameter=mode>\nwith\nnewline\n</parameter>\n</function>\n</tool_call>"
+            ),
+            "enum value with an escaped newline should be accepted:\n{grammar}"
+        );
     }
 
     #[test]

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -54,54 +54,40 @@ impl std::fmt::Debug for Tool {
     }
 }
 
-/// Project a JSON schema down to the keys we support, dropping everything else.
-/// llguidance's `%json` compiler rejects keys it hasn't implemented (e.g.
-/// `uniqueItems`) rather than ignoring them, so anything we don't explicitly
-/// keep must go. Recurses only into schema-valued positions; `const`/`enum`/
-/// `required` hold literal data and are copied verbatim.
-pub(crate) fn project_supported_schema(schema: &serde_json::Value) -> serde_json::Value {
-    use serde_json::Value;
-    let Some(obj) = schema.as_object() else {
-        // Bool schemas (`items: false`, `additionalProperties: false`) and any
-        // scalar pass through unchanged.
-        return schema.clone();
-    };
-    let mut out = serde_json::Map::new();
-    for (k, v) in obj {
-        match k.as_str() {
-            // single nested schema (may also be a bool)
-            "items" | "additionalProperties" | "not" | "contains" => {
-                out.insert(k.clone(), project_supported_schema(v));
-            }
-            // array of schemas
-            "oneOf" | "anyOf" | "allOf" | "prefixItems" => {
-                if let Some(arr) = v.as_array() {
-                    out.insert(
-                        k.clone(),
-                        Value::Array(arr.iter().map(project_supported_schema).collect()),
-                    );
-                }
-            }
-            // map of schemas
-            "properties" | "$defs" | "definitions" | "patternProperties" => {
-                if let Some(m) = v.as_object() {
-                    let mm = m
-                        .iter()
-                        .map(|(pk, pv)| (pk.clone(), project_supported_schema(pv)))
-                        .collect();
-                    out.insert(k.clone(), Value::Object(mm));
-                }
-            }
-            // data / annotations kept verbatim (NOT recursed into)
-            "type" | "required" | "const" | "enum" | "$ref" | "description" | "title"
-            | "format" => {
-                out.insert(k.clone(), v.clone());
-            }
-            // everything else (uniqueItems, examples, $schema, ...) dropped
-            _ => {}
-        }
+/// Serialize a JSON schema for embedding after a Lark `%json` directive.
+///
+/// Tags the schema with `x-guidance: { "lenient": true }`, which tells
+/// llguidance's `%json` compiler to *ignore* (with a warning) any schema
+/// keyword it doesn't implement — e.g. `uniqueItems`, `dependencies` — instead
+/// of failing the whole grammar build. Every keyword llguidance *does*
+/// implement is still enforced: `minimum`/`maximum`, `exclusiveMinimum`/
+/// `exclusiveMaximum`, `multipleOf`, `minLength`/`maxLength`, `pattern`,
+/// `minItems`/`maxItems`, `minProperties`/`maxProperties`, `patternProperties`,
+/// `$ref`, `format`, and the structural keywords. This keeps as much constraint
+/// as the sampler can enforce, rather than the previous whitelist that dropped
+/// every constraint keyword outright.
+///
+/// The `x-guidance` tag is only honored at the root of the schema handed to a
+/// single `%json` node (its effect is global to that compile), so it is applied
+/// here at each embedding site rather than once on the whole tool schema.
+///
+/// Note: `lenient` also downgrades `oneOf` to `anyOf`. That is harmless for tool
+/// calling — the Qwen3 wrapper's alternatives are made mutually exclusive by a
+/// `name: { const }` discriminator, so `anyOf` accepts exactly the same inputs.
+pub(crate) fn json_schema_for_llguidance(
+    schema: &serde_json::Value,
+) -> Result<String, ToolFormatError> {
+    let mut schema = schema.clone();
+    if let Some(obj) = schema.as_object_mut() {
+        obj.insert(
+            "x-guidance".to_string(),
+            serde_json::json!({ "lenient": true }),
+        );
     }
-    Value::Object(out)
+    // Non-object schemas (bare `true`/`false`) carry no keywords to tolerate,
+    // so they are serialized untouched.
+    serde_json::to_string(&schema)
+        .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))
 }
 
 impl Tool {
@@ -114,7 +100,7 @@ impl Tool {
         Self {
             name: name.into(),
             description: description.into(),
-            json_schema: project_supported_schema(&json_schema),
+            json_schema,
             function,
         }
     }
@@ -602,11 +588,12 @@ mod tests {
     }
 
     #[test]
-    fn tool_new_projects_unsupported_schema_keys() {
-        // A `set`-typed parameter carries `uniqueItems`, which llguidance's
-        // `%json` compiler rejects. `Tool::new` must strip it (and any other
-        // unsupported key) while preserving the structural schema, so the
-        // per-format grammars compile.
+    fn tool_new_preserves_schema_and_helper_tags_lenient() {
+        // Unlike the old whitelist projection, `Tool::new` now stores the schema
+        // verbatim — including constraint keywords llguidance enforces
+        // (`maximum`) and ones it doesn't (`uniqueItems`). Tolerance is delegated
+        // to llguidance via the `x-guidance: {lenient: true}` tag that
+        // `json_schema_for_llguidance` injects at each `%json` embedding site.
         let tool = Tool::new(
             "set_intersection",
             "intersect two sets",
@@ -615,37 +602,81 @@ mod tests {
                 "properties": {
                     "set1": {
                         "type": "array",
-                        "items": {"type": "integer"},
+                        "items": {"type": "integer", "maximum": 100},
                         "uniqueItems": true
-                    },
-                    // `const` holds literal data, not a schema: a key that
-                    // collides with a dropped keyword must survive untouched.
-                    "mode": {"const": {"uniqueItems": 5}}
+                    }
                 },
                 "required": ["set1"]
             }),
             Arc::new(|_| String::new()),
         );
 
-        let schema_str = serde_json::to_string(&tool.json_schema).unwrap();
+        // Nothing is stripped: both the enforceable and the unimplemented
+        // keyword survive on the stored schema.
+        let items = &tool.json_schema["properties"]["set1"]["items"];
+        assert_eq!(items["maximum"], 100);
+        assert_eq!(tool.json_schema["properties"]["set1"]["uniqueItems"], true);
 
-        // The unsupported keyword is gone from every schema position...
-        assert!(
-            !schema_str.contains("\"uniqueItems\":true"),
-            "uniqueItems keyword should be stripped: {schema_str}"
-        );
-        // ...but structural keys survive.
-        let props = &tool.json_schema["properties"];
-        assert_eq!(props["set1"]["type"], "array");
-        assert_eq!(props["set1"]["items"]["type"], "integer");
-        assert_eq!(tool.json_schema["required"][0], "set1");
-        // ...and literal `const` data is NOT filtered (recursion stops at data).
-        assert_eq!(props["mode"]["const"]["uniqueItems"], 5);
+        // The embedding helper tags the root leniently and keeps every keyword.
+        let embedded = json_schema_for_llguidance(&tool.json_schema).unwrap();
+        assert!(embedded.contains("x-guidance"), "missing tag: {embedded}");
+        assert!(embedded.contains("lenient"), "missing lenient: {embedded}");
+        assert!(embedded.contains("uniqueItems"), "keyword dropped: {embedded}");
+        assert!(embedded.contains("maximum"), "keyword dropped: {embedded}");
 
-        // The projected schema compiles into a `%json`-embedding grammar.
+        // Grammar generation (string level) still succeeds.
         ToolFormat::Qwen3(Qwen3Handler)
             .to_lark(&[tool], None)
-            .expect("projected schema should produce valid lark");
+            .expect("schema should produce valid lark");
+    }
+
+    /// Regression: llguidance's `%json` compiler hard-errors on keywords it
+    /// hasn't implemented (e.g. `uniqueItems`). We no longer pre-strip those;
+    /// instead `json_schema_for_llguidance` tags the schema `lenient`, so the
+    /// grammar must still *compile* against a real tokenizer (create_parser
+    /// would otherwise fail at worker init). Simultaneously, a constraint
+    /// llguidance *does* implement (`maximum`) — which the old whitelist dropped
+    /// entirely — must now actually be enforced. Uses the TEST_MODEL tokenizer.
+    #[test]
+    fn unimplemented_keyword_tolerated_and_supported_constraint_enforced() {
+        let model = crate::test_utils::load_test_model();
+        let tool = Tool::new(
+            "rate",
+            "rate something",
+            json!({
+                "type": "object",
+                "properties": {
+                    // `uniqueItems` is unimplemented -> must be tolerated.
+                    "tags": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+                    // `maximum` is implemented -> must be enforced.
+                    "score": {"type": "integer", "minimum": 0, "maximum": 5}
+                },
+                "required": ["score"]
+            }),
+            Arc::new(|_| String::new()),
+        );
+        let grammar = ToolFormat::Qwen3(Qwen3Handler)
+            .to_lark(&[tool], Some(&model.language_model))
+            .unwrap();
+
+        // Compiles despite `uniqueItems`, and a within-range score is accepted.
+        assert!(
+            grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<tool_call>{\"name\":\"rate\",\"arguments\":{\"score\":3}}</tool_call>"
+            ),
+            "valid call should be accepted (proves lenient compile):\n{grammar}"
+        );
+        // `maximum: 5` is enforced: 9 is out of range and must be rejected.
+        assert!(
+            !grammar_accepts_tok(
+                &model,
+                &grammar,
+                "<tool_call>{\"name\":\"rate\",\"arguments\":{\"score\":9}}</tool_call>"
+            ),
+            "out-of-range score must be rejected (proves constraint kept):\n{grammar}"
+        );
     }
 
     #[test]

--- a/nobodywho/core/src/tool_calling/qwen3.rs
+++ b/nobodywho/core/src/tool_calling/qwen3.rs
@@ -1,7 +1,4 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{nt, nt_plus, seq, t, GrammarBuilder};
-use gbnf::json::json_schema_to_grammar;
-use gbnf::GbnfGrammar;
 use serde_json::json;
 use tracing::debug;
 
@@ -17,47 +14,36 @@ impl ToolFormatHandler for Qwen3Handler {
         "</tool_call>"
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
-        let tool_call_schemas: serde_json::Value = tools
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let tool_schemas: Vec<serde_json::Value> = tools
             .iter()
             .map(|tool| {
-                json!(
-                    {
-                        "type": "object",
-                        "properties": {
-                            "name": { "const": tool.name, },
-                            "arguments": tool.json_schema
-                        },
-                        "required": ["name", "arguments"]
-                    }
-                )
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "const": tool.name },
+                        "arguments": tool.json_schema
+                    },
+                    "required": ["name", "arguments"]
+                })
             })
             .collect();
 
-        let tool_call_schema = json!(
-            { "oneOf": tool_call_schemas }
-        );
+        let schema_str = serde_json::to_string(&json!({ "oneOf": tool_schemas }))
+            .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
 
-        // Generate JSON grammar from schema, then extend it with wrapping rules
-        let json_grammar = json_schema_to_grammar(tool_call_schema, "root")?;
-
-        let grammar = GrammarBuilder::from_existing(json_grammar)
-            .rule(
-                "toolcall",
-                seq(&[
-                    t(self.begin_token()),
-                    nt("ws"),
-                    nt("root"),
-                    nt("ws"),
-                    t(self.end_token()),
-                    nt("ws"),
-                ]),
-            )
-            .rule("superroot", nt_plus("toolcall"))
-            .root("superroot")
-            .build();
-
-        Ok(grammar)
+        let mut lark = String::from("%llguidance {}\n");
+        lark.push_str("start: toolcall+\n");
+        let begin = super::lark_delimiter(model, "<tool_call>");
+        let end = super::lark_delimiter(model, "</tool_call>");
+        lark.push_str(&format!("toolcall: {begin} ws? body ws? {end} ws?\n"));
+        lark.push_str(&format!("body: %json {schema_str}\n"));
+        lark.push_str("ws: /[ \\t\\n\\r]+/\n");
+        Ok(lark)
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {

--- a/nobodywho/core/src/tool_calling/qwen3.rs
+++ b/nobodywho/core/src/tool_calling/qwen3.rs
@@ -33,8 +33,7 @@ impl ToolFormatHandler for Qwen3Handler {
             })
             .collect();
 
-        let schema_str = serde_json::to_string(&json!({ "oneOf": tool_schemas }))
-            .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+        let schema_str = super::json_schema_for_llguidance(&json!({ "oneOf": tool_schemas }))?;
 
         let mut lark = String::from("%llguidance {}\n");
         lark.push_str("start: toolcall+\n");

--- a/nobodywho/core/src/tool_calling/qwen3.rs
+++ b/nobodywho/core/src/tool_calling/qwen3.rs
@@ -14,6 +14,10 @@ impl ToolFormatHandler for Qwen3Handler {
         "</tool_call>"
     }
 
+    fn slice_regexes(&self) -> Vec<String> {
+        super::json_body_slice_regexes()
+    }
+
     fn to_lark(
         &self,
         tools: &[Tool],

--- a/nobodywho/core/src/tool_calling/qwen35_36.rs
+++ b/nobodywho/core/src/tool_calling/qwen35_36.rs
@@ -1,7 +1,4 @@
 use super::{Tool, ToolCall, ToolFormatError, ToolFormatHandler};
-use gbnf::builder::{alt, nt, nt_plus, seq, t, GrammarBuilder, NoRoot};
-use gbnf::json::json_schema_to_grammar;
-use gbnf::{CharacterRange, Expr, GbnfGrammar, Quantifier};
 use regex::Regex;
 use serde_json::{Map, Value};
 use std::collections::HashSet;
@@ -10,14 +7,6 @@ use tracing::debug;
 
 const BEGIN_TOKEN: &str = "<tool_call>";
 const END_TOKEN: &str = "</tool_call>";
-
-/// Terminator of a `<parameter=...>` block, as emitted by the Qwen3.5/3.6 chat template.
-///
-/// The leading `\n` separates the value content from the close; the trailing `\n`
-/// precedes either the next `<parameter=...>` or `</function>`.
-const PARAM_TERMINATOR: &str = "\n</parameter>\n";
-
-type Builder = GrammarBuilder<NoRoot>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Qwen35_36Handler;
@@ -31,27 +20,102 @@ impl ToolFormatHandler for Qwen35_36Handler {
         END_TOKEN
     }
 
-    fn generate_grammar(&self, tools: &[Tool]) -> Result<GbnfGrammar, ToolFormatError> {
-        let (body_rule, mut builder) =
-            add_param_value_body_rule("qwen35-val", GrammarBuilder::new());
+    fn to_lark(
+        &self,
+        tools: &[Tool],
+        model: Option<&llama_cpp_2::model::LlamaModel>,
+    ) -> Result<String, ToolFormatError> {
+        let mut lark = String::from("%llguidance {}\n");
+        lark.push_str("start: toolcall+\n");
 
-        let mut tool_rule_names = Vec::with_capacity(tools.len());
+        let alts: Vec<String> = (0..tools.len()).map(|i| format!("tool_{i}")).collect();
+        let begin = super::lark_delimiter(model, "<tool_call>");
+        let end = super::lark_delimiter(model, "</tool_call>");
+        lark.push_str(&format!("toolcall: {begin} \"\\n\" tool_alt {end}\n"));
+        lark.push_str(&format!("tool_alt: {}\n", alts.join(" | ")));
+
         for (ti, tool) in tools.iter().enumerate() {
-            let (tool_rule, next) = add_tool_rule(tool, ti, &body_rule, builder)?;
-            builder = next;
-            tool_rule_names.push(tool_rule);
+            let tprefix = format!("qwen35_t{ti}");
+            let required = required_params(tool);
+
+            let mut block_rules: Vec<(String, bool)> = Vec::new();
+
+            if let Some(props) = tool
+                .json_schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+            {
+                for (pi, (pname, pschema)) in props.iter().enumerate() {
+                    let pprefix = format!("{tprefix}_p{pi}_{}", super::sanitize_lark(pname));
+                    let block_rule = format!("{pprefix}_block");
+                    let is_required = required.contains(pname.as_str());
+                    let pname = super::escape_lark_string(pname);
+
+                    let ty = pschema
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("string");
+
+                    if ty == "string" {
+                        if let Some(variants) = pschema.get("enum").and_then(|e| e.as_array()) {
+                            let enum_alts: Vec<String> = variants
+                                .iter()
+                                .filter_map(|v| v.as_str())
+                                .map(|s| format!("\"{}\"", super::escape_lark_string(s)))
+                                .collect();
+                            if !enum_alts.is_empty() {
+                                lark.push_str(&format!(
+                                    "{block_rule}: \"<parameter={pname}>\\n\" ({}) \"\\n</parameter>\\n\"\n",
+                                    enum_alts.join(" | ")
+                                ));
+                                block_rules.push((block_rule, is_required));
+                                continue;
+                            }
+                        }
+                        // Free-form string: match any text up to the first
+                        // `\n</parameter>\n` terminator, which the lazy `suffix`
+                        // consumes. This allows values containing `<`, embedded
+                        // newlines, or a trailing newline — none of which a
+                        // character-class body can represent without either
+                        // banning valid content or failing to terminate.
+                        let body_rule = format!("{pprefix}_body");
+                        lark.push_str(&format!(
+                            "{block_rule}: \"<parameter={pname}>\\n\" {body_rule}\n"
+                        ));
+                        lark.push_str(&format!(
+                            "{body_rule}[suffix=/\\n<\\/parameter>\\n/]: /(?s:.*)/\n"
+                        ));
+                    } else {
+                        let val_rule = format!("{pprefix}_val");
+                        let schema_str = serde_json::to_string(pschema)
+                            .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+                        lark.push_str(&format!("{val_rule}: %json {schema_str}\n"));
+                        lark.push_str(&format!(
+                            "{block_rule}: \"<parameter={pname}>\\n\" {val_rule} \"\\n</parameter>\\n\"\n"
+                        ));
+                    }
+
+                    block_rules.push((block_rule, is_required));
+                }
+            }
+
+            let mut rule = format!(
+                "tool_{ti}: \"<function={}>\\n\"",
+                super::escape_lark_string(&tool.name)
+            );
+            for (block_rule, is_required) in &block_rules {
+                if *is_required {
+                    rule.push_str(&format!(" {block_rule}"));
+                } else {
+                    rule.push_str(&format!(" {block_rule}?"));
+                }
+            }
+            rule.push_str(" \"</function>\\n\"");
+            lark.push_str(&rule);
+            lark.push('\n');
         }
 
-        let tool_alts: Vec<Expr> = tool_rule_names.iter().map(|n| nt(n)).collect();
-        Ok(builder
-            .rule("tool-alt", alt(&tool_alts))
-            .rule(
-                "toolcall",
-                seq(&[t(BEGIN_TOKEN), t("\n"), nt("tool-alt"), t(END_TOKEN)]),
-            )
-            .rule("superroot", nt_plus("toolcall"))
-            .root("superroot")
-            .build())
+        Ok(lark)
     }
 
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
@@ -64,165 +128,12 @@ impl ToolFormatHandler for Qwen35_36Handler {
     }
 }
 
-// ============================================================================
-// Grammar construction
-// ============================================================================
-//
-// Each `add_*` helper receives the in-progress `Builder`, appends one or more
-// rules, and returns the new `Builder` together with the name of the rule the
-// caller should reference.
-
-fn none_of(chars: &[char]) -> Expr {
-    Expr::CharacterRange(CharacterRange::Set {
-        chars: chars.to_vec(),
-        negated: true,
-    })
-}
-
-/// Add GBNF rules for an arbitrary-content body that cannot consume
-/// `PARAM_TERMINATOR` (`\n</parameter>\n`).
-///
-/// The terminator always begins with `\n<`, so the body allows multi-line
-/// content but forbids `<` at the start of any line. This is two rules
-/// instead of the 14-state KMP automaton needed to match the full terminator
-/// string, and is sufficient in practice because tool-call parameter values
-/// (code, text, etc.) rarely start a line with `<`.
-fn add_param_value_body_rule(prefix: &str, mut b: Builder) -> (String, Builder) {
-    let body = format!("{prefix}-body");
-    let after_nl = format!("{prefix}-after-nl");
-
-    // body ::= "" | [^\n] body | "\n" after-nl
-    b = b.rule(
-        &body,
-        alt(&[
-            t(""),
-            seq(&[none_of(&['\n']), nt(&body)]),
-            seq(&[t("\n"), nt(&after_nl)]),
-        ]),
-    );
-
-    // after-nl ::= "" | [^<\n] body | "\n" after-nl
-    b = b.rule(
-        &after_nl,
-        alt(&[
-            t(""),
-            seq(&[none_of(&['<', '\n']), nt(&body)]),
-            seq(&[t("\n"), nt(&after_nl)]),
-        ]),
-    );
-
-    (body, b)
-}
-
-/// Build a rule matching a single parameter value per its JSON schema type.
-fn add_value_rule(
-    schema: &Value,
-    prefix: &str,
-    body_rule: &str,
-    b: Builder,
-) -> Result<(String, Builder), ToolFormatError> {
-    let ty = schema
-        .get("type")
-        .and_then(|t| t.as_str())
-        .unwrap_or("string");
-
-    if ty != "string" {
-        let alias = format!("{prefix}-json");
-        let json_gram = json_schema_to_grammar(schema.clone(), "root")?;
-        return Ok((alias.clone(), b.include_grammar_as(&json_gram, &alias)));
-    }
-
-    if let Some(variants) = schema.get("enum").and_then(|e| e.as_array()) {
-        let alts: Vec<Expr> = variants.iter().filter_map(|v| v.as_str()).map(t).collect();
-        if !alts.is_empty() {
-            let rule_name = format!("{prefix}-enum");
-            return Ok((rule_name.clone(), b.rule(&rule_name, alt(&alts))));
-        }
-    }
-
-    Ok((body_rule.to_string(), b))
-}
-
 fn required_params(tool: &Tool) -> HashSet<&str> {
     tool.json_schema
         .get("required")
         .and_then(|r| r.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default()
-}
-
-fn add_parameter_rule(
-    pname: &str,
-    pschema: &Value,
-    tprefix: &str,
-    body_rule: &str,
-    required: &HashSet<&str>,
-    builder: Builder,
-) -> Result<(Expr, Builder), ToolFormatError> {
-    let pprefix = format!("{tprefix}-p-{}", sanitize(pname));
-    let (value_rule, builder) = add_value_rule(pschema, &pprefix, body_rule, builder)?;
-
-    let param_rule = format!("{pprefix}-block");
-    let builder = builder.rule(
-        &param_rule,
-        seq(&[
-            t(&format!("<parameter={pname}>\n")),
-            nt(&value_rule),
-            t(PARAM_TERMINATOR),
-        ]),
-    );
-
-    let param_expr = if required.contains(pname) {
-        nt(&param_rule)
-    } else {
-        Expr::Quantified {
-            expr: Box::new(nt(&param_rule)),
-            quantifier: Quantifier::Optional,
-        }
-    };
-
-    Ok((param_expr, builder))
-}
-
-fn add_tool_rule(
-    tool: &Tool,
-    tool_index: usize,
-    body_rule: &str,
-    mut builder: Builder,
-) -> Result<(String, Builder), ToolFormatError> {
-    let tprefix = format!("qwen35-t{tool_index}");
-    let required = required_params(tool);
-    let mut param_exprs: Vec<Expr> = Vec::new();
-
-    if let Some(props) = tool
-        .json_schema
-        .get("properties")
-        .and_then(|p| p.as_object())
-    {
-        for (pname, pschema) in props {
-            let (expr, next) =
-                add_parameter_rule(pname, pschema, &tprefix, body_rule, &required, builder)?;
-            builder = next;
-            param_exprs.push(expr);
-        }
-    }
-
-    let tool_rule = format!("{tprefix}-call");
-    let mut call_seq: Vec<Expr> = Vec::with_capacity(param_exprs.len() + 2);
-    call_seq.push(t(&format!("<function={}>\n", tool.name)));
-    call_seq.extend(param_exprs);
-    call_seq.push(t("</function>\n"));
-
-    Ok((tool_rule.clone(), builder.rule(&tool_rule, seq(&call_seq))))
-}
-
-/// llama.cpp's grammar parser only accepts `[a-zA-Z0-9-]` in rule names
-/// (see `is_word_char` in `llama-grammar.cpp`), so underscores in parameter
-/// names must be mapped to `-`.
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
 }
 
 // ============================================================================
@@ -327,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn grammar_builds_for_typical_schema() {
+    fn lark_builds_for_typical_schema() {
         let h = Qwen35_36Handler;
         let tool = Tool {
             name: "get_weather".to_string(),
@@ -343,15 +254,17 @@ mod tests {
             }),
             function: std::sync::Arc::new(|_| "".to_string()),
         };
-        let gram = h.generate_grammar(&[tool]).expect("grammar should build");
-        let s = gram.as_str();
-        assert!(s.contains("<tool_call>"));
-        assert!(s.contains("<function=get_weather>"));
-        assert!(s.contains("<parameter=city>"));
+        let lark = h.to_lark(&[tool], None).expect("lark should build");
+        assert!(lark.contains("%llguidance"));
+        assert!(lark.contains("<tool_call>"));
+        assert!(lark.contains("<function=get_weather>"));
+        assert!(lark.contains("<parameter=city>"));
+        assert!(lark.contains("<parameter=units>"));
+        assert!(lark.contains("<parameter=verbose>"));
     }
 
     #[test]
-    fn grammar_reuses_json_scalar_rules_for_non_strings() {
+    fn lark_includes_scalar_types() {
         let h = Qwen35_36Handler;
         let tool = Tool {
             name: "f".to_string(),
@@ -367,12 +280,11 @@ mod tests {
             }),
             function: std::sync::Arc::new(|_| "".to_string()),
         };
-
-        let grammar = h.generate_grammar(&[tool]).expect("grammar should build");
-        let s = grammar.as_str();
-        assert!(s.contains("json-integer"));
-        assert!(s.contains("json-number"));
-        assert!(s.contains("json-boolean"));
-        assert!(s.contains("json-null"));
+        let lark = h.to_lark(&[tool], None).expect("lark should build");
+        assert!(lark.contains("%json"));
+        assert!(lark.contains("<parameter=n>"));
+        assert!(lark.contains("<parameter=x>"));
+        assert!(lark.contains("<parameter=b>"));
+        assert!(lark.contains("<parameter=z>"));
     }
 }

--- a/nobodywho/core/src/tool_calling/qwen35_36.rs
+++ b/nobodywho/core/src/tool_calling/qwen35_36.rs
@@ -87,8 +87,7 @@ impl ToolFormatHandler for Qwen35_36Handler {
                         ));
                     } else {
                         let val_rule = format!("{pprefix}_val");
-                        let schema_str = serde_json::to_string(pschema)
-                            .map_err(|e| ToolFormatError::GrammarGenerationFailed(e.to_string()))?;
+                        let schema_str = super::json_schema_for_llguidance(pschema)?;
                         lark.push_str(&format!("{val_rule}: %json {schema_str}\n"));
                         lark.push_str(&format!(
                             "{block_rule}: \"<parameter={pname}>\\n\" {val_rule} \"\\n</parameter>\\n\"\n"

--- a/nobodywho/core/src/tool_calling/qwen35_36.rs
+++ b/nobodywho/core/src/tool_calling/qwen35_36.rs
@@ -117,6 +117,16 @@ impl ToolFormatHandler for Qwen35_36Handler {
         Ok(lark)
     }
 
+    // NOTE: intentionally no `slice_regexes` override. The hot position is the
+    // free-form `<parameter=…>` body, `body[suffix=/\n<\/parameter>\n/]:
+    // /(?s:.*)/`, whose `.*` compiles to a *lazy* lexeme. llguidance excludes
+    // lazy lexemes from slice subsumption (`RegexVec::subsume_possible` returns
+    // false whenever a lazy lexeme is in the state), so no slice regex can ever
+    // apply here — verified empirically (`slices_applied` stayed 0, trie walk
+    // unchanged). A useful slice would require expressing the body as a *greedy*
+    // bounded repeat (as FunctionGemma does), which we can't without banning the
+    // `<`, embedded/trailing newlines the suffix rule deliberately allows.
+
     fn extract_tool_calls(&self, input: &str) -> Option<Vec<ToolCall>> {
         let calls: Vec<ToolCall> = outer_tool_call_regex()
             .captures_iter(input)

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -6,7 +6,7 @@
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_source_file@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
-  "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#llama-cpp-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh",
-  "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#llama-cpp-sys-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh",
+  "git+https://github.com/jona605a/llama-cpp-rs?rev=7ffc9a92362d4e9ebb4bfa4437b076867acdc955#llama-cpp-2@0.1.152": "0ccwj9azblc6xyl0xnkh24si3qnvgcaybnbhrydfw1wkqy4jssw5",
+  "git+https://github.com/jona605a/llama-cpp-rs?rev=7ffc9a92362d4e9ebb4bfa4437b076867acdc955#llama-cpp-sys-2@0.1.152": "0ccwj9azblc6xyl0xnkh24si3qnvgcaybnbhrydfw1wkqy4jssw5",
   "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa"
 }

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -6,7 +6,7 @@
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_source_file@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
-  "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh"
+  "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#llama-cpp-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh",
+  "git+https://github.com/jona605a/llama-cpp-rs?branch=feat%2Ffull-eog-set-in-tok-env#llama-cpp-sys-2@0.1.152": "1q0pfdiv070brx5yfl0skx1fawsqlz9dzi82sg71wx5hiflb4kkh",
+  "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa"
 }

--- a/nobodywho/grammar/gbnf/src/gbnf_to_lark.rs
+++ b/nobodywho/grammar/gbnf/src/gbnf_to_lark.rs
@@ -31,6 +31,12 @@ enum Node {
     Literal(String),
     Regex(String),
     RuleRef(String),
+    /// A llama.cpp GBNF token reference (`<name>` or `<[42]>`), optionally
+    /// negated (`!<name>`). Maps to Lark `<name>` / `~<name>` syntax.
+    SpecialToken {
+        name: String,
+        negated: bool,
+    },
     Repetition {
         node: Box<Node>,
         min: u32,
@@ -75,6 +81,11 @@ impl Node {
     fn is_terminal(&self, terminal_names: &HashSet<String>) -> bool {
         match self {
             Node::Literal(_) | Node::Regex(_) => true,
+            // Special tokens resolve to specific vocab token IDs at sampler-
+            // init time. llguidance forbids them inside Lark TERMINALS (the
+            // lexer operates on bytes, not token IDs), so any rule that
+            // references one must stay a non-terminal.
+            Node::SpecialToken { .. } => false,
             Node::RuleRef(name) => terminal_names.contains(name),
             Node::Repetition { node, .. } => node.is_terminal(terminal_names),
             Node::Sequence(nodes) | Node::Alternative(nodes) => {
@@ -86,7 +97,7 @@ impl Node {
     fn rename_refs(&mut self, old: &str, new: &str) {
         match self {
             Node::RuleRef(name) if name == old => *name = new.to_string(),
-            Node::RuleRef(_) | Node::Literal(_) | Node::Regex(_) => {}
+            Node::RuleRef(_) | Node::Literal(_) | Node::Regex(_) | Node::SpecialToken { .. } => {}
             Node::Repetition { node, .. } => node.rename_refs(old, new),
             Node::Sequence(nodes) | Node::Alternative(nodes) => {
                 for n in nodes.iter_mut() {
@@ -103,7 +114,7 @@ impl Node {
                     *name = new.clone();
                 }
             }
-            Node::Literal(_) | Node::Regex(_) => {}
+            Node::Literal(_) | Node::Regex(_) | Node::SpecialToken { .. } => {}
             Node::Repetition { node, .. } => node.apply_rename_map(map),
             Node::Sequence(nodes) | Node::Alternative(nodes) => {
                 for n in nodes.iter_mut() {
@@ -123,7 +134,7 @@ impl Node {
                     )));
                 }
             }
-            Node::Literal(_) | Node::Regex(_) => {}
+            Node::Literal(_) | Node::Regex(_) | Node::SpecialToken { .. } => {}
             Node::Repetition { node, .. } => node.validate_refs(known)?,
             Node::Sequence(nodes) | Node::Alternative(nodes) => {
                 for n in nodes {
@@ -140,6 +151,13 @@ impl Node {
             Node::Literal(s) => format!("\"{}\"", s),
             Node::Regex(rx) => format!("/{}/", rx),
             Node::RuleRef(name) => name.clone(),
+            Node::SpecialToken { name, negated } => {
+                if *negated {
+                    format!("~<{}>", name)
+                } else {
+                    format!("<{}>", name)
+                }
+            }
             Node::Repetition { node, min, max } => {
                 let inner = node.to_lark();
                 let inner = if node.is_atomic() {
@@ -355,6 +373,41 @@ impl Parser {
         Ok(Node::Regex(r))
     }
 
+    /// Parse a special-token reference: `<name>` (e.g. `<|"|>`, `<[42]>`).
+    ///
+    /// Both llama.cpp GBNF and Lark/llguidance use this syntax to denote a
+    /// specific vocab token — the bytes between the angle brackets are the
+    /// token's name in the model's vocab (or `[N]` / `[N-M]` for token-id
+    /// ranges). At sampler-init time it's resolved to one (or a range of)
+    /// token IDs and used as a single-token constraint. We just pass the
+    /// inner bytes through unchanged. `negated` reflects a leading `!`
+    /// already consumed by the caller (rendered as `~<name>` in Lark).
+    fn parse_special_token(&mut self, negated: bool) -> Result<Node, GbnfToLarkError> {
+        if self.current() != Some('<') {
+            return Err(self.err("Expected '<'"));
+        }
+        self.advance(1);
+        let start = self.pos;
+        while let Some(c) = self.current() {
+            if c == '>' {
+                break;
+            }
+            if c == '<' || c.is_whitespace() {
+                return Err(self.err("Invalid character in token reference"));
+            }
+            self.advance(1);
+        }
+        if self.current() != Some('>') {
+            return Err(self.err("Unterminated token reference (expected '>')"));
+        }
+        let name: String = self.chars[start..self.pos].iter().collect();
+        self.advance(1);
+        if name.is_empty() {
+            return Err(self.err("Empty token reference"));
+        }
+        Ok(Node::SpecialToken { name, negated })
+    }
+
     fn parse_literal(&mut self) -> Result<Node, GbnfToLarkError> {
         if self.current() != Some('"') {
             return Err(self.err("Expected '\"'"));
@@ -445,6 +498,13 @@ impl Parser {
                 Some('.') => {
                     nodes.push(Node::Regex(".".to_string()));
                     self.advance(1);
+                }
+                // GBNF token reference: <name> or <[42]>
+                Some('<') => nodes.push(self.parse_special_token(false)?),
+                // GBNF negated token reference: !<name>
+                Some('!') if self.chars.get(self.pos + 1) == Some(&'<') => {
+                    self.advance(1);
+                    nodes.push(self.parse_special_token(true)?);
                 }
                 Some(c) if Self::is_word_char(c) => {
                     let name = self.parse_name()?;
@@ -583,7 +643,7 @@ fn to_lark_name(name: &str, is_terminal: bool) -> String {
     }
 }
 
-fn resolve(rules: &mut [Rule]) -> Result<(), GbnfToLarkError> {
+fn resolve(rules: &mut [Rule], entry_name: &str) -> Result<(), GbnfToLarkError> {
     // 1. Assign declaration order; simplify AST
     for (i, rule) in rules.iter_mut().enumerate() {
         rule.order = i;
@@ -596,14 +656,19 @@ fn resolve(rules: &mut [Rule]) -> Result<(), GbnfToLarkError> {
         rule.body.validate_refs(&known_names)?;
     }
 
-    // 3. Rename "root" → "start"; update all refs
-    let root_idx = rules
-        .iter()
-        .position(|r| r.name == "root")
-        .ok_or_else(|| GbnfToLarkError::ResolutionError("No 'root' rule found".to_string()))?;
-    rules[root_idx].name = "start".to_string();
-    for rule in rules.iter_mut() {
-        rule.body.rename_refs("root", "start");
+    // 3. Rename the entry rule to "start"; update all refs.
+    // If entry_name is already "start", there's nothing to do at this step.
+    if entry_name != "start" {
+        let entry_idx = rules
+            .iter()
+            .position(|r| r.name == entry_name)
+            .ok_or_else(|| {
+                GbnfToLarkError::ResolutionError(format!("Entry rule '{}' not found", entry_name))
+            })?;
+        rules[entry_idx].name = "start".to_string();
+        for rule in rules.iter_mut() {
+            rule.body.rename_refs(entry_name, "start");
+        }
     }
 
     // 4. Terminal detection fixpoint (skip "start")
@@ -638,11 +703,21 @@ fn resolve(rules: &mut [Rule]) -> Result<(), GbnfToLarkError> {
 
 // ===== Public functions =====
 
-/// Convert a GBNF grammar string to Lark syntax.
+/// Convert a GBNF grammar string to Lark syntax, treating the rule literally
+/// named `"root"` as the entry point (the llama.cpp GBNF convention).
+///
+/// If your grammar uses a different entry rule name, use
+/// [`gbnf_to_lark_with_entry`] instead.
 pub fn gbnf_to_lark(text: &str) -> Result<String, GbnfToLarkError> {
+    gbnf_to_lark_with_entry(text, "root")
+}
+
+/// Convert a GBNF grammar string to Lark syntax, using `entry_name` as the
+/// entry rule (renamed to `start` in the output).
+pub fn gbnf_to_lark_with_entry(text: &str, entry_name: &str) -> Result<String, GbnfToLarkError> {
     let mut parser = Parser::new(text);
     let mut rules = parser.parse_all()?;
-    resolve(&mut rules)?;
+    resolve(&mut rules, entry_name)?;
     rules.sort_by_key(|r| r.order);
 
     let mut out = String::from("%llguidance {}\n\n");
@@ -826,6 +901,31 @@ mod tests {
         let result = gbnf_to_lark("foo ::= \"bar\"");
         assert!(matches!(result, Err(GbnfToLarkError::ResolutionError(_))));
         assert!(result.unwrap_err().to_string().contains("root"));
+    }
+
+    #[test]
+    fn test_custom_entry_rule_renamed_to_start() {
+        // Grammar with a non-"root" entry rule, plus a "root" rule that should
+        // remain untouched (this is the shape tool-calling handlers produce
+        // when they wrap a JSON sub-grammar whose own entry is "root").
+        let gbnf = "superroot ::= toolcall\ntoolcall ::= \"<\" root \">\"\nroot ::= [a-z]+";
+        let lark = gbnf_to_lark_with_entry(gbnf, "superroot").unwrap();
+        assert!(lark.contains("start:"), "expected start: rule:\n{}", lark);
+        // The leftover "root" rule must not collide with the Lark entry.
+        assert!(
+            lark.contains("ROOT") || lark.contains("root"),
+            "leftover root rule should survive:\n{}",
+            lark
+        );
+        // start must reference what was originally "superroot"'s body.
+        assert!(lark.contains("TOOLCALL") || lark.contains("toolcall"));
+    }
+
+    #[test]
+    fn test_custom_entry_missing_errors() {
+        let result = gbnf_to_lark_with_entry("foo ::= \"bar\"", "superroot");
+        assert!(matches!(result, Err(GbnfToLarkError::ResolutionError(_))));
+        assert!(result.unwrap_err().to_string().contains("superroot"));
     }
 
     #[test]

--- a/nobodywho/grammar/gbnf/src/gbnf_to_lark.rs
+++ b/nobodywho/grammar/gbnf/src/gbnf_to_lark.rs
@@ -657,7 +657,6 @@ fn resolve(rules: &mut [Rule], entry_name: &str) -> Result<(), GbnfToLarkError> 
     }
 
     // 3. Rename the entry rule to "start"; update all refs.
-    // If entry_name is already "start", there's nothing to do at this step.
     if entry_name != "start" {
         let entry_idx = rules
             .iter()

--- a/nobodywho/python/tests/test_tool_calling.py
+++ b/nobodywho/python/tests/test_tool_calling.py
@@ -358,6 +358,9 @@ def test_python_tool(model):
 
 
 def test_bash_tool(model):
+    if is_functiongemma():
+        pytest.skip("Test not supported with FunctionGemma models")
+
     chat = nobodywho.Chat(
         model,
         tools=[nobodywho.bash_tool(max_commands=1000)],


### PR DESCRIPTION

This PR looks at how sampling for tool calling is compiled, precomputed and activated in nobodywho. We are now using llguidance with lark grammars, and the code concerning sampling for tool calling has been refactored. 

## Changes.

**GBNF to Lark migration**. We previously used gbnf grammars for tool calling (which is still supported with `gbnf_to_lark`), and now grammar generation is changed to emit lark directly, across different model formats (Qwen3, Qwen3.5/3.6, Gemma4, FunctionGemma, LFM2, Ministral3). 

**llguidance**. We are now using llguidance for grammar sampling, which makes constrained generation much faster, especially for large vocabularies. 

**Pre-built samplers**. We now have two samplers / sampling states: free generation and grammar-constrained, with respective samplers `base_sampler` and `tool_sampler`. The base sampler is pre-built on creating a chat worker, and the tool sampler is also pre-built if tools are enabled, otherwise when tools are set. This way, we avoid the long (~400-1000 ms) startup time of compiling the tool sampler during a response. 

**Dynamic grammar activation**. During generation, sampling is performed using the `base_sampler` until a `<begin_tool_call>` token is generated, which switches in the `tool_sampler` instead for the remainder of that response. 

**"Slices" as a model-specific speedup**. Using constrained generation takes time to pre-compile the sampler and makes generation slower. In order to speed these up, "slices" can be given to the llguidance parser. I wrote a PR to llama-cpp-rs enabling us to select slices that match each model format. In short, when the parser checks for valid tokens and is in a position where almost all tokens are allowed (such as inside a string in a json), the validation step takes a long time, and you can give it a regex slice that allows the parser to accept all strings accepted by the regex at once, giving a speedup. These are also model-specific: since Qwen3 uses json for tool formatting, it needs json-tuned slices, whereas Gemma4 needs another. 
I have not yet looked into other parser optimizations than slices, but such configuration is exposed through a unified `llguidance_sampler`. 

**Improved error handling**. 

## Remaining todos:

**Cache the `tok_env` per model**. The llguidance sampler requires 1) A model's token environment, and 2) A grammar. The first only depends on the model and can thus be cached, so we don't need to re-compute it on every new chat worker. 

**Fix DRY / penalty history**. With dynamic tool-call activation, we are switching in a different sampler during generation, since lark / llguidance has no native trigger-work mechanism like GBNF's `grammar_lazy`. This means repetition penalties / DRY sampling loses the state. Fix could be to replay an amount of tokens to the sampler.

**Fix multi-token marker leak** (Claude-reported bug). If some `<begin_tool_call>` token is longer than a single token, `wrap_respond` (in inference.rs) leaks the first token(s). 

**Point to the official llama-cpp-rs once my PR has been accepted**. I have a small pending PR to llama-cpp-rs that fixes a bug where some models like Gemma4 wants to output another EOG token but the grammar masks it out. 

**Enable compatibility for MTP when tools are active**. Because MTP does lookahead and also since it samples many tokens at once, grammar activation in the middle becomes tricky. I'm considering making a single stateful sampler that switches between base ("free") sampling and tool (constrained) sampling. Deferred to a later PR. 
