### PR TITLE
Godot: Add license file to zip, remove debug builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,19 +16,10 @@ jobs:
         target:
           - "x86_64-unknown-linux-gnu"
           - "aarch64-unknown-linux-gnu"
-        profile:
-          - "debug"
-          - "release"
         integration:
           - "godot"
           - "flutter"
           - "uniffi"
-        exclude:
-          # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
-          - integration: "flutter"
-            profile: "debug"
-          - integration: "uniffi"
-            profile: "debug"
         include:
           - target: x86_64-unknown-linux-gnu
             runner: warp-ubuntu-latest-x64-4x
@@ -47,9 +38,9 @@ jobs:
           path: |
             ~/.cargo
             nobodywho/target
-          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-
+            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-
       - name: "Setup rust toolchain"
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -80,18 +71,18 @@ jobs:
           version: 3.35.5
 
       - name: "Compile for linux"
-        run: cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }} --locked
+        run: cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} --release --locked
         working-directory: ./nobodywho
 
       - name: "Rename built file"
         run: |
-          cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.so ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.so
+          cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.so ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.so
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v5
         with:
-          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}
-          path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.so
+          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-release
+          path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.so
 
   cargo-build-windows:
     if: inputs.full_ci
@@ -101,19 +92,10 @@ jobs:
       matrix:
         target:
           - "x86_64-pc-windows-msvc"
-        profile:
-          - "debug"
-          - "release"
         integration:
           - "godot"
           - "flutter"
           - "uniffi"
-        exclude:
-          # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
-          - integration: "flutter"
-            profile: "debug"
-          - integration: "uniffi"
-            profile: "debug"
     env:
       RUSTFLAGS: >-
         -l Advapi32
@@ -133,9 +115,9 @@ jobs:
           path: |
             ~/.cargo
             nobodywho/target
-          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-
+            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -177,7 +159,7 @@ jobs:
           git config --system core.longpaths true
           cd C:/
           # Use an even shorter target directory to avoid path length issues with git dependencies
-          cargo build -p nobodywho-${{ matrix.integration }} --target ${{ matrix.target }} --verbose ${{ matrix.profile == 'release' && '--release' || '' }} --locked --target-dir C:/t
+          cargo build -p nobodywho-${{ matrix.integration }} --target ${{ matrix.target }} --verbose --release --locked --target-dir C:/t
         env:
           NOBODYWHO_SKIP_CODEGEN: "1"
           RUSTFLAGS: >-
@@ -191,16 +173,16 @@ jobs:
 
       - name: "Rename built files"
         run: |
-          cp C:/t/${{ matrix.target }}/${{ matrix.profile }}/nobodywho_${{ matrix.integration }}.dll ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.dll
-          cp C:/t/${{ matrix.target }}/${{ matrix.profile }}/nobodywho_${{ matrix.integration }}.pdb ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.pdb
+          cp C:/t/${{ matrix.target }}/release/nobodywho_${{ matrix.integration }}.dll ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.dll
+          cp C:/t/${{ matrix.target }}/release/nobodywho_${{ matrix.integration }}.pdb ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.pdb
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v5
         with:
-          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}
+          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-release
           path: |
-            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.dll
-            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.pdb
+            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.dll
+            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.pdb
 
   cargo-build-macos:
     if: inputs.full_ci
@@ -217,9 +199,6 @@ jobs:
           - "aarch64-apple-visionos-sim"
           - "aarch64-apple-watchos"
           - "aarch64-apple-watchos-sim"
-        profile:
-          - "debug"
-          - "release"
         integration:
           - "godot"
           - "flutter"
@@ -245,11 +224,6 @@ jobs:
             target: "aarch64-apple-watchos"
           - integration: "flutter"
             target: "aarch64-apple-watchos-sim"
-          # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
-          - integration: "flutter"
-            profile: "debug"
-          - integration: "uniffi"
-            profile: "debug"
     steps:
       - uses: actions/checkout@v5
       - name: "Setup Rust toolchain"
@@ -310,7 +284,7 @@ jobs:
           if [ -n "${{ steps.ort.outputs.lib_path }}" ]; then
             export ORT_LIB_PATH="${{ steps.ort.outputs.lib_path }}"
           fi
-          cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }} --locked
+          cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} --release --locked
         working-directory: ./nobodywho
         env:
           IPHONEOS_DEPLOYMENT_TARGET: "18.5"
@@ -319,31 +293,31 @@ jobs:
         if: contains(matrix.target, 'visionos') || contains(matrix.target, 'watchos')
         run: |
           export ORT_LIB_PATH="${{ steps.ort.outputs.lib_path }}"
-          cargo +nightly build -p nobodywho-${{ matrix.integration }} -Z build-std --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }}
+          cargo +nightly build -p nobodywho-${{ matrix.integration }} -Z build-std --verbose --target ${{ matrix.target }} --release
         working-directory: ./nobodywho
 
       - name: "Rename built file"
         run: |
           if [ "${{ matrix.integration }}" = "uniffi" ]; then
             # Static library (.a) for xcframeworks (React Native, Swift)
-            cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.a \
-              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.a
+            cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.a \
+              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.a
             # Dynamic library (.dylib) for macOS desktop JNA (Kotlin JVM)
-            if [ -f ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.dylib ]; then
-              cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.dylib \
-                ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.dylib
+            if [ -f ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.dylib ]; then
+              cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.dylib \
+                ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.dylib
             fi
           else
-            cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.dylib \
-              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.dylib
+            cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.dylib \
+              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.dylib
           fi
 
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v5
         with:
-          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}
+          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-release
           # wildcard path to match both .dylib and .a
-          path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.*
+          path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.*
 
   # builds an "xcframework"
   # which is an apple thing that contains binaries for multiple systems
@@ -525,19 +499,10 @@ jobs:
         target:
           - "aarch64-linux-android"
           - "x86_64-linux-android"
-        profile:
-          - "debug"
-          - "release"
         integration:
           - "godot"
           - "flutter"
           - "uniffi"
-        exclude:
-          # debug builds are only consumed by the godot .gdextension; other integrations ship release-only
-          - integration: "flutter"
-            profile: "debug"
-          - integration: "uniffi"
-            profile: "debug"
     steps:
       - uses: actions/checkout@v5
 
@@ -547,9 +512,9 @@ jobs:
           path: |
             ~/.cargo
             nobodywho/target
-          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}-
+            ${{ runner.os }}-cargo-home-${{ matrix.integration }}-${{ matrix.target }}-release-
       - name: "Setup rust toolchain"
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -600,7 +565,7 @@ jobs:
             export ORT_LIB_PATH="${{ steps.ort-android.outputs.ort_dir }}"
             export ORT_PREFER_DYNAMIC_LINK=1
           fi
-          cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} ${{ matrix.profile == 'release' && '--release' || '' }} --locked
+          cargo build -p nobodywho-${{ matrix.integration }} --verbose --target ${{ matrix.target }} --release --locked
         working-directory: ./nobodywho
         env:
           ANDROID_NDK: "${{ steps.setup-ndk.outputs.ndk-path }}"
@@ -622,13 +587,13 @@ jobs:
         run: |
           if [ "${{ matrix.integration }}" = "uniffi" ]; then
             # uniffi produces both static (.a) for React Native/Swift and shared (.so) for Kotlin/JNA
-            cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.a \
-              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.a
-            cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.so \
-              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.so
+            cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.a \
+              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.a
+            cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.so \
+              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.so
           else
-            cp ./nobodywho/target/${{ matrix.target }}/${{ matrix.profile }}/libnobodywho_${{ matrix.integration }}.so \
-              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.so
+            cp ./nobodywho/target/${{ matrix.target }}/release/libnobodywho_${{ matrix.integration }}.so \
+              ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.so
           fi
           # x86_64 Android links dynamically against libonnxruntime.so — ship it alongside.
           if [ "${{ matrix.target }}" = "x86_64-linux-android" ]; then
@@ -638,7 +603,7 @@ jobs:
       - name: "Upload build artifact"
         uses: actions/upload-artifact@v5
         with:
-          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}
+          name: nobodywho-${{ matrix.integration }}-${{ matrix.target }}-release
           path: |
-            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-${{ matrix.profile }}.*
+            ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.*
             ./libonnxruntime.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,11 @@ jobs:
             cp ./assets/icon.svg ./nobodywho-release/bin/addons/nobodywho/
             cp ./LICENSE ./nobodywho-release/bin/addons/nobodywho/
         - name: "Upload zipped godot build artifacts"
-          uses: actions/upload-artifact@v5
+          uses: actions/upload-artifact@v7
           with:
             name: nobodywho-godot-all-platforms
             path: ./nobodywho-release
+            compression_level: 9
 
   create-github-release-godot:
     needs: [godot-distributable]
@@ -58,7 +59,7 @@ jobs:
 
       - name: "Make zip file"
         working-directory: ./nobodywho-release-godot
-        run: zip -r "../nobodywho-godot-${{ github.ref_name }}.zip" ./**
+        run: zip -9 -r "../nobodywho-godot-${{ github.ref_name }}.zip" ./**
 
       - name: "Create GitHub Release"
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
             # copy in gdextension metadata
             cp ./nobodywho/godot/nobodywho.gdextension ./nobodywho-release/bin/addons/nobodywho/
             cp ./assets/icon.svg ./nobodywho-release/bin/addons/nobodywho/
+            cp ./LICENSE ./nobodywho-release/bin/addons/nobodywho/
         - name: "Upload zipped godot build artifacts"
           uses: actions/upload-artifact@v5
           with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
           with:
             name: nobodywho-godot-all-platforms
             path: ./nobodywho-release
-            compression_level: 9
 
   create-github-release-godot:
     needs: [godot-distributable]
@@ -59,7 +58,7 @@ jobs:
 
       - name: "Make zip file"
         working-directory: ./nobodywho-release-godot
-        run: zip -9 -r "../nobodywho-godot-${{ github.ref_name }}.zip" ./**
+        run: zip -r "../nobodywho-godot-${{ github.ref_name }}.zip" ./**
 
       - name: "Create GitHub Release"
         uses: softprops/action-gh-release@v2

--- a/nobodywho/godot/nobodywho.gdextension
+++ b/nobodywho/godot/nobodywho.gdextension
@@ -4,17 +4,17 @@ compatibility_minimum = 4.5
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://addons/nobodywho/libnobodywho-godot-x86_64-unknown-linux-gnu-debug.so"
+linux.debug.x86_64 =     "res://addons/nobodywho/libnobodywho-godot-x86_64-unknown-linux-gnu-release.so"
 linux.release.x86_64 =   "res://addons/nobodywho/libnobodywho-godot-x86_64-unknown-linux-gnu-release.so"
-linux.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-unknown-linux-gnu-debug.so"
+linux.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-unknown-linux-gnu-release.so"
 linux.release.arm64 =    "res://addons/nobodywho/libnobodywho-godot-aarch64-unknown-linux-gnu-release.so"
-windows.debug.x86_64 =   "res://addons/nobodywho/libnobodywho-godot-x86_64-pc-windows-msvc-debug.dll"
+windows.debug.x86_64 =   "res://addons/nobodywho/libnobodywho-godot-x86_64-pc-windows-msvc-release.dll"
 windows.release.x86_64 = "res://addons/nobodywho/libnobodywho-godot-x86_64-pc-windows-msvc-release.dll"
-macos.debug =            "res://addons/nobodywho/libnobodywho-godot-x86_64-apple-darwin-debug.dylib"
+macos.debug =            "res://addons/nobodywho/libnobodywho-godot-x86_64-apple-darwin-release.dylib"
 macos.release =          "res://addons/nobodywho/libnobodywho-godot-x86_64-apple-darwin-release.dylib"
-macos.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-apple-darwin-debug.dylib"
+macos.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-apple-darwin-release.dylib"
 macos.release.arm64 =    "res://addons/nobodywho/libnobodywho-godot-aarch64-apple-darwin-release.dylib"
-android.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-linux-android-debug.so"
+android.debug.arm64 =      "res://addons/nobodywho/libnobodywho-godot-aarch64-linux-android-release.so"
 android.release.arm64 =    "res://addons/nobodywho/libnobodywho-godot-aarch64-linux-android-release.so"
 
 [icons]


### PR DESCRIPTION
Two changes to be compliant with artifact rules for the new godot asset store.

The two new rules are:
1. the zipped artifact must contain a license file. Easy.
2. the zipped artifact must be less than 1GB

I was a bit surprised to find out that our godot distributable is 1.1GB.
This is mostly because it contains binaries compiled for so many different targets. The binaries are roughly ~50MB for each target in release mode, but a few of the targets (android, linux) are ~150MB with debug symbols included.

~~This first attempt just does the easy thing and applies a more aggressive zip compression level, hopefully that'll get us below 1GB. Otherwise we can consider removing debug builds entirely - that'll definitely solve the problem.~~

The dumb fix wasn't enough. I'm removing all debug builds from the godot distributable.