### PR TITLE
Update CI to be gated.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -10,34 +10,36 @@ The headline rule: **`build-and-test.yml` invokes a `plan` job that reads the ev
 |---|---|---|---|---|
 | `lint` | `cargo fmt --check`, `cargo clippy` | any | — | every event |
 | `regen` | uniffi swift / kotlin / RN bindings regen + flutter doctest regen | any | — | every event |
-| `rust_core` | `nix flake check` (canonical core test suite) | `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `python` | wheel build, pytest, pip-install, multimodal, model-downloading, **plus the always-run python static checks** (ruff/ty/stub regen) | `python/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `python_models` | 6-model tool-calling matrix (multi-GB downloads) | — | `test:python-models`, `full-ci` | main, tag, merge queue |
-| `godot` | godot integration build (linux, windows, macos, android) | `godot/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `flutter` | flutter integration build + multimodal tests + xcframework | `flutter/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `swift` | uniffi Apple build + swift xcframework + swift tests | `swift/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `kotlin` | uniffi build for desktop+android + JVM/Android compile + tests | `kotlin/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `react_native` | uniffi iOS+android build + RN xcframework | `react-native/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
-| `docs` | docusaurus build + Cloudflare Pages deploy | `docs/` | — | main only |
+| `rust_core` | `nix flake check` (canonical core test suite) | `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `python` | wheel build (linux/windows/macos), pytest, pip-install, multimodal, model-downloading, **plus the always-run python static checks** (ruff/ty/stub regen) | `python/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `python_models` | 6-model tool-calling matrix (multi-GB downloads); builds the linux wheel only | `core/` | `test:python-models`, `full-ci` | tag, merge queue |
+| `godot` | godot integration build (linux, windows, macos, android) | `godot/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `flutter` | flutter integration build + multimodal tests + xcframework | `flutter/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `swift` | uniffi Apple build + swift xcframework + swift tests | `swift/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `kotlin` | uniffi build for desktop+android + JVM/Android compile + tests | `kotlin/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `react_native` | uniffi iOS+android build + RN xcframework | `react-native/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
+| `docs` | docusaurus build + Cloudflare Pages deploy | — | — | main (deploy only) |
 | `release` | publish to PyPI / pub.dev / npm / Maven Central / Swift mirror | — | — | release tag only |
 
-Two cascade rules:
+Cascade rules:
 
-- A change to `nobodywho/core/**` cascades to **every** Rust-consuming bucket (each binding links core).
+- A change to `nobodywho/core/**` cascades to `rust_core` and every binding (`godot`, `flutter`, `swift`, `kotlin`, `react_native`), plus `python_models`. It does **not** trigger the full `python` bucket — python's core coverage is the tool-calling matrix; the wheel/pytest/pip-install suite runs only on `python/**` or a full run.
 - A change to `nobodywho/uniffi/**` cascades to `swift`, `kotlin`, `react_native`.
 - A change to `Cargo.lock` or `.github/workflows/**` forces everything on (safety net).
+
+Note: `main` is absent from "always on" — the merge queue already validated the merged tree, so a push to `main` runs docs deploy only (see below).
 
 ## Trigger → behavior
 
 | trigger | what runs |
 |---|---|
 | **Draft PR** opened/updated | only the bucket(s) touched by *the latest push*, no cascade |
-| **Non-draft PR** opened/updated | bucket(s) touched by *the whole PR diff* + cross-bucket cascade (core → all bindings, uniffi → swift/kotlin/RN) |
+| **Non-draft PR** opened/updated | bucket(s) touched by *the whole PR diff* + cross-bucket cascade (core → all bindings + `python_models`, uniffi → swift/kotlin/RN) |
 | PR marked **ready-for-review** | re-runs CI in non-draft mode (full diff + cascade) |
 | PR with `full-ci` label | every bucket (sticky; remove label to revert) — overrides draft mode |
 | PR comment `/full-ci` | one-shot full run via `workflow_dispatch` (see `full-ci-comment.yml`) |
 | PR with `test:python-models` label | adds the 6-model matrix on top of path-filtered |
-| Push to `main` | every bucket (post-merge canonical run) + docs deploy |
+| Push to `main` | docs deploy only — the merge queue already validated the merged tree |
 | Push to `nobodywho-*` tag | every bucket + `release.yml` |
 | Merge queue (`merge_group`) | every bucket against the merged tree |
 | `workflow_dispatch` (Actions UI) | every bucket if `full_ci=true`, else lint+regen only |
@@ -45,7 +47,7 @@ Two cascade rules:
 
 ### Why draft vs non-draft matters
 
-While a PR is **draft**, paths-filter compares only the latest push (`before..after`), and cascade rules are disabled. This lets you push messy core changes without dragging every binding's CI into every iteration. When you flip the PR to **ready-for-review**, CI re-runs with the full cumulative PR diff and the cross-bucket cascade — that's the real verification before merge queue picks it up.
+While a PR is **draft**, the plan job diffs only the latest push (`before..after`), and cascade rules are disabled. This lets you push messy core changes without dragging every binding's CI into every iteration. When you flip the PR to **ready-for-review**, CI re-runs with the full cumulative PR diff and the cross-bucket cascade — that's the real verification before merge queue picks it up.
 
 Merge queue refuses to queue drafts, so a draft can't sneak into `main` on the lighter draft-mode CI.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -5,15 +5,15 @@
 ## Workflow
 
 - **Open a PR and push freely.** Each push runs only the bucket(s) whose paths it touched — cheap, fast feedback. (No draft/non-draft distinction.)
-- **Want the full matrix on the PR first?** Add the `full-ci` label or comment `/full-ci`.
-- **Merge via the merge queue.** It runs **full CI against the merged tree** — that's the gate. A push to `main` afterwards only deploys docs (the queue already validated it).
+- **Per-push CI is intentionally partial** — it's not complete or thorough, so green on a PR push does **not** mean the whole project passes. For the full matrix, add the `full-ci` label or comment `/full-ci`.
+- **Merge via the merge queue.** It runs **full CI against the merged tree** — that's the real gate, so nothing lands on `main` unvalidated even though PR runs are lean. A push to `main` afterwards only deploys docs.
 
 ## Buckets
 
 | bucket | what runs | path trigger | always on |
 |---|---|---|---|
 | `lint` | rustfmt + clippy | any | every event |
-| `regen` | uniffi/flutter regen-drift checks | any | every event |
+| `regen` | uniffi/flutter bindings regen-drift | `core/`, `uniffi/`, `grammar/`, `Cargo.*`, `*/generated/`, binding config | tag, merge queue |
 | `rust_core` | `nix flake check` | `core/` | tag, merge queue |
 | `python` | wheels + pytest + pip-install + multimodal (+ always-on static checks: ruff/ty/stubs) | `python/` | tag, merge queue |
 | `python_models` | 6-model tool-calling matrix (linux wheel only) | `core/` | tag, merge queue |
@@ -38,7 +38,7 @@ Cross-bucket: `core/**` → `rust_core` + `python_models`; `uniffi/**` → `swif
 | push `main` | docs deploy + always-on floor only |
 | `[skip ci]` | nothing |
 
-Always-on floor (every event): lint, regen-drift, flutter doctest-drift. Concurrency: PR runs cancel on a new push; `merge_group`/`main`/tags/dispatch run to completion.
+Always-on floor (every event): lint + flutter doctest-drift. Concurrency: PR runs cancel on a new push; `merge_group`/`main`/tags/dispatch run to completion.
 
 ## macOS granularity
 
@@ -63,7 +63,7 @@ visionOS/watchOS compile ONNX Runtime from source and are swift-only, so they bu
 plan.yml            Source of truth: paths/labels/event → run_* flags.
 build-and-test.yml  Entry point: calls plan, gates children, defines `required`.
 linting.yml         Always-on rustfmt + clippy.
-regen-checks.yml    Always-on regen-drift checks.
+regen-checks.yml    Bindings regen-drift checks (gated by run_regen).
 build.yml           Per-platform cargo builds; matrix-gen computes integration + macOS matrix.
 test.yml            nix flake check (run_rust_core) + flutter tests (run_flutter) + always-on doctest-drift.
 python-ci.yml       Static checks always; wheels/tests by run_python; model matrix by run_python_models.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,142 @@
+# CI overview
+
+This directory holds the GitHub Actions workflows that build, test, and release nobodywho across its language bindings (Rust core, Python, Godot, Flutter, Swift, Kotlin, React Native).
+
+The headline rule: **`build-and-test.yml` invokes a `plan` job that reads the event, paths, and labels, then emits a `run_*` boolean per CI bucket. Every other job gates on those outputs.** No other workflow inspects labels, paths, or the event type.
+
+## The buckets
+
+| bucket | what runs | path triggers (auto-on) | label opt-in | always on |
+|---|---|---|---|---|
+| `lint` | `cargo fmt --check`, `cargo clippy` | any | — | every event |
+| `regen` | uniffi swift / kotlin / RN bindings regen + flutter doctest regen | any | — | every event |
+| `rust_core` | `nix flake check` (canonical core test suite) | `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `python` | wheel build, pytest, pip-install, multimodal, model-downloading, **plus the always-run python static checks** (ruff/ty/stub regen) | `python/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `python_models` | 6-model tool-calling matrix (multi-GB downloads) | — | `test:python-models`, `full-ci` | main, tag, merge queue |
+| `godot` | godot integration build (linux, windows, macos, android) | `godot/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `flutter` | flutter integration build + multimodal tests + xcframework | `flutter/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `swift` | uniffi Apple build + swift xcframework + swift tests | `swift/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `kotlin` | uniffi build for desktop+android + JVM/Android compile + tests | `kotlin/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `react_native` | uniffi iOS+android build + RN xcframework | `react-native/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | main, tag, merge queue |
+| `docs` | docusaurus build + Cloudflare Pages deploy | `docs/` | — | main only |
+| `release` | publish to PyPI / pub.dev / npm / Maven Central / Swift mirror | — | — | release tag only |
+
+Two cascade rules:
+
+- A change to `nobodywho/core/**` cascades to **every** Rust-consuming bucket (each binding links core).
+- A change to `nobodywho/uniffi/**` cascades to `swift`, `kotlin`, `react_native`.
+- A change to `Cargo.lock` or `.github/workflows/**` forces everything on (safety net).
+
+## Trigger → behavior
+
+| trigger | what runs |
+|---|---|
+| **Draft PR** opened/updated | only the bucket(s) touched by *the latest push*, no cascade |
+| **Non-draft PR** opened/updated | bucket(s) touched by *the whole PR diff* + cross-bucket cascade (core → all bindings, uniffi → swift/kotlin/RN) |
+| PR marked **ready-for-review** | re-runs CI in non-draft mode (full diff + cascade) |
+| PR with `full-ci` label | every bucket (sticky; remove label to revert) — overrides draft mode |
+| PR comment `/full-ci` | one-shot full run via `workflow_dispatch` (see `full-ci-comment.yml`) |
+| PR with `test:python-models` label | adds the 6-model matrix on top of path-filtered |
+| Push to `main` | every bucket (post-merge canonical run) + docs deploy |
+| Push to `nobodywho-*` tag | every bucket + `release.yml` |
+| Merge queue (`merge_group`) | every bucket against the merged tree |
+| `workflow_dispatch` (Actions UI) | every bucket if `full_ci=true`, else lint+regen only |
+| `[skip ci]` in commit message | nothing (GitHub native) |
+
+### Why draft vs non-draft matters
+
+While a PR is **draft**, paths-filter compares only the latest push (`before..after`), and cascade rules are disabled. This lets you push messy core changes without dragging every binding's CI into every iteration. When you flip the PR to **ready-for-review**, CI re-runs with the full cumulative PR diff and the cross-bucket cascade — that's the real verification before merge queue picks it up.
+
+Merge queue refuses to queue drafts, so a draft can't sneak into `main` on the lighter draft-mode CI.
+
+Concurrency: PR runs cancel each other (new push kills stale CI). `merge_group`, `main` pushes, tags, and dispatches always run to completion.
+
+## Workflow files
+
+```
+plan.yml             Source of truth. Reads paths/labels/event → emits run_* outputs.
+build-and-test.yml   Top-level entry. Calls plan, wires every child workflow's gates,
+                     defines the `required` aggregator and concurrency.
+
+linting.yml          Always-on Rust lint (rustfmt, clippy).
+regen-checks.yml     Always-on regen-drift checks (uniffi bindings + flutter doctests).
+
+build.yml            Per-platform cargo builds (linux, windows, macos, android).
+                     A `matrix-gen` job emits the integration list (linux/windows/
+                     android) and an explicit per-consumer macOS build matrix; each
+                     platform job is gated on whether any consumer bucket needs it.
+                     Apple xcframeworks (flutter / RN / swift) are separate jobs
+                     gated on their owner bucket. See "macOS granularity" below.
+test.yml             nix flake check (gated by run_rust_core),
+                     flutter doctest/multimodal/STT tests (gated by run_flutter).
+python-ci.yml        Static checks always run when invoked; wheel builds + pytest
+                     gated by run_python; 6-model matrix by run_python_models.
+swift-ci.yml         Swift macro + integration tests. Single job, gated upstream.
+kotlin-ci.yml        Kotlin/JVM + Android tests. Single job, gated upstream.
+
+docs.yml             Build + deploy docusaurus to Cloudflare Pages. Gated by
+                     build-and-test.yml to main branch only.
+release.yml          PyPI / pub.dev / npm / Maven Central / Swift mirror publish.
+                     Gated by release tag.
+
+full-ci-comment.yml  Handles `/full-ci` PR comments: permission-checks the commenter,
+                     adds the `full-ci` label and dispatches build-and-test.yml with
+                     full_ci=true.
+ai-review.yml        AI code review on pull requests. Independent trigger; not part
+                     of the plan-gated graph.
+
+rust-install-test.yml  Smoke test that `cargo check -p nobodywho-rust` works on
+                       Ubuntu / macOS / Windows / Nix. workflow_dispatch only.
+test-npm-publish.yml   Standalone test for the React Native npm publish flow.
+```
+
+## macOS granularity
+
+macOS (`warp-macos-15-arm64-6x`) is the most expensive runner, so `cargo-build-macos`
+is gated harder than the other platforms. Instead of a static target × integration
+cross-product, `matrix-gen` emits an explicit `{integration, target, profile}` list
+containing only the combos some *triggered* consumer actually downloads:
+
+| consumer | bucket | macOS targets built |
+|---|---|---|
+| godot | `run_godot` | macOS (x86_64+arm64) + iOS device/sim, debug+release |
+| flutter | `run_flutter` | macOS (x86_64+arm64) + iOS device/sim, release |
+| swift | `run_swift` | uniffi: macOS + iOS device/sim (always) **+ visionOS/watchOS device/sim (full runs only)** |
+| react-native | `run_react_native` | uniffi: iOS device/sim |
+| kotlin | `run_kotlin` | **none** — kotlin's CI tests use the Linux uniffi lib; its macOS release dylib is produced by swift's build on full runs |
+
+Two extra gates beyond the per-consumer target set:
+
+- **visionOS/watchOS are full-run only.** They compile ONNX Runtime *from source*
+  (nightly + `-Z build-std`) and are consumed solely by the shipped swift xcframework,
+  so they build only when `plan`'s `is_full` output is true (main / tag / merge_group /
+  `full-ci` / dispatch), wired in as `build.yml`'s `apple_extended` input. On a partial
+  swift PR the swift xcframework is packaged from whatever slices exist (macOS + iOS);
+  `swift-ci` `swift test`s the macOS slice, so it still passes. The merge queue is a full
+  run, so the complete 7-platform xcframework is verified before anything lands on `main`.
+- **kotlin builds nothing on macOS in CI**, so `run_kotlin` is deliberately absent from
+  `cargo-build-macos`'s `if:`.
+
+## The `required` aggregator
+
+`build-and-test.yml` defines a single job named `required` that depends on every other top-level job. It passes when each `needs.*.result` is `success` or `skipped` (skipped is correct when the plan job gated a bucket out). Failed or cancelled = it exits 1.
+
+**Branch protection on `main` should require exactly one check: `required`.** Renaming a matrix entry inside `build.yml` doesn't break protection because protection points only at the aggregator.
+
+## How to add a new bucket
+
+If you add a new binding or test scope:
+
+1. Add a `run_<new_bucket>` workflow_call output in `plan.yml` and decide its trigger logic in the `decide` step.
+2. In `build-and-test.yml`, add the workflow call with `needs: plan` and `if: needs.plan.outputs.run_<new_bucket> == 'true'`.
+3. Add the new workflow call to the `required` aggregator's `needs:` list.
+4. Update the table at the top of this file.
+
+## Manually re-running a stalled merge queue run
+
+If a `merge_group` run fails for an infrastructure reason (flaky runner, network blip), re-trigger by:
+
+1. Re-queue the PR from the GitHub UI (Merge → Add to queue), or
+2. Push an empty commit to the PR branch to bump it, then re-queue.
+
+Don't cancel an in-flight `merge_group` run — `cancel-in-progress` is intentionally `false` for them.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,144 +1,82 @@
 # CI overview
 
-This directory holds the GitHub Actions workflows that build, test, and release nobodywho across its language bindings (Rust core, Python, Godot, Flutter, Swift, Kotlin, React Native).
+`build-and-test.yml` runs a **`plan`** job that reads the event, changed paths, and labels and emits a `run_*` flag per bucket; every other job just gates on those flags. Nothing else inspects paths/labels/events.
 
-The headline rule: **`build-and-test.yml` invokes a `plan` job that reads the event, paths, and labels, then emits a `run_*` boolean per CI bucket. Every other job gates on those outputs.** No other workflow inspects labels, paths, or the event type.
+## Workflow
 
-## The buckets
+- **Open a PR and push freely.** Each push runs only the bucket(s) whose paths it touched — cheap, fast feedback. (No draft/non-draft distinction.)
+- **Want the full matrix on the PR first?** Add the `full-ci` label or comment `/full-ci`.
+- **Merge via the merge queue.** It runs **full CI against the merged tree** — that's the gate. A push to `main` afterwards only deploys docs (the queue already validated it).
 
-| bucket | what runs | path triggers (auto-on) | label opt-in | always on |
-|---|---|---|---|---|
-| `lint` | `cargo fmt --check`, `cargo clippy` | any | — | every event |
-| `regen` | uniffi swift / kotlin / RN bindings regen + flutter doctest regen | any | — | every event |
-| `rust_core` | `nix flake check` (canonical core test suite) | `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `python` | wheel build (linux/windows/macos), pytest, pip-install, multimodal, model-downloading, **plus the always-run python static checks** (ruff/ty/stub regen) | `python/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `python_models` | 6-model tool-calling matrix (multi-GB downloads); builds the linux wheel only | `core/` | `test:python-models`, `full-ci` | tag, merge queue |
-| `godot` | godot integration build (linux, windows, macos, android) | `godot/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `flutter` | flutter integration build + multimodal tests + xcframework | `flutter/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `swift` | uniffi Apple build + swift xcframework + swift tests | `swift/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `kotlin` | uniffi build for desktop+android + JVM/Android compile + tests | `kotlin/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `react_native` | uniffi iOS+android build + RN xcframework | `react-native/`, `uniffi/`, `core/`, `Cargo.lock` | `full-ci` | tag, merge queue |
-| `docs` | docusaurus build + Cloudflare Pages deploy | — | — | main (deploy only) |
-| `release` | publish to PyPI / pub.dev / npm / Maven Central / Swift mirror | — | — | release tag only |
+## Buckets
 
-Cascade rules:
+| bucket | what runs | path trigger | always on |
+|---|---|---|---|
+| `lint` | rustfmt + clippy | any | every event |
+| `regen` | uniffi/flutter regen-drift checks | any | every event |
+| `rust_core` | `nix flake check` | `core/` | tag, merge queue |
+| `python` | wheels + pytest + pip-install + multimodal (+ always-on static checks: ruff/ty/stubs) | `python/` | tag, merge queue |
+| `python_models` | 6-model tool-calling matrix (linux wheel only) | `core/` | tag, merge queue |
+| `godot` | godot build (linux/win/macos/android) | `godot/` | tag, merge queue |
+| `flutter` | flutter build + multimodal tests + xcframework | `flutter/` | tag, merge queue |
+| `swift` | uniffi Apple build + xcframework + tests | `swift/`, `uniffi/` | tag, merge queue |
+| `kotlin` | uniffi build + JVM/Android tests | `kotlin/`, `uniffi/` | tag, merge queue |
+| `react_native` | uniffi build + RN xcframework | `react-native/`, `uniffi/` | tag, merge queue |
+| `docs` | docusaurus build + Cloudflare Pages deploy | — | main only |
+| `release` | publish PyPI / pub.dev / npm / Maven / Swift | — | release tag |
 
-- A change to `nobodywho/core/**` cascades to `rust_core` and every binding (`godot`, `flutter`, `swift`, `kotlin`, `react_native`), plus `python_models`. It does **not** trigger the full `python` bucket — python's core coverage is the tool-calling matrix; the wheel/pytest/pip-install suite runs only on `python/**` or a full run.
-- A change to `nobodywho/uniffi/**` cascades to `swift`, `kotlin`, `react_native`.
-- A change to `Cargo.lock` or `.github/workflows/**` forces everything on (safety net).
+Cross-bucket: `core/**` → `rust_core` + `python_models`; `uniffi/**` → `swift`/`kotlin`/`react_native`. Otherwise a bucket runs only on its own path. `Cargo.lock` and `.github/workflows/**` do **not** auto-trigger full CI — use `full-ci` or the merge queue.
 
-Note: `main` is absent from "always on" — the merge queue already validated the merged tree, so a push to `main` runs docs deploy only (see below).
+## Triggers
 
-## Trigger → behavior
-
-| trigger | what runs |
+| trigger | runs |
 |---|---|
-| **Draft PR** opened/updated | only the bucket(s) touched by *the latest push*, no cascade |
-| **Non-draft PR** opened/updated | bucket(s) touched by *the whole PR diff* + cross-bucket cascade (core → all bindings + `python_models`, uniffi → swift/kotlin/RN) |
-| PR marked **ready-for-review** | re-runs CI in non-draft mode (full diff + cascade) |
-| PR with `full-ci` label | every bucket (sticky; remove label to revert) — overrides draft mode |
-| PR comment `/full-ci` | one-shot full run via `workflow_dispatch` (see `full-ci-comment.yml`) |
-| PR with `test:python-models` label | adds the 6-model matrix on top of path-filtered |
-| Push to `main` | docs deploy only — the merge queue already validated the merged tree |
-| Push to `nobodywho-*` tag | every bucket + `release.yml` |
-| Merge queue (`merge_group`) | every bucket against the merged tree |
-| `workflow_dispatch` (Actions UI) | every bucket if `full_ci=true`, else lint+regen only |
-| `[skip ci]` in commit message | nothing (GitHub native) |
+| PR push | buckets touched by that push (+ `uniffi → swift/kotlin/RN`) |
+| `full-ci` label / `/full-ci` / `workflow_dispatch` (full_ci) | everything |
+| `merge_group` (merge queue) | everything, against the merged tree |
+| tag `nobodywho-*` | everything + release |
+| push `main` | docs deploy + always-on floor only |
+| `[skip ci]` | nothing |
 
-### Why draft vs non-draft matters
+Always-on floor (every event): lint, regen-drift, flutter doctest-drift. Concurrency: PR runs cancel on a new push; `merge_group`/`main`/tags/dispatch run to completion.
 
-While a PR is **draft**, the plan job diffs only the latest push (`before..after`), and cascade rules are disabled. This lets you push messy core changes without dragging every binding's CI into every iteration. When you flip the PR to **ready-for-review**, CI re-runs with the full cumulative PR diff and the cross-bucket cascade — that's the real verification before merge queue picks it up.
+## macOS granularity
 
-Merge queue refuses to queue drafts, so a draft can't sneak into `main` on the lighter draft-mode CI.
+`cargo-build-macos` is the priciest job, so `matrix-gen` emits an explicit `{integration, target}` list — only the combos a triggered consumer downloads (all release):
 
-Concurrency: PR runs cancel each other (new push kills stale CI). `merge_group`, `main` pushes, tags, and dispatches always run to completion.
+| consumer | macOS targets |
+|---|---|
+| godot / flutter | macOS (x86_64+arm64) + iOS device/sim |
+| swift | uniffi: macOS + iOS device/sim, **+ visionOS/watchOS (full runs only)** |
+| react-native | uniffi: iOS device/sim |
+| kotlin | none (CI tests use the Linux lib) |
+
+visionOS/watchOS compile ONNX Runtime from source and are swift-only, so they build only on full runs (`plan`'s `is_full` → `build.yml`'s `apple_extended`). Partial swift PRs package the xcframework from whatever slices exist; `swift-ci` tests the macOS slice, so it passes. The merge queue (full) verifies all 7 platforms before merge.
+
+## `required` aggregator
+
+`build-and-test.yml` has one `required` job depending on all others; it passes when each result is `success` or `skipped`, fails on `failure`/`cancelled`. **Branch protection should require exactly `required`** — matrix renames never break it.
 
 ## Workflow files
 
 ```
-plan.yml             Source of truth. Reads paths/labels/event → emits run_* outputs.
-build-and-test.yml   Top-level entry. Calls plan, wires every child workflow's gates,
-                     defines the `required` aggregator and concurrency.
-
-linting.yml          Always-on Rust lint (rustfmt, clippy).
-regen-checks.yml     Always-on regen-drift checks (uniffi bindings + flutter doctests).
-
-build.yml            Per-platform cargo builds (linux, windows, macos, android).
-                     A `matrix-gen` job emits the integration list (linux/windows/
-                     android) and an explicit per-consumer macOS build matrix; each
-                     platform job is gated on whether any consumer bucket needs it.
-                     Apple xcframeworks (flutter / RN / swift) are separate jobs
-                     gated on their owner bucket. See "macOS granularity" below.
-test.yml             nix flake check (gated by run_rust_core),
-                     flutter doctest/multimodal/STT tests (gated by run_flutter).
-python-ci.yml        Static checks always run when invoked; wheel builds + pytest
-                     gated by run_python; 6-model matrix by run_python_models.
-swift-ci.yml         Swift macro + integration tests. Single job, gated upstream.
-kotlin-ci.yml        Kotlin/JVM + Android tests. Single job, gated upstream.
-
-docs.yml             Build + deploy docusaurus to Cloudflare Pages. Gated by
-                     build-and-test.yml to main branch only.
-release.yml          PyPI / pub.dev / npm / Maven Central / Swift mirror publish.
-                     Gated by release tag.
-
-full-ci-comment.yml  Handles `/full-ci` PR comments: permission-checks the commenter,
-                     adds the `full-ci` label and dispatches build-and-test.yml with
-                     full_ci=true.
-ai-review.yml        AI code review on pull requests. Independent trigger; not part
-                     of the plan-gated graph.
-
-rust-install-test.yml  Smoke test that `cargo check -p nobodywho-rust` works on
-                       Ubuntu / macOS / Windows / Nix. workflow_dispatch only.
-test-npm-publish.yml   Standalone test for the React Native npm publish flow.
+plan.yml            Source of truth: paths/labels/event → run_* flags.
+build-and-test.yml  Entry point: calls plan, gates children, defines `required`.
+linting.yml         Always-on rustfmt + clippy.
+regen-checks.yml    Always-on regen-drift checks.
+build.yml           Per-platform cargo builds; matrix-gen computes integration + macOS matrix.
+test.yml            nix flake check (run_rust_core) + flutter tests (run_flutter) + always-on doctest-drift.
+python-ci.yml       Static checks always; wheels/tests by run_python; model matrix by run_python_models.
+swift-ci.yml        Swift tests. kotlin-ci.yml  Kotlin/Android tests. (both gated upstream)
+docs.yml            Docusaurus deploy (main only).
+release.yml         Package publish (release tag).
+full-ci-comment.yml `/full-ci` comment → label + dispatch full CI.
+ai-review.yml       `/ai-review` comment. (independent, not plan-gated)
+rust-install-test.yml / test-npm-publish.yml  Standalone smoke tests (dispatch only).
 ```
 
-## macOS granularity
+## Adding a bucket
 
-macOS (`warp-macos-15-arm64-6x`) is the most expensive runner, so `cargo-build-macos`
-is gated harder than the other platforms. Instead of a static target × integration
-cross-product, `matrix-gen` emits an explicit `{integration, target, profile}` list
-containing only the combos some *triggered* consumer actually downloads:
-
-| consumer | bucket | macOS targets built |
-|---|---|---|
-| godot | `run_godot` | macOS (x86_64+arm64) + iOS device/sim, debug+release |
-| flutter | `run_flutter` | macOS (x86_64+arm64) + iOS device/sim, release |
-| swift | `run_swift` | uniffi: macOS + iOS device/sim (always) **+ visionOS/watchOS device/sim (full runs only)** |
-| react-native | `run_react_native` | uniffi: iOS device/sim |
-| kotlin | `run_kotlin` | **none** — kotlin's CI tests use the Linux uniffi lib; its macOS release dylib is produced by swift's build on full runs |
-
-Two extra gates beyond the per-consumer target set:
-
-- **visionOS/watchOS are full-run only.** They compile ONNX Runtime *from source*
-  (nightly + `-Z build-std`) and are consumed solely by the shipped swift xcframework,
-  so they build only when `plan`'s `is_full` output is true (main / tag / merge_group /
-  `full-ci` / dispatch), wired in as `build.yml`'s `apple_extended` input. On a partial
-  swift PR the swift xcframework is packaged from whatever slices exist (macOS + iOS);
-  `swift-ci` `swift test`s the macOS slice, so it still passes. The merge queue is a full
-  run, so the complete 7-platform xcframework is verified before anything lands on `main`.
-- **kotlin builds nothing on macOS in CI**, so `run_kotlin` is deliberately absent from
-  `cargo-build-macos`'s `if:`.
-
-## The `required` aggregator
-
-`build-and-test.yml` defines a single job named `required` that depends on every other top-level job. It passes when each `needs.*.result` is `success` or `skipped` (skipped is correct when the plan job gated a bucket out). Failed or cancelled = it exits 1.
-
-**Branch protection on `main` should require exactly one check: `required`.** Renaming a matrix entry inside `build.yml` doesn't break protection because protection points only at the aggregator.
-
-## How to add a new bucket
-
-If you add a new binding or test scope:
-
-1. Add a `run_<new_bucket>` workflow_call output in `plan.yml` and decide its trigger logic in the `decide` step.
-2. In `build-and-test.yml`, add the workflow call with `needs: plan` and `if: needs.plan.outputs.run_<new_bucket> == 'true'`.
-3. Add the new workflow call to the `required` aggregator's `needs:` list.
-4. Update the table at the top of this file.
-
-## Manually re-running a stalled merge queue run
-
-If a `merge_group` run fails for an infrastructure reason (flaky runner, network blip), re-trigger by:
-
-1. Re-queue the PR from the GitHub UI (Merge → Add to queue), or
-2. Push an empty commit to the PR branch to bump it, then re-queue.
-
-Don't cancel an in-flight `merge_group` run — `cancel-in-progress` is intentionally `false` for them.
+1. Add a `run_<bucket>` output in `plan.yml` and its trigger in the `decide` step.
+2. In `build-and-test.yml`, add the call with `needs: plan` + `if: needs.plan.outputs.run_<bucket> == 'true'`, and to `required`'s `needs`.
+3. Update the table above.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AI_REVIEW_PROVIDER: opencode-go
-  AI_REVIEW_MODEL: glm-5.2
+  AI_REVIEW_MODEL: deepseek-v4-pro
   AI_REVIEW_THINKING: high
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,10 @@ on:
     branches: [main]
     tags: ['nobodywho-*']
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # ready_for_review needs to be in this list so flipping a draft PR to
+    # "ready" re-triggers CI with the full PR-base diff + cascade rules.
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+  merge_group:
   workflow_dispatch:
     inputs:
       full_ci:
@@ -12,9 +15,12 @@ on:
         default: true
         description: 'Run full CI suite (all platforms, all tests)'
 
+# Cancel in-flight PR runs when a new commit is pushed to that PR.
+# Don't cancel merge_group / main / tag / dispatch runs — those are
+# canonical signals we want to see through to completion.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
@@ -23,6 +29,14 @@ permissions:
   deployments: write
 
 jobs:
+  # Single source of truth for "what should this CI run do?" — reads paths,
+  # labels, and the event, emits a run_* boolean per bucket. Every other job
+  # gates on these outputs; no other workflow inspects labels or paths.
+  plan:
+    uses: ./.github/workflows/plan.yml
+    with:
+      dispatch_full_ci: ${{ github.event_name == 'workflow_dispatch' && inputs.full_ci }}
+
   linting:
     uses: ./.github/workflows/linting.yml
 
@@ -30,38 +44,56 @@ jobs:
     uses: ./.github/workflows/regen-checks.yml
 
   python-ci:
+    needs: plan
+    if: needs.plan.outputs.run_python == 'true' || needs.plan.outputs.run_python_models == 'true'
     uses: ./.github/workflows/python-ci.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_python:        ${{ needs.plan.outputs.run_python == 'true' }}
+      run_python_models: ${{ needs.plan.outputs.run_python_models == 'true' }}
 
   build:
+    needs: plan
+    if: |
+      needs.plan.outputs.run_godot == 'true' ||
+      needs.plan.outputs.run_flutter == 'true' ||
+      needs.plan.outputs.run_swift == 'true' ||
+      needs.plan.outputs.run_kotlin == 'true' ||
+      needs.plan.outputs.run_react_native == 'true'
     uses: ./.github/workflows/build.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_godot:        ${{ needs.plan.outputs.run_godot == 'true' }}
+      run_flutter:      ${{ needs.plan.outputs.run_flutter == 'true' }}
+      run_swift:        ${{ needs.plan.outputs.run_swift == 'true' }}
+      run_kotlin:       ${{ needs.plan.outputs.run_kotlin == 'true' }}
+      run_react_native: ${{ needs.plan.outputs.run_react_native == 'true' }}
+      # visionOS/watchOS (ORT-from-source, swift-only) build on full runs only.
+      apple_extended:   ${{ needs.plan.outputs.is_full == 'true' }}
 
   swift-ci:
-    needs: [build]
+    needs: [plan, build]
+    if: needs.plan.outputs.run_swift == 'true'
     uses: ./.github/workflows/swift-ci.yml
-    with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
 
   kotlin-ci:
-    needs: [build]
+    needs: [plan, build]
+    if: needs.plan.outputs.run_kotlin == 'true'
     uses: ./.github/workflows/kotlin-ci.yml
-    with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
 
   test:
+    # Always invoked so the flutter doctest-drift check runs on every event.
+    # The heavy jobs inside (nix flake check, flutter multimodal/STT) gate
+    # themselves on run_rust_core / run_flutter.
+    needs: plan
     uses: ./.github/workflows/test.yml
     with:
-      full_ci: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
-      run_nix: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci')) || (github.event_name == 'workflow_dispatch' && inputs.full_ci) }}
+      run_rust_core: ${{ needs.plan.outputs.run_rust_core == 'true' }}
+      run_flutter:   ${{ needs.plan.outputs.run_flutter == 'true' }}
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/nobodywho-')
-    needs: [linting, regen-checks, build, test, python-ci, swift-ci, kotlin-ci]
+    needs: [plan, linting, regen-checks, build, test, python-ci, swift-ci, kotlin-ci]
+    if: needs.plan.outputs.run_release == 'true'
     uses: ./.github/workflows/release.yml
     secrets:
       TEST_PYPI_AUTH_TOKEN: ${{ secrets.TEST_PYPI_AUTH_TOKEN }}
@@ -74,8 +106,41 @@ jobs:
       MAVEN_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
 
   docs:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy-cloudflare-pages'
+    # Build+deploy only happens on main (or the legacy deploy branch). On PRs
+    # docs.yml would publish from a non-main ref, so keep this ref-gated even
+    # when run_docs is true. PR-time docs verification is a future improvement.
+    needs: plan
+    if: needs.plan.outputs.run_docs == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy-cloudflare-pages')
     uses: ./.github/workflows/docs.yml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  # Single check name for branch protection / merge queue. Passes when every
+  # listed job either succeeded or was correctly skipped by the plan job.
+  # Renaming any matrix entry inside a child workflow no longer breaks the
+  # protection rule.
+  required:
+    if: always()
+    needs:
+      - plan
+      - linting
+      - regen-checks
+      - python-ci
+      - build
+      - swift-ci
+      - kotlin-ci
+      - test
+      - docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Verify required jobs succeeded or were skipped"
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+          if echo "$RESULTS" | grep -qE '"(failure|cancelled)"'; then
+            echo "::error::One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs succeeded or were correctly skipped."

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,7 @@ on:
     branches: [main]
     tags: ['nobodywho-*']
   pull_request:
-    # ready_for_review needs to be in this list so flipping a draft PR to
-    # "ready" re-triggers CI with the full PR-base diff + cascade rules.
-    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,8 @@ jobs:
     uses: ./.github/workflows/linting.yml
 
   regen-checks:
+    needs: plan
+    if: needs.plan.outputs.run_regen == 'true'
     uses: ./.github/workflows/regen-checks.yml
 
   python-ci:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,77 @@ name: "Build"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full build matrix (all platforms, all targets, all profiles)."
+      run_godot:
+        type: boolean
+        default: false
+      run_flutter:
+        type: boolean
+        default: false
+      run_swift:
+        type: boolean
+        default: false
+      run_kotlin:
+        type: boolean
+        default: false
+      run_react_native:
+        type: boolean
+        default: false
+      apple_extended:
         type: boolean
         default: false
 
 jobs:
+  matrix-gen:
+    runs-on: ubuntu-latest
+    outputs:
+      integrations: ${{ steps.gen.outputs.integrations }}
+      macos_matrix: ${{ steps.gen.outputs.macos_matrix }}
+    steps:
+      - id: gen
+        run: |
+          ints=()
+          [[ "${{ inputs.run_godot }}"   == "true" ]] && ints+=('"godot"')   || true
+          [[ "${{ inputs.run_flutter }}" == "true" ]] && ints+=('"flutter"') || true
+          if [[ "${{ inputs.run_swift }}"        == "true" ]] || \
+             [[ "${{ inputs.run_kotlin }}"       == "true" ]] || \
+             [[ "${{ inputs.run_react_native }}" == "true" ]]; then
+            ints+=('"uniffi"')
+          fi
+          IFS=,
+          echo "integrations=[${ints[*]}]" >> "$GITHUB_OUTPUT"
+          unset IFS
+
+          combos=()
+          add() { combos+=("{\"integration\":\"$1\",\"target\":\"$2\"}"); }
+          desktop_ios=(x86_64-apple-darwin aarch64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim)
+          [[ "${{ inputs.run_godot }}"   == "true" ]] && for t in "${desktop_ios[@]}"; do add godot "$t"; done
+          [[ "${{ inputs.run_flutter }}" == "true" ]] && for t in "${desktop_ios[@]}"; do add flutter "$t"; done
+          declare -A uni=()
+          if [[ "${{ inputs.run_swift }}" == "true" ]]; then
+            for t in aarch64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim; do uni["$t"]=1; done
+            if [[ "${{ inputs.apple_extended }}" == "true" ]]; then
+              for t in aarch64-apple-visionos aarch64-apple-visionos-sim \
+                       aarch64-apple-watchos aarch64-apple-watchos-sim; do uni["$t"]=1; done
+            fi
+          fi
+          if [[ "${{ inputs.run_react_native }}" == "true" ]]; then
+            uni["aarch64-apple-ios"]=1; uni["aarch64-apple-ios-sim"]=1
+          fi
+          for t in "${!uni[@]}"; do add uniffi "$t"; done
+          IFS=,
+          echo "macos_matrix={\"include\":[${combos[*]}]}" >> "$GITHUB_OUTPUT"
+          unset IFS
+
   cargo-build-linux:
-    if: inputs.full_ci
+    needs: matrix-gen
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin
     strategy:
       fail-fast: false
       matrix:
         target:
           - "x86_64-unknown-linux-gnu"
           - "aarch64-unknown-linux-gnu"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
         include:
           - target: x86_64-unknown-linux-gnu
             runner: warp-ubuntu-latest-x64-4x
@@ -85,17 +138,15 @@ jobs:
           path: ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.so
 
   cargo-build-windows:
-    if: inputs.full_ci
+    needs: matrix-gen
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         target:
           - "x86_64-pc-windows-msvc"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
     env:
       RUSTFLAGS: >-
         -l Advapi32
@@ -185,45 +236,14 @@ jobs:
             ./libnobodywho-${{ matrix.integration }}-${{ matrix.target }}-release.pdb
 
   cargo-build-macos:
-    if: inputs.full_ci
+    needs: matrix-gen
+    # No run_kotlin: kotlin's CI tests use the Linux uniffi lib and it downloads
+    # no macOS artifact; its release dylib comes from swift's build on full runs.
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_swift || inputs.run_react_native
     runs-on: warp-macos-15-arm64-6x
     strategy:
       fail-fast: false
-      matrix:
-        target:
-          - "x86_64-apple-darwin"
-          - "aarch64-apple-darwin"
-          - "aarch64-apple-ios"
-          - "aarch64-apple-ios-sim"
-          - "aarch64-apple-visionos"
-          - "aarch64-apple-visionos-sim"
-          - "aarch64-apple-watchos"
-          - "aarch64-apple-watchos-sim"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
-        exclude:
-          # uniffi doesn't need macOS x86_64 (Intel Macs are EOL)
-          - integration: "uniffi"
-            target: "x86_64-apple-darwin"
-          # godot and flutter only support macOS and iOS
-          - integration: "godot"
-            target: "aarch64-apple-visionos"
-          - integration: "godot"
-            target: "aarch64-apple-visionos-sim"
-          - integration: "godot"
-            target: "aarch64-apple-watchos"
-          - integration: "godot"
-            target: "aarch64-apple-watchos-sim"
-          - integration: "flutter"
-            target: "aarch64-apple-visionos"
-          - integration: "flutter"
-            target: "aarch64-apple-visionos-sim"
-          - integration: "flutter"
-            target: "aarch64-apple-watchos"
-          - integration: "flutter"
-            target: "aarch64-apple-watchos-sim"
+      matrix: ${{ fromJSON(needs.matrix-gen.outputs.macos_matrix) }}
     steps:
       - uses: actions/checkout@v5
       - name: "Setup Rust toolchain"
@@ -322,7 +342,7 @@ jobs:
   # builds an "xcframework"
   # which is an apple thing that contains binaries for multiple systems
   build-flutter-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_flutter
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -401,7 +421,7 @@ jobs:
 
   # builds an xcframework containing static libraries for React Native iOS
   build-react-native-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_react_native
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -437,7 +457,7 @@ jobs:
 
   # builds an xcframework containing static libraries + headers for Swift SPM
   build-swift-xcframework:
-    if: inputs.full_ci
+    if: inputs.run_swift
     runs-on: warp-macos-15-arm64-6x
     needs: [cargo-build-macos]
     steps:
@@ -454,32 +474,34 @@ jobs:
 
       - name: "Build XCFramework with headers"
         run: |
-          mkdir -p ios-device/Headers ios-sim/Headers macos/Headers \
-                   visionos-device/Headers visionos-sim/Headers \
-                   watchos-device/Headers watchos-sim/Headers
-
-          cp libnobodywho-uniffi-aarch64-apple-ios-release.a ios-device/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-ios-sim-release.a ios-sim/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-darwin-release.a macos/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-visionos-release.a visionos-device/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-visionos-sim-release.a visionos-sim/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-watchos-release.a watchos-device/libnobodywho_uniffi.a
-          cp libnobodywho-uniffi-aarch64-apple-watchos-sim-release.a watchos-sim/libnobodywho_uniffi.a
-
-          for dir in ios-device ios-sim macos visionos-device visionos-sim watchos-device watchos-sim; do
-            cp nobodywho/swift/generated/nobodywhoFFI.h $dir/Headers/
-            cp nobodywho/swift/generated/nobodywhoFFI.modulemap $dir/Headers/module.modulemap
+          set -euo pipefail
+          slices=(
+            "ios-device:aarch64-apple-ios"
+            "ios-sim:aarch64-apple-ios-sim"
+            "macos:aarch64-apple-darwin"
+            "visionos-device:aarch64-apple-visionos"
+            "visionos-sim:aarch64-apple-visionos-sim"
+            "watchos-device:aarch64-apple-watchos"
+            "watchos-sim:aarch64-apple-watchos-sim"
+          )
+          args=()
+          for entry in "${slices[@]}"; do
+            dir="${entry%%:*}"; target="${entry##*:}"
+            lib="libnobodywho-uniffi-${target}-release.a"
+            if [[ ! -f "$lib" ]]; then
+              echo "skipping $dir — $lib not built this run"
+              continue
+            fi
+            mkdir -p "$dir/Headers"
+            cp "$lib" "$dir/libnobodywho_uniffi.a"
+            cp nobodywho/swift/generated/nobodywhoFFI.h "$dir/Headers/"
+            cp nobodywho/swift/generated/nobodywhoFFI.modulemap "$dir/Headers/module.modulemap"
+            args+=(-library "$dir/libnobodywho_uniffi.a" -headers "$dir/Headers")
           done
-
-          xcodebuild -create-xcframework \
-            -library ios-device/libnobodywho_uniffi.a -headers ios-device/Headers \
-            -library ios-sim/libnobodywho_uniffi.a -headers ios-sim/Headers \
-            -library macos/libnobodywho_uniffi.a -headers macos/Headers \
-            -library visionos-device/libnobodywho_uniffi.a -headers visionos-device/Headers \
-            -library visionos-sim/libnobodywho_uniffi.a -headers visionos-sim/Headers \
-            -library watchos-device/libnobodywho_uniffi.a -headers watchos-device/Headers \
-            -library watchos-sim/libnobodywho_uniffi.a -headers watchos-sim/Headers \
-            -output NobodyWhoNative.xcframework
+          if [[ ${#args[@]} -eq 0 ]]; then
+            echo "::error::no uniffi Apple slices were built"; exit 1
+          fi
+          xcodebuild -create-xcframework "${args[@]}" -output NobodyWhoNative.xcframework
 
       - name: "Zip XCFramework"
         run: zip -y -r NobodyWhoNative.xcframework.zip NobodyWhoNative.xcframework
@@ -491,7 +513,8 @@ jobs:
           path: ./NobodyWhoNative.xcframework.zip
 
   cargo-build-android:
-    if: inputs.full_ci
+    needs: matrix-gen
+    if: inputs.run_godot || inputs.run_flutter || inputs.run_kotlin || inputs.run_react_native
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       fail-fast: false
@@ -499,10 +522,7 @@ jobs:
         target:
           - "aarch64-linux-android"
           - "x86_64-linux-android"
-        integration:
-          - "godot"
-          - "flutter"
-          - "uniffi"
+        integration: ${{ fromJSON(needs.matrix-gen.outputs.integrations) }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -1,19 +1,14 @@
 name: "Kotlin CI"
 
-on:
-  workflow_call:
-    inputs:
-      full_ci:
-        description: "Run full Kotlin CI (compilation and integration tests with model)."
-        type: boolean
-        default: false
+# Gated by build-and-test.yml on needs.plan.outputs.run_kotlin — the workflow
+# itself has no input; it only runs when the plan job says kotlin is in scope.
+on: workflow_call
 
 permissions:
   contents: read
 
 jobs:
   test:
-    if: inputs.full_ci
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,7 @@ on: workflow_call
 
 jobs:
   lint:
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -56,16 +56,15 @@ jobs:
       is_full:           ${{ steps.decide.outputs.is_full }}
     steps:
       # fetch-depth: 0 is required so the `git diff` below can reach an
-      # arbitrary base SHA (we pass github.event.before for draft PRs). With
-      # the default shallow clone (depth 1) the base commit is unreachable and
-      # our draft-mode last-push diff stops working.
+      # arbitrary base SHA (github.event.before for a synchronize push). With
+      # the default shallow clone the base commit is unreachable and the diff
+      # would fail.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      # Diagnostic line: surfaces what the event, action, and base SHA were
-      # so the next time draft-mode CI behaves oddly we can read it directly
-      # from the job summary instead of guessing.
+      # Diagnostic line: surfaces the event, action, and base SHA in the job
+      # summary so odd CI routing can be read directly instead of guessed.
       - name: "Echo event diagnostics"
         run: |
           echo "event:    ${{ github.event_name }}"
@@ -87,25 +86,12 @@ jobs:
             echo "| after | \`${{ github.event.after || '(empty)' }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Compute the changed-file list ourselves with `git diff`. We tried
-      # dorny/paths-filter v3 first but it silently kept returning the full
-      # PR diff on synchronize events even with `base:` set to the previous
-      # push SHA and `fetch-depth: 0` on the checkout. Bypassing it removes
-      # the unknown.
-      #
+      # Compute the changed-file list ourselves with `git diff`.
       # Diff base by event:
-      #   - draft PR + synchronize + non-empty `before`: base = before SHA
-      #       (cheap last-push diff while iterating in draft).
-      #   - draft PR + any other action (opened, labeled, ready_for_review[*],
-      #       edited): no meaningful "last push" — leave base empty, no diff.
-      #       Always-on jobs and label-driven `everything=true` still work.
-      #   - non-draft PR: base = PR base SHA → full PR diff + cascade.
+      #   - PR synchronize: base = github.event.before → just that push (incremental).
+      #   - PR opened/reopened/labeled: no "before", so base = PR base SHA.
       #   - push to main: base = github.event.before of the push.
-      #   - merge_group / workflow_dispatch / tag push: skip (decide step
-      #       forces everything=true).
-      #
-      # [*] ready_for_review flips pull_request.draft to false, so it falls
-      #     into the non-draft branch.
+      #   - merge_group / workflow_dispatch / tag: skipped (decide forces everything).
       - name: "Detect changed paths"
         id: paths
         run: |
@@ -116,21 +102,18 @@ jobs:
 
           case "${{ github.event_name }}" in
             pull_request)
-              DRAFT="${{ github.event.pull_request.draft }}"
               ACTION="${{ github.event.action }}"
               EVT_BEFORE="${{ github.event.before }}"
               PR_BASE_SHA="${{ github.event.pull_request.base.sha }}"
               PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-              if [[ "$DRAFT" == "true" ]]; then
-                if [[ "$ACTION" == "synchronize" ]] && [[ -n "$EVT_BEFORE" ]]; then
-                  BASE="$EVT_BEFORE"
-                  HEAD="$PR_HEAD_SHA"
-                fi
-                # else: draft non-synchronize → leave BASE empty, no buckets
+              # synchronize = a new push: diff just that push (incremental).
+              # opened/reopened have no `before`, so diff the PR base once.
+              if [[ "$ACTION" == "synchronize" && -n "$EVT_BEFORE" ]]; then
+                BASE="$EVT_BEFORE"
               else
                 BASE="$PR_BASE_SHA"
-                HEAD="$PR_HEAD_SHA"
               fi
+              HEAD="$PR_HEAD_SHA"
               ;;
             push)
               if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -163,8 +146,6 @@ jobs:
           out() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
 
           # Emit one p_* per filter, mirroring the names the decide step reads.
-          contains '^\.github/workflows/'    && out workflows    true || out workflows    false
-          contains '^nobodywho/Cargo\.lock$' && out cargo_lock   true || out cargo_lock   false
           contains '^nobodywho/core/'        && out core         true || out core         false
           contains '^nobodywho/uniffi/'      && out uniffi       true || out uniffi       false
           contains '^nobodywho/python/'      && out python       true || out python       false
@@ -196,11 +177,8 @@ jobs:
         env:
           EVENT:            ${{ github.event_name }}
           REF:              ${{ github.ref }}
-          IS_DRAFT:         ${{ github.event.pull_request.draft }}
           LABELS:           ${{ toJSON(github.event.pull_request.labels.*.name) }}
           DISPATCH_FULL_CI: ${{ inputs.dispatch_full_ci }}
-          P_WORKFLOWS:      ${{ steps.paths.outputs.workflows }}
-          P_CARGO_LOCK:     ${{ steps.paths.outputs.cargo_lock }}
           P_CORE:           ${{ steps.paths.outputs.core }}
           P_UNIFFI:         ${{ steps.paths.outputs.uniffi }}
           P_PYTHON:         ${{ steps.paths.outputs.python }}
@@ -222,9 +200,7 @@ jobs:
           }
           has_label() { echo "${LABELS:-[]}" | grep -q "\"$1\""; }
 
-          # Normalize dorny outputs (may be empty when the step was skipped).
-          p_workflows="${P_WORKFLOWS:-false}"
-          p_cargo_lock="${P_CARGO_LOCK:-false}"
+          # Normalize path outputs (may be empty when no diff ran).
           p_core="${P_CORE:-false}"
           p_uniffi="${P_UNIFFI:-false}"
           p_python="${P_PYTHON:-false}"
@@ -242,64 +218,37 @@ jobs:
           push_main=false
           if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then push_main=true; fi
 
-          # ---- "run everything" conditions ---------------------------------
+          # ---- full CI (everything) ----------------------------------------
+          # A normal PR push never lands here — it runs only the buckets whose
+          # own paths changed. Full CI is authoritative/opt-in gates only:
           everything=false
-          # Release tag: full surface, then release.yml fires.
-          if [[ "$REF" == refs/tags/nobodywho-* ]]; then everything=true; fi
-          # Merge queue: full surface against the would-be merged tree.
-          if [[ "$EVENT" == "merge_group" ]]; then everything=true; fi
-          # workflow_dispatch with full_ci checked.
-          if [[ "$DISPATCH_FULL_CI" == "true" ]]; then everything=true; fi
-          # `full-ci` label on the PR.
-          if has_label "full-ci"; then everything=true; fi
-          # CI infra changes: safety net — verify everything still works.
-          if [[ "$p_workflows" == "true" ]]; then everything=true; fi
-          # Cargo.lock change: any Rust binding could be affected.
-          if [[ "$p_cargo_lock" == "true" ]]; then everything=true; fi
-
-          # ---- draft-PR mode ----------------------------------------------
-          # On a draft PR we run cheap mode: paths-filter already diffs the
-          # last push only (see the dorny step's `base:` input), and we
-          # disable the cross-bucket cascade rules so a one-off core touch
-          # doesn't drag every binding into CI on subsequent pushes.
-          # Marking the PR ready-for-review re-triggers CI with the full
-          # cumulative diff + cascade.
-          is_draft_pr=false
-          if [[ "$EVENT" == "pull_request" && "$IS_DRAFT" == "true" ]]; then
-            is_draft_pr=true
-          fi
-
-          # ---- cascading scopes --------------------------------------------
-          # core/** is shared by every binding — cascade to all of them.
-          # uniffi/** is shared by swift+kotlin+react-native.
-          # Both cascades disabled in draft mode.
-          if $is_draft_pr; then
-            core_cascade=false
-            uniffi_cascade=false
-          else
-            core_cascade="$p_core"
-            uniffi_cascade="$p_uniffi"
-          fi
+          if [[ "$REF" == refs/tags/nobodywho-* ]]; then everything=true; fi   # release tag
+          if [[ "$EVENT" == "merge_group" ]]; then everything=true; fi          # merge queue = the gate
+          if [[ "$DISPATCH_FULL_CI" == "true" ]]; then everything=true; fi      # workflow_dispatch full_ci
+          if has_label "full-ci"; then everything=true; fi                      # opt-in label / /full-ci
 
           # ---- per-bucket decisions ----------------------------------------
-          run_rust_core=$(any "$everything" "$core_cascade" "$p_core")
+          # Path-gated, no cascade — except uniffi/** → swift/kotlin/RN, which
+          # consume its generated FFI. core/** is core coverage → rust_core +
+          # the tool-calling matrix (python_models below), not the bindings.
+          run_rust_core=$(any "$everything" "$p_core")
           run_python=$(any "$everything" "$p_python")
-          run_godot=$(any "$everything" "$core_cascade" "$p_godot")
-          run_flutter=$(any "$everything" "$core_cascade" "$p_flutter")
-          run_swift=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_swift")
-          run_kotlin=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_kotlin")
-          run_react_native=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_rn")
+          run_godot=$(any "$everything" "$p_godot")
+          run_flutter=$(any "$everything" "$p_flutter")
+          run_swift=$(any "$everything" "$p_uniffi" "$p_swift")
+          run_kotlin=$(any "$everything" "$p_uniffi" "$p_kotlin")
+          run_react_native=$(any "$everything" "$p_uniffi" "$p_rn")
 
-          # python_models: tool-calling matrix (core coverage) — also gated on core_cascade.
+          # python_models: tool-calling matrix (core coverage) — runs on any core change.
           run_python_models=false
-          if [[ "$everything" == "true" ]] || has_label "test:python-models" || [[ "$core_cascade" == "true" ]]; then
+          if [[ "$everything" == "true" ]] || [[ "$p_core" == "true" ]]; then
             run_python_models=true
           fi
 
           # push to main is deploy-only: the merge queue already validated this
           # exact tree, so force every build/test bucket off and only (re)deploy
           # docs below. Without this, buckets touched by the merge commit would
-          # still fire via their path/cascade triggers.
+          # still fire via their path triggers.
           if $push_main; then
             run_rust_core=false
             run_python=false
@@ -338,7 +287,7 @@ jobs:
           {
             echo "## CI Plan"
             echo
-            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  draft-mode: \`$is_draft_pr\`  ·  full-everything: \`$everything\`"
+            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  full-everything: \`$everything\`"
             echo
             echo "| bucket | run? |"
             echo "|---|---|"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -30,13 +30,14 @@ on:
         value: ${{ jobs.plan.outputs.run_react_native }}
       run_docs:
         value: ${{ jobs.plan.outputs.run_docs }}
+      run_regen:
+        value: ${{ jobs.plan.outputs.run_regen }}
       run_release:
         value: ${{ jobs.plan.outputs.run_release }}
       is_full:
-        # True on the "run everything" events (main, tag, merge_group,
-        # dispatch full_ci, full-ci label, workflows/Cargo.lock change).
-        # Consumers use it to gate expensive-but-rarely-broken work (e.g. the
-        # visionOS/watchOS Apple targets) to full runs only.
+        # True on the "run everything" triggers (tag, merge_group, dispatch
+        # full_ci, full-ci label). Consumers use it to gate expensive work
+        # (e.g. visionOS/watchOS) to full runs only.
         value: ${{ jobs.plan.outputs.is_full }}
 
 jobs:
@@ -52,6 +53,7 @@ jobs:
       run_kotlin:        ${{ steps.decide.outputs.run_kotlin }}
       run_react_native:  ${{ steps.decide.outputs.run_react_native }}
       run_docs:          ${{ steps.decide.outputs.run_docs }}
+      run_regen:         ${{ steps.decide.outputs.run_regen }}
       run_release:       ${{ steps.decide.outputs.run_release }}
       is_full:           ${{ steps.decide.outputs.is_full }}
     steps:
@@ -155,6 +157,8 @@ jobs:
           contains '^nobodywho/kotlin/'      && out kotlin       true || out kotlin       false
           contains '^nobodywho/react-native/' && out react_native true || out react_native false
           contains '^docs/'                  && out docs         true || out docs         false
+          # regen-drift surface: anything that can change generated bindings/stubs.
+          contains '^nobodywho/(core/|uniffi/|grammar/|Cargo\.(toml|lock)$|swift/generated/|swift/Package\.swift$|kotlin/common/generated/|kotlin/.*\.gradle\.kts$|react-native/generated/|react-native/package(-lock)?\.json$)' && out regen true || out regen false
 
           {
             echo "## Path detection"
@@ -188,6 +192,7 @@ jobs:
           P_KOTLIN:         ${{ steps.paths.outputs.kotlin }}
           P_RN:             ${{ steps.paths.outputs.react_native }}
           P_DOCS:           ${{ steps.paths.outputs.docs }}
+          P_REGEN:          ${{ steps.paths.outputs.regen }}
         run: |
           set -euo pipefail
 
@@ -210,6 +215,7 @@ jobs:
           p_kotlin="${P_KOTLIN:-false}"
           p_rn="${P_RN:-false}"
           p_docs="${P_DOCS:-false}"
+          p_regen="${P_REGEN:-false}"
 
           # push to main: NOT a full run. The merge queue (merge_group below)
           # already validated this exact merged tree, so re-running the matrix
@@ -245,6 +251,9 @@ jobs:
             run_python_models=true
           fi
 
+          # regen-checks: only when the generated-binding surface changed (or full run).
+          run_regen=$(any "$everything" "$p_regen")
+
           # push to main is deploy-only: the merge queue already validated this
           # exact tree, so force every build/test bucket off and only (re)deploy
           # docs below. Without this, buckets touched by the merge commit would
@@ -258,6 +267,7 @@ jobs:
             run_swift=false
             run_kotlin=false
             run_react_native=false
+            run_regen=false
           fi
 
           # docs: deploy only on a push to main (the docs job is ref-gated to
@@ -279,6 +289,7 @@ jobs:
             echo "run_kotlin=$run_kotlin"
             echo "run_react_native=$run_react_native"
             echo "run_docs=$run_docs"
+            echo "run_regen=$run_regen"
             echo "run_release=$run_release"
             echo "is_full=$everything"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -108,14 +108,17 @@ jobs:
               EVT_BEFORE="${{ github.event.before }}"
               PR_BASE_SHA="${{ github.event.pull_request.base.sha }}"
               PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-              # synchronize = a new push: diff just that push (incremental).
-              # opened/reopened have no `before`, so diff the PR base once.
-              if [[ "$ACTION" == "synchronize" && -n "$EVT_BEFORE" ]]; then
+              HEAD="$PR_HEAD_SHA"
+              # synchronize = a new push: diff just that push (incremental). But
+              # a force-push/rebase orphans `before` (unreachable in the fetched
+              # history), and opened/reopened have no `before` — in both cases
+              # fall back to the PR base SHA (always reachable via the merge ref).
+              if [[ "$ACTION" == "synchronize" && -n "$EVT_BEFORE" ]] \
+                 && git cat-file -e "${EVT_BEFORE}^{commit}" 2>/dev/null; then
                 BASE="$EVT_BEFORE"
               else
                 BASE="$PR_BASE_SHA"
               fi
-              HEAD="$PR_HEAD_SHA"
               ;;
             push)
               if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1,0 +1,340 @@
+name: "plan"
+
+# Reads event, labels, and changed paths and emits a `run_*` boolean per CI
+# bucket. Every other workflow gates on these outputs. This is the only place
+# that knows about routing — child workflows just consume their input.
+
+on:
+  workflow_call:
+    inputs:
+      dispatch_full_ci:
+        description: "True when build-and-test.yml was invoked via workflow_dispatch with full_ci=true."
+        type: boolean
+        default: false
+    outputs:
+      run_rust_core:
+        value: ${{ jobs.plan.outputs.run_rust_core }}
+      run_python:
+        value: ${{ jobs.plan.outputs.run_python }}
+      run_python_models:
+        value: ${{ jobs.plan.outputs.run_python_models }}
+      run_godot:
+        value: ${{ jobs.plan.outputs.run_godot }}
+      run_flutter:
+        value: ${{ jobs.plan.outputs.run_flutter }}
+      run_swift:
+        value: ${{ jobs.plan.outputs.run_swift }}
+      run_kotlin:
+        value: ${{ jobs.plan.outputs.run_kotlin }}
+      run_react_native:
+        value: ${{ jobs.plan.outputs.run_react_native }}
+      run_docs:
+        value: ${{ jobs.plan.outputs.run_docs }}
+      run_release:
+        value: ${{ jobs.plan.outputs.run_release }}
+      is_full:
+        # True on the "run everything" events (main, tag, merge_group,
+        # dispatch full_ci, full-ci label, workflows/Cargo.lock change).
+        # Consumers use it to gate expensive-but-rarely-broken work (e.g. the
+        # visionOS/watchOS Apple targets) to full runs only.
+        value: ${{ jobs.plan.outputs.is_full }}
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run_rust_core:     ${{ steps.decide.outputs.run_rust_core }}
+      run_python:        ${{ steps.decide.outputs.run_python }}
+      run_python_models: ${{ steps.decide.outputs.run_python_models }}
+      run_godot:         ${{ steps.decide.outputs.run_godot }}
+      run_flutter:       ${{ steps.decide.outputs.run_flutter }}
+      run_swift:         ${{ steps.decide.outputs.run_swift }}
+      run_kotlin:        ${{ steps.decide.outputs.run_kotlin }}
+      run_react_native:  ${{ steps.decide.outputs.run_react_native }}
+      run_docs:          ${{ steps.decide.outputs.run_docs }}
+      run_release:       ${{ steps.decide.outputs.run_release }}
+      is_full:           ${{ steps.decide.outputs.is_full }}
+    steps:
+      # fetch-depth: 0 is required so the `git diff` below can reach an
+      # arbitrary base SHA (we pass github.event.before for draft PRs). With
+      # the default shallow clone (depth 1) the base commit is unreachable and
+      # our draft-mode last-push diff stops working.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Diagnostic line: surfaces what the event, action, and base SHA were
+      # so the next time draft-mode CI behaves oddly we can read it directly
+      # from the job summary instead of guessing.
+      - name: "Echo event diagnostics"
+        run: |
+          echo "event:    ${{ github.event_name }}"
+          echo "action:   ${{ github.event.action }}"
+          echo "ref:      ${{ github.ref }}"
+          echo "draft:    ${{ github.event.pull_request.draft }}"
+          echo "before:   ${{ github.event.before }}"
+          echo "after:    ${{ github.event.after }}"
+          {
+            echo "## Event diagnostics"
+            echo
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| event | \`${{ github.event_name }}\` |"
+            echo "| action | \`${{ github.event.action }}\` |"
+            echo "| ref | \`${{ github.ref }}\` |"
+            echo "| draft | \`${{ github.event.pull_request.draft }}\` |"
+            echo "| before | \`${{ github.event.before || '(empty)' }}\` |"
+            echo "| after | \`${{ github.event.after || '(empty)' }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Compute the changed-file list ourselves with `git diff`. We tried
+      # dorny/paths-filter v3 first but it silently kept returning the full
+      # PR diff on synchronize events even with `base:` set to the previous
+      # push SHA and `fetch-depth: 0` on the checkout. Bypassing it removes
+      # the unknown.
+      #
+      # Diff base by event:
+      #   - draft PR + synchronize + non-empty `before`: base = before SHA
+      #       (cheap last-push diff while iterating in draft).
+      #   - draft PR + any other action (opened, labeled, ready_for_review[*],
+      #       edited): no meaningful "last push" — leave base empty, no diff.
+      #       Always-on jobs and label-driven `everything=true` still work.
+      #   - non-draft PR: base = PR base SHA → full PR diff + cascade.
+      #   - push to main: base = github.event.before of the push.
+      #   - merge_group / workflow_dispatch / tag push: skip (decide step
+      #       forces everything=true).
+      #
+      # [*] ready_for_review flips pull_request.draft to false, so it falls
+      #     into the non-draft branch.
+      - name: "Detect changed paths"
+        id: paths
+        run: |
+          set -uo pipefail
+
+          BASE=""
+          HEAD=""
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              DRAFT="${{ github.event.pull_request.draft }}"
+              ACTION="${{ github.event.action }}"
+              EVT_BEFORE="${{ github.event.before }}"
+              PR_BASE_SHA="${{ github.event.pull_request.base.sha }}"
+              PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+              if [[ "$DRAFT" == "true" ]]; then
+                if [[ "$ACTION" == "synchronize" ]] && [[ -n "$EVT_BEFORE" ]]; then
+                  BASE="$EVT_BEFORE"
+                  HEAD="$PR_HEAD_SHA"
+                fi
+                # else: draft non-synchronize → leave BASE empty, no buckets
+              else
+                BASE="$PR_BASE_SHA"
+                HEAD="$PR_HEAD_SHA"
+              fi
+              ;;
+            push)
+              if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+                BASE="${{ github.event.before }}"
+                HEAD="${{ github.event.after }}"
+              fi
+              ;;
+          esac
+
+          if [[ -n "$BASE" ]] && [[ -n "$HEAD" ]]; then
+            echo "Diffing $BASE..$HEAD"
+            CHANGED="$(git diff --name-only "$BASE..$HEAD" 2>&1)"
+            git_rc=$?
+            if [[ $git_rc -ne 0 ]]; then
+              echo "::warning::git diff failed (exit $git_rc); treating as no changes"
+              CHANGED=""
+            fi
+          else
+            echo "No diff base; treating as no changes"
+            CHANGED=""
+          fi
+
+          echo "---- Changed files ----"
+          if [[ -z "$CHANGED" ]]; then echo "(none)"; else echo "$CHANGED"; fi
+          echo "-----------------------"
+
+          contains() {
+            [[ -n "$CHANGED" ]] && echo "$CHANGED" | grep -qE "$1"
+          }
+          out() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
+          # Emit one p_* per filter, mirroring the names the decide step reads.
+          contains '^\.github/workflows/'    && out workflows    true || out workflows    false
+          contains '^nobodywho/Cargo\.lock$' && out cargo_lock   true || out cargo_lock   false
+          contains '^nobodywho/core/'        && out core         true || out core         false
+          contains '^nobodywho/uniffi/'      && out uniffi       true || out uniffi       false
+          contains '^nobodywho/python/'      && out python       true || out python       false
+          contains '^nobodywho/godot/'       && out godot        true || out godot        false
+          contains '^nobodywho/flutter/'     && out flutter      true || out flutter      false
+          contains '^nobodywho/swift/'       && out swift        true || out swift        false
+          contains '^nobodywho/kotlin/'      && out kotlin       true || out kotlin       false
+          contains '^nobodywho/react-native/' && out react_native true || out react_native false
+          contains '^docs/'                  && out docs         true || out docs         false
+
+          {
+            echo "## Path detection"
+            echo
+            echo "Base: \`${BASE:-(none)}\`  ·  Head: \`${HEAD:-(none)}\`"
+            echo
+            if [[ -z "$CHANGED" ]]; then
+              echo "Changed files: _none_"
+            else
+              echo "Changed files:"
+              echo
+              echo '```'
+              echo "$CHANGED"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Decide which buckets to run"
+        id: decide
+        env:
+          EVENT:            ${{ github.event_name }}
+          REF:              ${{ github.ref }}
+          IS_DRAFT:         ${{ github.event.pull_request.draft }}
+          LABELS:           ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          DISPATCH_FULL_CI: ${{ inputs.dispatch_full_ci }}
+          P_WORKFLOWS:      ${{ steps.paths.outputs.workflows }}
+          P_CARGO_LOCK:     ${{ steps.paths.outputs.cargo_lock }}
+          P_CORE:           ${{ steps.paths.outputs.core }}
+          P_UNIFFI:         ${{ steps.paths.outputs.uniffi }}
+          P_PYTHON:         ${{ steps.paths.outputs.python }}
+          P_GODOT:          ${{ steps.paths.outputs.godot }}
+          P_FLUTTER:        ${{ steps.paths.outputs.flutter }}
+          P_SWIFT:          ${{ steps.paths.outputs.swift }}
+          P_KOTLIN:         ${{ steps.paths.outputs.kotlin }}
+          P_RN:             ${{ steps.paths.outputs.react_native }}
+          P_DOCS:           ${{ steps.paths.outputs.docs }}
+        run: |
+          set -euo pipefail
+
+          # Returns "true" if any positional arg equals "true".
+          any() {
+            for v in "$@"; do
+              if [[ "$v" == "true" ]]; then echo true; return; fi
+            done
+            echo false
+          }
+          has_label() { echo "${LABELS:-[]}" | grep -q "\"$1\""; }
+
+          # Normalize dorny outputs (may be empty when the step was skipped).
+          p_workflows="${P_WORKFLOWS:-false}"
+          p_cargo_lock="${P_CARGO_LOCK:-false}"
+          p_core="${P_CORE:-false}"
+          p_uniffi="${P_UNIFFI:-false}"
+          p_python="${P_PYTHON:-false}"
+          p_godot="${P_GODOT:-false}"
+          p_flutter="${P_FLUTTER:-false}"
+          p_swift="${P_SWIFT:-false}"
+          p_kotlin="${P_KOTLIN:-false}"
+          p_rn="${P_RN:-false}"
+          p_docs="${P_DOCS:-false}"
+
+          # ---- "run everything" conditions ---------------------------------
+          everything=false
+          # Push to main: full surface (this is the post-merge canonical run).
+          if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then everything=true; fi
+          # Release tag: full surface, then release.yml fires.
+          if [[ "$REF" == refs/tags/nobodywho-* ]]; then everything=true; fi
+          # Merge queue: full surface against the would-be merged tree.
+          if [[ "$EVENT" == "merge_group" ]]; then everything=true; fi
+          # workflow_dispatch with full_ci checked.
+          if [[ "$DISPATCH_FULL_CI" == "true" ]]; then everything=true; fi
+          # `full-ci` label on the PR.
+          if has_label "full-ci"; then everything=true; fi
+          # CI infra changes: safety net — verify everything still works.
+          if [[ "$p_workflows" == "true" ]]; then everything=true; fi
+          # Cargo.lock change: any Rust binding could be affected.
+          if [[ "$p_cargo_lock" == "true" ]]; then everything=true; fi
+
+          # ---- draft-PR mode ----------------------------------------------
+          # On a draft PR we run cheap mode: paths-filter already diffs the
+          # last push only (see the dorny step's `base:` input), and we
+          # disable the cross-bucket cascade rules so a one-off core touch
+          # doesn't drag every binding into CI on subsequent pushes.
+          # Marking the PR ready-for-review re-triggers CI with the full
+          # cumulative diff + cascade.
+          is_draft_pr=false
+          if [[ "$EVENT" == "pull_request" && "$IS_DRAFT" == "true" ]]; then
+            is_draft_pr=true
+          fi
+
+          # ---- cascading scopes --------------------------------------------
+          # core/** is shared by every binding — cascade to all of them.
+          # uniffi/** is shared by swift+kotlin+react-native.
+          # Both cascades disabled in draft mode.
+          if $is_draft_pr; then
+            core_cascade=false
+            uniffi_cascade=false
+          else
+            core_cascade="$p_core"
+            uniffi_cascade="$p_uniffi"
+          fi
+
+          # ---- per-bucket decisions ----------------------------------------
+          run_rust_core=$(any "$everything" "$core_cascade")
+          run_python=$(any "$everything" "$core_cascade" "$p_python")
+          run_godot=$(any "$everything" "$core_cascade" "$p_godot")
+          run_flutter=$(any "$everything" "$core_cascade" "$p_flutter")
+          run_swift=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_swift")
+          run_kotlin=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_kotlin")
+          run_react_native=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_rn")
+
+          # python_models: heavy 6-model matrix. On main / full-ci / explicit label.
+          run_python_models=false
+          if [[ "$everything" == "true" ]] || has_label "test:python-models"; then
+            run_python_models=true
+          fi
+
+          # The model matrix consumes the python wheel, so force-on the python
+          # wheel build/test bucket whenever the model matrix is requested.
+          if [[ "$run_python_models" == "true" ]]; then
+            run_python=true
+          fi
+
+          # docs: rebuild whenever docs/** changed, or on a full run.
+          run_docs=$(any "$everything" "$p_docs")
+
+          # release: only on a release tag.
+          run_release=false
+          if [[ "$REF" == refs/tags/nobodywho-* ]]; then run_release=true; fi
+
+          # ---- emit --------------------------------------------------------
+          {
+            echo "run_rust_core=$run_rust_core"
+            echo "run_python=$run_python"
+            echo "run_python_models=$run_python_models"
+            echo "run_godot=$run_godot"
+            echo "run_flutter=$run_flutter"
+            echo "run_swift=$run_swift"
+            echo "run_kotlin=$run_kotlin"
+            echo "run_react_native=$run_react_native"
+            echo "run_docs=$run_docs"
+            echo "run_release=$run_release"
+            echo "is_full=$everything"
+          } >> "$GITHUB_OUTPUT"
+
+          # ---- run summary -------------------------------------------------
+          {
+            echo "## CI Plan"
+            echo
+            echo "Event: \`$EVENT\`  ·  Ref: \`$REF\`  ·  draft-mode: \`$is_draft_pr\`  ·  full-everything: \`$everything\`"
+            echo
+            echo "| bucket | run? |"
+            echo "|---|---|"
+            echo "| rust_core | $run_rust_core |"
+            echo "| python | $run_python |"
+            echo "| python_models | $run_python_models |"
+            echo "| godot | $run_godot |"
+            echo "| flutter | $run_flutter |"
+            echo "| swift | $run_swift |"
+            echo "| kotlin | $run_kotlin |"
+            echo "| react_native | $run_react_native |"
+            echo "| docs | $run_docs |"
+            echo "| release | $run_release |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -235,10 +235,15 @@ jobs:
           p_rn="${P_RN:-false}"
           p_docs="${P_DOCS:-false}"
 
+          # push to main: NOT a full run. The merge queue (merge_group below)
+          # already validated this exact merged tree, so re-running the matrix
+          # here is pure duplication. Only main-only side effects run — docs
+          # deploy (via run_docs) and, on tags, release.
+          push_main=false
+          if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then push_main=true; fi
+
           # ---- "run everything" conditions ---------------------------------
           everything=false
-          # Push to main: full surface (this is the post-merge canonical run).
-          if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then everything=true; fi
           # Release tag: full surface, then release.yml fires.
           if [[ "$REF" == refs/tags/nobodywho-* ]]; then everything=true; fi
           # Merge queue: full surface against the would-be merged tree.
@@ -277,28 +282,38 @@ jobs:
           fi
 
           # ---- per-bucket decisions ----------------------------------------
-          run_rust_core=$(any "$everything" "$core_cascade")
-          run_python=$(any "$everything" "$core_cascade" "$p_python")
+          run_rust_core=$(any "$everything" "$core_cascade" "$p_core")
+          run_python=$(any "$everything" "$p_python")
           run_godot=$(any "$everything" "$core_cascade" "$p_godot")
           run_flutter=$(any "$everything" "$core_cascade" "$p_flutter")
           run_swift=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_swift")
           run_kotlin=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_kotlin")
           run_react_native=$(any "$everything" "$core_cascade" "$uniffi_cascade" "$p_rn")
 
-          # python_models: heavy 6-model matrix. On main / full-ci / explicit label.
+          # python_models: tool-calling matrix (core coverage) — also gated on core_cascade.
           run_python_models=false
-          if [[ "$everything" == "true" ]] || has_label "test:python-models"; then
+          if [[ "$everything" == "true" ]] || has_label "test:python-models" || [[ "$core_cascade" == "true" ]]; then
             run_python_models=true
           fi
 
-          # The model matrix consumes the python wheel, so force-on the python
-          # wheel build/test bucket whenever the model matrix is requested.
-          if [[ "$run_python_models" == "true" ]]; then
-            run_python=true
+          # push to main is deploy-only: the merge queue already validated this
+          # exact tree, so force every build/test bucket off and only (re)deploy
+          # docs below. Without this, buckets touched by the merge commit would
+          # still fire via their path/cascade triggers.
+          if $push_main; then
+            run_rust_core=false
+            run_python=false
+            run_python_models=false
+            run_godot=false
+            run_flutter=false
+            run_swift=false
+            run_kotlin=false
+            run_react_native=false
           fi
 
-          # docs: rebuild whenever docs/** changed, or on a full run.
-          run_docs=$(any "$everything" "$p_docs")
+          # docs: deploy only on a push to main (the docs job is ref-gated to
+          # main anyway, so this never fires on PRs or in the merge queue).
+          run_docs="$push_main"
 
           # release: only on a release tag.
           run_release=false

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -3,8 +3,12 @@ name: "Python CI"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full Python CI (builds, tests, pip-install checks). If false, only static checks run."
+      run_python:
+        description: "Build wheels + run pytest / multimodal / pip-install checks. If false, only static checks run."
+        type: boolean
+        default: false
+      run_python_models:
+        description: "Run the 6-model tool-calling matrix (multi-GB downloads)."
         type: boolean
         default: false
 
@@ -72,7 +76,7 @@ jobs:
         run: uv run ty check
 
   linux-build:
-    if: inputs.full_ci
+    if: inputs.run_python || inputs.run_python_models
     # Build inside manylinux_2_34 container for glibc 2.34 compatibility
     # This targets glibc version 2.34 which covers most distros going back to 2021
     # See: https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#distro-compatibility
@@ -170,7 +174,7 @@ jobs:
           path: ./wheelhouse/nobodywho*.whl
 
   windows-build:
-    if: inputs.full_ci
+    if: inputs.run_python
     strategy:
       fail-fast: false
       matrix:
@@ -229,7 +233,7 @@ jobs:
           path: C:/target/wheels/nobodywho*.whl
 
   mac-os-build:
-    if: inputs.full_ci
+    if: inputs.run_python
     runs-on: warp-macos-latest-arm64-6x
     strategy:
       fail-fast: false
@@ -251,7 +255,7 @@ jobs:
           path: ./nobodywho/target/wheels/nobodywho*.whl
 
   linux-pytest:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
@@ -311,7 +315,7 @@ jobs:
           python3 -m pytest --markdown-docs ../../docs --markdown-docs-syntax=superfences
 
   linux-multimodal-tests:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
@@ -386,7 +390,7 @@ jobs:
     
 
   linux-tool-calling-tests:
-    if: inputs.full_ci
+    if: inputs.run_python_models
     needs: [linux-build]
     runs-on: warp-ubuntu-latest-x64-4x
     strategy:
@@ -466,7 +470,7 @@ jobs:
           echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
   linux-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [linux-build]
     strategy:
       fail-fast: false
@@ -516,7 +520,7 @@ jobs:
           bash nobodywho/python/tests/test_reliability.sh -n ${{ matrix.model_iterations }} nobodywho/python/examples/small_model_demo.py "linux/nobodypython/models/${{ matrix.model_name }}"
 
   windows-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [windows-build]
     strategy:
       fail-fast: false
@@ -567,7 +571,7 @@ jobs:
           ./nobodywho/python/tests/test_reliability.ps1 -ScriptPath "${{ github.workspace }}/nobodywho/python/examples/small_model_demo.py" -Iterations ${{ matrix.model_iterations }} "${{ github.workspace }}/windows/nobodywho_python/models/${{ matrix.model_name }}"
 
   mac-os-pip-install-test:
-    if: inputs.full_ci
+    if: inputs.run_python
     needs: [mac-os-build]
     runs-on: warp-macos-latest-arm64-6x
     strategy:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,15 +33,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev cmake libshaderc-dev libvulkan-dev glslc
           uv venv
-          uv sync --locked
+          uv sync --locked --no-install-project
 
       - name: Format check
         working-directory: ./nobodywho/python
-        run: uv run ruff format --check
+        run: uv run --no-sync ruff format --check
 
       - name: Lint check
         working-directory: ./nobodywho/python
-        run: uv run ruff check
+        run: uv run --no-sync ruff check
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -55,7 +55,7 @@ jobs:
 
       - name: Format generated stubs
         working-directory: ./nobodywho/python
-        run: uv run ruff format nobodywho.pyi
+        run: uv run --no-sync ruff format nobodywho.pyi
 
       - name: Check generated stubs
         working-directory: ./nobodywho/python
@@ -73,7 +73,7 @@ jobs:
 
       - name: Type check
         working-directory: ./nobodywho/python
-        run: uv run ty check
+        run: uv run --no-sync ty check
 
   linux-build:
     if: inputs.run_python || inputs.run_python_models
@@ -271,25 +271,41 @@ jobs:
         with:
           name: nobodywho_python_linux_manylinux_2_34_x86_64
           path: ./wheels
+      - name: Restore test model cache
+        id: test-model-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: models
+          # Bump v1 whenever a URL or downloaded file changes.
+          key: linux-python-test-models-v1
       - name: Download test models
         run: |
-          mkdir -p models
-          curl -L --fail --progress-bar https://huggingface.co/bartowski/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf -o models/Qwen_Qwen3-0.6B-Q4_K_M.gguf
-          curl -L --fail --progress-bar https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf -o models/bge-small-en-v1.5-q8_0.gguf
-          curl -L --fail --progress-bar https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf -o models/bge-reranker-v2-m3-Q8_0.gguf
-          curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/google_gemma-4-E2B-it-Q4_K_M.gguf -o models/google_gemma-4-E2B-it-Q4_K_M.gguf
-          curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/mmproj-google_gemma-4-E2B-it-f16.gguf -o models/mmproj-google_gemma-4-E2B-it-f16.gguf
-          # Whisper ONNX — only the files we actually load. The STT tests
-          # request quantization="default" (fp32), so we download the unsuffixed
-          # ONNX files here. (Keep in sync with the tests and models.nix.)
-          WHISPER_BASE="https://huggingface.co/onnx-community/whisper-base/resolve/main"
+          download_pids=()
+          download() {
+            test -f "$2" && return
+            if [ "${#download_pids[@]}" -ge 4 ]; then
+              wait "${download_pids[0]}"
+              download_pids=("${download_pids[@]:1}")
+            fi
+            curl -L --fail --progress-bar "$1" -o "$2" &
+            download_pids+=("$!")
+          }
           mkdir -p models/whisper-base/onnx
-          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/encoder_model.onnx"       -o models/whisper-base/onnx/encoder_model.onnx
-          curl -L --fail --progress-bar "$WHISPER_BASE/onnx/decoder_model_merged.onnx" -o models/whisper-base/onnx/decoder_model_merged.onnx
-          curl -L --fail --progress-bar "$WHISPER_BASE/tokenizer.json"                 -o models/whisper-base/tokenizer.json
-          curl -L --fail --progress-bar "$WHISPER_BASE/generation_config.json"         -o models/whisper-base/generation_config.json
-          curl -L --fail --progress-bar "$WHISPER_BASE/config.json"                    -o models/whisper-base/config.json
-          curl -L --fail --progress-bar "$WHISPER_BASE/preprocessor_config.json"       -o models/whisper-base/preprocessor_config.json
+          download https://huggingface.co/bartowski/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf models/Qwen_Qwen3-0.6B-Q4_K_M.gguf
+          download https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf models/bge-small-en-v1.5-q8_0.gguf
+          download https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf models/bge-reranker-v2-m3-Q8_0.gguf
+          download https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/google_gemma-4-E2B-it-Q4_K_M.gguf models/google_gemma-4-E2B-it-Q4_K_M.gguf
+          download https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/mmproj-google_gemma-4-E2B-it-f16.gguf models/mmproj-google_gemma-4-E2B-it-f16.gguf
+          whisper_base=https://huggingface.co/onnx-community/whisper-base/resolve/main
+          download "$whisper_base/onnx/encoder_model.onnx" models/whisper-base/onnx/encoder_model.onnx
+          download "$whisper_base/onnx/decoder_model_merged.onnx" models/whisper-base/onnx/decoder_model_merged.onnx
+          download "$whisper_base/tokenizer.json" models/whisper-base/tokenizer.json
+          download "$whisper_base/generation_config.json" models/whisper-base/generation_config.json
+          download "$whisper_base/config.json" models/whisper-base/config.json
+          download "$whisper_base/preprocessor_config.json" models/whisper-base/preprocessor_config.json
+          for pid in "${download_pids[@]}"; do
+            wait "$pid"
+          done
       - name: Set up virtualenv and install dependencies
         working-directory: ./nobodywho/python
         run: |
@@ -313,6 +329,12 @@ jobs:
           python3 -m pytest --ignore=tests/test_model_downloading.py
           # docs tests
           python3 -m pytest --markdown-docs ../../docs --markdown-docs-syntax=superfences
+      - name: Save test model cache
+        if: success() && steps.test-model-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: models
+          key: ${{ steps.test-model-cache.outputs.cache-primary-key }}
 
   linux-multimodal-tests:
     if: inputs.run_python
@@ -331,11 +353,16 @@ jobs:
         with:
           name: nobodywho_python_linux_manylinux_2_34_x86_64
           path: ./wheels
+      - name: Restore test model cache
+        uses: actions/cache/restore@v5
+        with:
+          path: models
+          key: linux-python-test-models-v1
       - name: Download vision models
         run: |
           mkdir -p models
-          curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/google_gemma-4-E2B-it-Q4_K_M.gguf -o models/google_gemma-4-E2B-it-Q4_K_M.gguf
-          curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/mmproj-google_gemma-4-E2B-it-f16.gguf -o models/mmproj-google_gemma-4-E2B-it-f16.gguf
+          test -f models/google_gemma-4-E2B-it-Q4_K_M.gguf || curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/google_gemma-4-E2B-it-Q4_K_M.gguf -o models/google_gemma-4-E2B-it-Q4_K_M.gguf
+          test -f models/mmproj-google_gemma-4-E2B-it-f16.gguf || curl -L --fail --progress-bar https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/main/mmproj-google_gemma-4-E2B-it-f16.gguf -o models/mmproj-google_gemma-4-E2B-it-f16.gguf
       - name: Set up virtualenv and install dependencies
         working-directory: ./nobodywho/python
         run: |

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,19 +1,14 @@
 name: "Swift CI"
 
-on:
-  workflow_call:
-    inputs:
-      full_ci:
-        description: "Run full Swift CI (integration tests with model)."
-        type: boolean
-        default: false
+# Gated by build-and-test.yml on needs.plan.outputs.run_swift — the workflow
+# itself has no input; it only runs when the plan job says swift is in scope.
+on: workflow_call
 
 permissions:
   contents: read
 
 jobs:
   tests:
-    if: inputs.full_ci
     runs-on: warp-macos-15-arm64-6x
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,12 @@ name: "Test"
 on:
   workflow_call:
     inputs:
-      full_ci:
-        description: "Run full test suite. If false, only lightweight checks run."
+      run_rust_core:
+        description: "Run the canonical core test suite (nix flake check)."
         type: boolean
         default: false
-      run_nix:
-        description: "Run nix flake check."
+      run_flutter:
+        description: "Run Flutter doctest/multimodal/STT tests."
         type: boolean
         default: false
     secrets:
@@ -49,7 +49,7 @@ jobs:
   # cachix actions as per these docs:
   # https://nix.dev/guides/recipes/continuous-integration-github-actions
   nix-flake-check:
-    if: inputs.run_nix
+    if: inputs.run_rust_core
     runs-on: warp-ubuntu-latest-x64-4x
     timeout-minutes: 360
     steps:
@@ -80,7 +80,7 @@ jobs:
 
 
   flutter-multimodal-tests:
-    if: inputs.full_ci
+    if: inputs.run_flutter
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v5
@@ -121,7 +121,7 @@ jobs:
 
 
   flutter-stt-tests:
-    if: inputs.full_ci
+    if: inputs.run_flutter
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Our CI has long been way to thorough for must pushes/commits.
However we also want to keep the coverage across integrations, systems and so on.
To fix the first problem while keeping this condition mind, we introduce path gated jobs. The flow in simple terms is:
plan.yml: Detects which files have been changed and creates a set of booleans based on this.
->
main.yml: Uses the bools from plan.yml to decide which jobs to run and distributes the bools to the jobs that need to make further distinctions.
-> 
Any jobs that need to run are run

Once this PR has been approved I suggest we consider using a merge queue, so we each PR runs full-ci before merging. This will also require adding branch protection using required checks. This will depend on the job "required".