### PR TITLE
Create project changelog

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -61,6 +61,17 @@ nobodywho/flutter/nobodywho/CHANGELOG.md
 
 Each new version section is a `## X.Y.Z` header followed by `### <Feature> (#PR)` subsections, with a short prose line. Match that heading style and tone exactly. Group fixes under a `### Fixes` subsection.
 
+Curate the file [`CHANGELOG.md`](../../../CHANGELOG.md): move relevant entries from `Unreleased` into a dated heading that lists every package's semantic version in the release. This is written by the release maintainer, not generated from commit messages. Don't add PR links.
+
+Use these sections when applicable (don't create new ones):
+
+- `Added` — new functionality.
+- `Changed` — changed behaviour.
+- `Deprecated` — functionality that will be removed in a future release.
+- `Removed` — removed functionality.
+- `Fixed` — bug fixes.
+- `Security` — vulnerability fixes.
+
 **The per-binding changelog files are NOT tracked in version control.** Write them into the gitignored directory `nobodywho/changelogs/` (already in `.gitignore`), one file per binding, **with the version number in the filename** so they can't be confused with each other or with a previous release's drafts:
 
 ```
@@ -106,7 +117,9 @@ Notes from past releases:
 
 Show the drafted changelogs to the user and get approval of the wording.
 
-Once approved, for Flutter **only**, prepend the approved `## X.Y.Z` section to the top of the tracked file:
+Once approved, update the tracked root file `CHANGELOG.md` with the curated dated version heading. Keep a fresh empty `Unreleased` section at the top; any post-release entries stay there.
+
+For Flutter **only**, also prepend the approved `## X.Y.Z` section to the top of the tracked file:
 
 ```
 nobodywho/flutter/nobodywho/CHANGELOG.md
@@ -350,6 +363,7 @@ Tag format **must** be `nobodywho-<binding>-vX.Y.Z` — `.github/workflows/build
 - [ ] Per-binding changelog drafted in `nobodywho/changelogs/<binding>-<v>.md` (gitignored, untracked)
 - [ ] Semver proposal per binding with rationale → **user approval**
 - [ ] Changelog wording → **user approval**
+- [ ] Root `CHANGELOG.md` moved from `Unreleased` into a dated package-version heading
 - [ ] Flutter `CHANGELOG.md` (tracked) prepended with new section
 - [ ] Version files bumped per binding (Step 5 table); Flutter's two files identical
 - [ ] `Cargo.lock` updated (`cargo update -p ... --precise ...`) — before `crate2nix`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,5 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules 
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] If this change affects users, I updated `CHANGELOG.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+Notable user-facing changes to NobodyWho.
+
+We follow [Semantic Versioning](https://semver.org/) for published bindings, which are released independently. Release entries list the package versions that contain the change.
+
+Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- Automatic model selection: pass `"auto"` as a model path to select a recommended model based on available memory. Available for all bindings
+
+### Changed
+
+- **React Native:** `STT` now takes a named options object. Replace `new STT(source, language, quantization)` with `new STT({ source, language, quantization })`.
+
+## [Python v1.6.0, Flutter v2.4.0, Godot v9.5.0, Kotlin v2.1.0, React Native v2.4.0, Swift v2.2.0] - 2026-07-13
+
+### Added
+
+- Offline text-to-speech through `Tts`, with Kokoro and Supertonic ONNX backends.
+- Offline speech-to-text through `Stt`, with Whisper ONNX models.
+- `Chat.getStats()` exposes context-window usage, while `Model.maxCtx()` returns the model's maximum context size.
+- Tokenize messages and prompts without inferencing.
+- Build prompts from JSON-serializable data.
+
+### Fixed
+
+- **Flutter:** Android builds are now compatible with Gradle 9.
+- **Flutter:** Function-parsing failures provide clearer errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,10 @@ This installs `just` (if not already present) and wires up the pre-push hook. Af
 
 1. Make sure all tests pass
 2. Link any relevant issues in your PR description
-3. The PR will be merged once you have the sign-off of at least one maintainer
+3. Add a concise, user-facing entry under `Unreleased` in [`CHANGELOG.md`](CHANGELOG.md) when the change affects users. Group it under `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`, and mention affected bindings when it is not universal. Do not add entries for internal maintenance, CI, or documentation-only changes. PR links are not required.
+4. The PR will be merged once you have the sign-off of at least one maintainer
+
+At release time, maintainers move the relevant `Unreleased` entries into a dated release section and list the independent package versions published in that release.
 
 ## Code Style
 


### PR DESCRIPTION
- Keeps a project level changelog based on [Keep a changelog](https://keepachangelog.com/)
- So that we have a clean *human-written* (preferably) history of changes to the project

NOB-145