### PR TITLE
feat: use physical core count instead of logical when spawning threads

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,4 +30,7 @@ jobs:
 
       - name: "Run clippy check"
         working-directory: "./nobodywho/core"
-        run: cargo clippy --no-deps -- -D warnings
+        # --all-targets so the test module is compiled too. Without it, platform-gated code
+        # reachable only from tests is never type-checked on any platform in a normal PR
+        # (lib tests themselves only run under `nix flake check`, which is opt-in).
+        run: cargo clippy --no-deps --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ### Added
 
+- Chat now accepts a CPU thread count (`n_threads` / `threadCount` / `thread_count`), for leaving CPU headroom for other work. Defaults to the detected physical core count. Available for all bindings.
 - Pocket TTS speech synthesis, including Hugging Face authentication for gated model files. Available for all bindings.
 - Automatic model selection: pass `"auto"` as a model path to select a recommended model based on available memory. Available for all bindings
 - MTP support for attention models with separate MTP files. This is mainly Gemma 4. Available for all bindings.
 
 ### Changed
 
+- Inference now defaults to one thread per physical core (performance cores only, on Apple silicon) instead of one per logical CPU. Hyperthread siblings and efficiency cores pace the whole thread pool, so the old default was measurably slower — up to 2x on CPU-only generation. Affects all bindings.
 - **React Native:** `STT` now takes a named options object. Replace `new STT(source, language, quantization)` with `new STT({ source, language, quantization })`.
 
 ### Fixed

--- a/docs/docs-flutter/chat.md
+++ b/docs/docs-flutter/chat.md
@@ -123,6 +123,26 @@ final stats = await chat.getStats();
 print("Using ${stats.contextUsed} of ${stats.contextSize} tokens");
 ```
 
+## CPU threads
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Hyperthread siblings and efficiency cores end up pacing the whole
+thread pool, so using every CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads)
+for the numbers.
+
+Override it with `threadCount` when you want to leave CPU headroom for the rest of your app —
+often a good idea on phones, where the big cores are also driving the UI:
+
+```dart
+final chat = await nobodywho.Chat.fromPath(
+  modelPath: "./model.gguf",
+  threadCount: 4
+);
+```
+
+Leave it unset to keep the detected default. Values above the device's CPU count are clamped,
+and it has little effect when the model is offloaded to the GPU.
+
 ## Sharing model between contexts
 
 There are scenarios where you would like to keep separate chat contexts (e.g. for every user of your app), but have only one model loaded. In this case you must load the model 

--- a/docs/docs-godot/chat.md
+++ b/docs/docs-godot/chat.md
@@ -173,6 +173,30 @@ You can control how the model picks tokens and constrain its output format. See 
 
 ## Performance and Memory Tips
 
+### Leave CPU Headroom with `thread_count`
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Hyperthread siblings and efficiency cores end up pacing the whole
+thread pool, so using every CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads)
+for the numbers.
+
+In a game you often want *fewer* threads than that, so inference doesn't compete with rendering
+and physics:
+
+```gdscript
+func _ready():
+    self.model_node = get_node("../SharedModel")
+    # Leave cores free for the rest of the game.
+    self.thread_count = 4
+    start_worker()
+```
+
+Leave `thread_count` at `0` to keep the detected default. Values above your CPU count are
+clamped, and the setting has little effect when the model is offloaded to the GPU.
+
+**Why:** the LLM worker runs on its own threads, but it still competes with your game for
+physical cores. Capping it trades some tokens per second for a steadier frame rate.
+
 ### Start the Worker Early
 
 In a real-time application, you don't want the user's first interaction to trigger a long loading time. Starting the worker early, like during a splash screen or initial setup, pre-loads the model into memory so the first response is fast.

--- a/docs/docs-kotlin/chat.md
+++ b/docs/docs-kotlin/chat.md
@@ -115,6 +115,25 @@ val stats = chat.getStats()
 println("Using ${stats.contextUsed} of ${stats.contextSize} tokens")
 ```
 
+## CPU threads
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Efficiency cores end up pacing the whole thread pool, so using every
+CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads) for the numbers.
+
+Override it with `threadCount` when you want to leave CPU headroom for the rest of your app —
+often a good idea on phones, where the big cores are also driving the UI:
+
+```kotlin
+val chat = Chat.fromPath(
+    modelPath = "./model.gguf",
+    threadCount = 4u
+)
+```
+
+Leave it unset — or pass `null` — to keep the detected default. Values above the device's CPU
+count are clamped, and it has little effect when the model is offloaded to the GPU.
+
 ## GPU
 
 When loading a model, GPU acceleration is enabled by default:

--- a/docs/docs-python/chat.md
+++ b/docs/docs-python/chat.md
@@ -102,6 +102,23 @@ stats = chat.stats()
 print(f"Using {stats.context_used} of {stats.context_size} tokens")
 ```
 
+## CPU threads
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Hyperthread siblings and efficiency cores end up pacing the whole
+thread pool, so using every CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads)
+for the numbers.
+
+Override it with `n_threads` when you want to leave CPU headroom for other work, or when
+NobodyWho could not read your machine's topology (it logs a warning if so):
+
+```python
+chat = Chat("./model.gguf", n_threads=4)
+```
+
+Leave it unset — or pass `None` — to keep the detected default. Values above your CPU count are
+clamped, and it has little effect when the model is offloaded to the GPU.
+
 ## Sharing model between contexts
 
 There are scenarios where you would like to keep separate chat contexts (e.g. for every user of your app), but have only one model loaded. With plain `Chat` this is not possible.

--- a/docs/docs-react-native/chat.md
+++ b/docs/docs-react-native/chat.md
@@ -126,6 +126,25 @@ const stats = await chat.getStats();
 console.log(`Using ${stats.contextUsed} of ${stats.contextSize} tokens`);
 ```
 
+## CPU threads
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Efficiency cores end up pacing the whole thread pool, so using every
+CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads) for the numbers.
+
+Override it with `threadCount` when you want to leave CPU headroom for the rest of your app —
+often a good idea on phones, where the big cores are also driving the UI:
+
+```typescript
+const chat = await Chat.fromPath({
+  modelPath: "/path/to/model.gguf",
+  threadCount: 4,
+});
+```
+
+Omit it to keep the detected default. Values above the device's CPU count are clamped, and it
+has little effect when the model is offloaded to the GPU.
+
 ## Sharing model between contexts
 
 There are scenarios where you would like to keep separate chat contexts (e.g. for every user of your app), but have only one model loaded. In this case you must load the model separately from creating the `Chat` instance.

--- a/docs/docs-swift/chat.md
+++ b/docs/docs-swift/chat.md
@@ -166,6 +166,24 @@ let stats = try await chat.getStats()
 print("Using \(stats.contextUsed) of \(stats.contextSize) tokens")
 ```
 
+## CPU threads
+
+When layers run on the CPU, NobodyWho picks a thread count for you: one per *performance* core,
+not one per logical CPU. Efficiency cores end up pacing the whole thread pool, so using every
+CPU is usually slower — see [LLM Basics](/docs/llm-basics#cpu-threads) for the numbers.
+
+Override it with `threadCount` when you want to leave CPU headroom for the rest of your app:
+
+```swift
+let chat = try await Chat.fromPath(
+    modelPath: "/path/to/model.gguf",
+    threadCount: 4
+)
+```
+
+Leave it unset — or pass `nil` — to keep the detected default. Values above the device's CPU
+count are clamped, and it has little effect when the model is offloaded to the GPU.
+
 ## Sharing model between contexts
 
 There are scenarios where you would like to keep separate chat contexts (e.g. for every user of your app), but have only one model loaded. In this case you must load the model separately from creating the `Chat` instance.

--- a/docs/docs/llm-basics.md
+++ b/docs/docs/llm-basics.md
@@ -33,6 +33,35 @@ Once you reach the context limit, you must either:
 Currently NobodyWho resolves this issue automatically by removing old messages from the context.
 Having a larger context allows for longer and more complex conversations, but it also slows down the response time, as the model has to process more tokens each time it generates a response.
 
+## CPU threads
+
+When layers run on the CPU, inference is split across a pool of threads. Every operation in
+the model ends at a barrier where all threads wait for the slowest one, so the pool is only as
+fast as its weakest member. That makes "more threads" the wrong instinct:
+
+- **Hyperthreads (SMT) don't add compute.** Two threads on one physical core contend for the
+  same vector units, so pairing them up mostly adds synchronisation overhead.
+- **Efficiency cores are genuinely slower hardware.** On a big.LITTLE CPU — Apple silicon, most
+  phones, newer Intel — an E-core in the pool holds every P-core at the barrier until it
+  catches up.
+
+So NobodyWho defaults to one thread per *performance* core rather than per logical CPU, the
+same choice llama.cpp's own tools make. On a 12-core Mac with 8 P-cores and 4 E-cores, that
+means 8 threads — and measured on that machine it is roughly twice as fast at generation as
+using all 12:
+
+| threads | prompt processing | generation |
+|---|---|---|
+| 8 (performance cores only) | 435 tok/s | 90 tok/s |
+| 12 (every logical CPU) | 327 tok/s | 48 tok/s |
+
+You normally shouldn't need to touch this. Two cases where you might: lowering it to leave CPU
+headroom for other work (rendering a game, serving several models from one box), or raising it
+if NobodyWho could not read your machine's topology and guessed low — it logs a warning when
+that happens. Every binding exposes the option on its chat type; see your binding's chat docs.
+Values above your CPU count are clamped, and offloading to the GPU makes the setting largely
+irrelevant.
+
 ## Samplers
 
 LLMs don't output text directly. Instead, they generate a probability distribution over all possible next tokens. Since the model weights are static after training, this means that the same input tokens always generate the same distribution. Depending on the use case however, there are many possible ways of choosing a next token from this distribution. This is configured using a **sampler**. A **sampler** splits the process of choosing a next token into two parts: Shifting the distribution and Sampling the distribution.

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ fmt:
     git diff --exit-code -- '*.rs' || (echo "cargo fmt made changes — commit them before pushing" && exit 1)
 
 clippy:
-    cd nobodywho/core && cargo clippy --no-deps -- -D warnings
+    cd nobodywho/core && cargo clippy --no-deps --all-targets -- -D warnings
 
 regen-python:
     cd nobodywho/python && maturin develop --uv && cargo run --bin make_stubs && uv run ruff format nobodywho.pyi && uv run ty check

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -240,6 +240,11 @@ pub struct ChatConfig {
     /// (see `llm::get_model`) — otherwise worker construction fails with
     /// `InitWorkerError::MtpDraftModelNotLoaded`.
     pub mtp: Option<MtpConfig>,
+    /// Threads used for inference. `None` (the default) detects the host's physical core
+    /// count — performance cores only, on Apple silicon — because hyperthread siblings and
+    /// efficiency cores slow down ggml's per-node thread barrier. Set it lower to leave CPU
+    /// headroom for other work. Values are clamped to the logical CPU count.
+    pub n_threads: Option<u32>,
 }
 
 impl Default for ChatConfig {
@@ -251,6 +256,7 @@ impl Default for ChatConfig {
             tools: Vec::new(),
             sampler_config: None,
             mtp: None,
+            n_threads: None,
         }
     }
 }
@@ -356,6 +362,17 @@ impl ChatBuilder {
     /// Enable MTP speculative decoding for this chat with the given tuning.
     pub fn with_mtp(mut self, config: MtpConfig) -> Self {
         self.config.mtp = Some(config);
+        self
+    }
+
+    /// Set the number of threads used for inference.
+    ///
+    /// Leave this unset to detect the host's physical core count (performance cores only, on
+    /// Apple silicon), which is usually fastest — hyperthread siblings and efficiency cores
+    /// slow down ggml's per-node thread barrier. Set it lower to leave CPU headroom for other
+    /// work. The value is clamped to the logical CPU count.
+    pub fn with_n_threads(mut self, n_threads: u32) -> Self {
+        self.config.n_threads = Some(n_threads);
         self
     }
 
@@ -1428,7 +1445,7 @@ impl<'a> Chat<'a> {
         // Build the low-level inference engine via the shared Worker constructor,
         // then take ownership of just the engine for the chat session.
         let Worker { engine, extra: () } =
-            Worker::new_with_type(model, config.n_ctx, false, config.mtp, ())?;
+            Worker::new_with_type(model, config.n_ctx, false, config.mtp, config.n_threads, ())?;
 
         Ok(Chat {
             engine,

--- a/nobodywho/core/src/cpu.rs
+++ b/nobodywho/core/src/cpu.rs
@@ -1,28 +1,17 @@
-//! CPU topology detection for choosing llama.cpp thread counts.
-//!
-//! `std::thread::available_parallelism()` counts *logical* CPUs: SMT siblings on x86 and
-//! efficiency cores on Apple silicon. ggml synchronizes every graph node on a spin
-//! barrier, so the slowest thread paces the whole operation — running one thread per
-//! logical CPU makes two threads fight over a single core's vector units, or parks work
-//! on an E-core that everyone else then waits for.
-//!
-//! llama.cpp's own tooling avoids this by defaulting to physical cores
-//! (`common_cpu_get_num_physical_cores()` in `common/common.cpp`), but that helper is not
-//! reachable from Rust: `llama-cpp-sys-2`'s bindgen allowlist only covers `ggml_*`,
-//! `gguf_*`, `llama_*` and `mtmd_*`, so `common_*` symbols are never bound. This module
-//! is a port of that function — same platform order, same fallbacks — so our default
-//! matches what `llama-cli` would pick on the same host.
-
+/// mirrors https://github.com/ggml-org/llama.cpp/blob/11b068d06605288ce7917534b46d52b47823dc13/common/common.cpp#L78
+///
+/// Deviations from upstream: no AIX branch (`powerpc64-ibm-aix` is Rust tier 3), and the tail
+/// fallback reads `available_parallelism()` rather than `hardware_concurrency()` so cgroup CPU
+/// limits are respected. Per-branch notes are inline below.
 use tracing::{info, warn};
 
 /// Fallback thread count, mirroring ggml's `GGML_DEFAULT_N_THREADS`.
 const GGML_DEFAULT_N_THREADS: u32 = 4;
 
-/// Number of threads to use for llama.cpp inference.
+/// Thread count for llama.cpp inference.
 ///
-/// Pass `Some(n)` to request a specific count, or `None` to detect one — which prefers
-/// physical cores (performance cores on Apple silicon). Either way the result is clamped
-/// into `1..=logical`, so this never returns 0 and never oversubscribes the host.
+/// `None` autodetects (physical cores, P-cores on Apple); `Some(n)` requests a count. Both
+/// are clamped to 1 <= n <= logical.
 pub fn inference_thread_count(requested: Option<u32>) -> u32 {
     let logical = logical_core_count();
     let physical = physical_core_count();
@@ -50,19 +39,10 @@ pub fn inference_thread_count(requested: Option<u32>) -> u32 {
     n_threads
 }
 
-/// Pick a thread count: an explicit request wins, otherwise the detected topology, otherwise
-/// llama.cpp's last-ditch heuristic. Always clamped into `1..=logical`.
+/// Thread count by precedence: explicit request, else detected physical cores, else
+/// heuristic. Clamped to `1..=logical`.
 ///
-/// That heuristic — keep every CPU on hosts with 4 or fewer, otherwise halve — is
-/// upstream's verbatim (`n_threads <= 4 ? n_threads : n_threads / 2`, the tail of
-/// `common_cpu_get_num_physical_cores()`), and it assumes the host is x86 with SMT, so
-/// halving lands on one thread per physical core. It is *wrong* on a non-SMT host whose
-/// topology we failed to read — an ARM server or a mobile device with restricted sysfs —
-/// where it under-provisions by 2x. We keep it anyway because the platforms that reach this
-/// branch at all (BSD and other unhandled OSes, plus Windows when
-/// `GetLogicalProcessorInformationEx` fails) skew x86-with-SMT, and because diverging from
-/// upstream here would be trading a measured default for a guess. Detection failure is
-/// logged at `warn` so it can be recognised in the field.
+/// The heuristic — keep all on ≤4 logical CPUs, else halve.
 fn resolve(requested: Option<u32>, physical: Option<u32>, logical: u32) -> u32 {
     let logical = logical.max(1);
     let chosen = requested
@@ -71,16 +51,14 @@ fn resolve(requested: Option<u32>, physical: Option<u32>, logical: u32) -> u32 {
     chosen.clamp(1, logical)
 }
 
-/// Number of logical CPUs, falling back to `GGML_DEFAULT_N_THREADS`.
 fn logical_core_count() -> u32 {
     std::thread::available_parallelism()
         .map(|count| count.get() as u32)
         .unwrap_or(GGML_DEFAULT_N_THREADS)
 }
 
-/// Count distinct sibling groups. Each entry is the raw contents of one CPU's
-/// `thread_siblings` file, so SMT siblings share an identical string and collapse into a
-/// single group.
+/// Distinct sibling-mask count. SMT siblings share an identical `thread_siblings` string,
+/// so they collapse into one group.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn count_sibling_groups(siblings: &[String]) -> Option<u32> {
     let unique: std::collections::HashSet<&str> =
@@ -90,22 +68,20 @@ fn count_sibling_groups(siblings: &[String]) -> Option<u32> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn physical_core_count() -> Option<u32> {
-    // Enumerate /sys/devices/system/cpu/cpuN/topology/thread_siblings until a CPU is
-    // missing; the number of distinct sibling masks is the number of physical cores.
-    // `thread_siblings` is a hex mask and `thread_siblings_list` the human-readable form —
-    // either works for equality comparison, so accept whichever is present.
+    // Count physical cores: enumerate cpuN/topology/thread_siblings until a CPU is missing;
+    // distinct masks = physical cores. Only the hex mask is read, as upstream does — falling
+    // back to `thread_siblings_list` would compare a list against a mask and count one core
+    // twice if the two forms ever mixed.
     let mut siblings = Vec::new();
     for cpu in 0.. {
         let directory = format!("/sys/devices/system/cpu/cpu{cpu}/topology");
         if !std::path::Path::new(&directory).exists() {
             break;
         }
-        let entry = std::fs::read_to_string(format!("{directory}/thread_siblings"))
-            .or_else(|_| std::fs::read_to_string(format!("{directory}/thread_siblings_list")));
-        match entry {
+        match std::fs::read_to_string(format!("{directory}/thread_siblings")) {
             Ok(mask) => siblings.push(mask),
-            // A CPU can be offline (topology files unreadable) while later ones are
-            // online, so keep scanning rather than bailing out.
+            // Upstream stops here. We keep scanning: a mid-range CPU can be offline while
+            // later ones aren't, and the directory check above is already our terminator.
             Err(error) => tracing::debug!(cpu, %error, "Could not read CPU sibling mask"),
         }
     }
@@ -132,20 +108,68 @@ fn physical_core_count() -> Option<u32> {
         Some(value as u32)
     }
 
-    // `hw.perflevel0.physicalcpu` is the performance-core count on Apple silicon; it does
-    // not exist on Intel Macs, where `hw.physicalcpu` already excludes SMT siblings.
+    // `hw.perflevel0.physicalcpu` is P-cores on Apple silicon; absent on Intel Macs, where
+    // `hw.physicalcpu` collapses SMT.
     sysctl_i32(c"hw.perflevel0.physicalcpu").or_else(|| sysctl_i32(c"hw.physicalcpu"))
+}
+
+/// `RelationProcessorCore` from `LOGICAL_PROCESSOR_RELATIONSHIP`. Duplicated as a literal so
+/// [`count_core_records`] can be tested on non-Windows hosts; the Windows path asserts it
+/// against `windows_sys`'s own constant.
+#[cfg(any(target_os = "windows", test))]
+const RELATION_PROCESSOR_CORE: i32 = 0;
+
+/// Count `RelationProcessorCore` records in a `GetLogicalProcessorInformationEx` buffer.
+///
+/// Records are variable-length and each carries its own `Size`, which for a core record is
+/// *smaller* than `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX` (48 vs 80 bytes on x64, because
+/// the struct's union is sized for `GROUP_RELATIONSHIP`). So the struct's size cannot gate the
+/// walk — doing so drops the final record — and a reference to it cannot be formed over a
+/// 48-byte record without reading past it. Only the two fixed leading fields are needed.
+///
+/// Split out from the FFI so it is testable off-Windows, which is the only platform branch
+/// here with real parsing logic.
+#[cfg(any(target_os = "windows", test))]
+fn count_core_records(buffer: &[u8]) -> u32 {
+    /// `Relationship: i32` followed by `Size: u32`.
+    const HEADER: usize = 2 * std::mem::size_of::<u32>();
+
+    let mut cores = 0u32;
+    let mut offset = 0usize;
+    while offset + HEADER <= buffer.len() {
+        // Read unaligned: `buffer` is bytes, so a record need not sit on a 4-byte boundary.
+        let base = unsafe { buffer.as_ptr().add(offset) };
+        let relationship = unsafe { base.cast::<i32>().read_unaligned() };
+        let record_size = unsafe {
+            base.add(std::mem::size_of::<i32>())
+                .cast::<u32>()
+                .read_unaligned()
+        } as usize;
+
+        // A zero or short `Size` would loop forever; a `Size` past the end means a truncated
+        // record we cannot trust.
+        if record_size < HEADER || offset + record_size > buffer.len() {
+            break;
+        }
+        // Upstream adds `info->Processor.GroupCount`, which is always 1 on a core record.
+        if relationship == RELATION_PROCESSOR_CORE {
+            cores += 1;
+        }
+        offset += record_size;
+    }
+    cores
 }
 
 #[cfg(target_os = "windows")]
 fn physical_core_count() -> Option<u32> {
     use windows_sys::Win32::System::SystemInformation::{
         GetLogicalProcessorInformationEx, RelationProcessorCore,
-        SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
     };
 
-    // First call with a null buffer to learn the required size, then walk the returned
-    // blob: the records are variable-length, each carrying its own `Size`.
+    debug_assert_eq!(RELATION_PROCESSOR_CORE, RelationProcessorCore);
+
+    // Null buffer to learn the size, then walk the variable-length records (each carries
+    // its own `Size`).
     let mut size = 0u32;
     if unsafe {
         GetLogicalProcessorInformationEx(RelationProcessorCore, std::ptr::null_mut(), &raw mut size)
@@ -167,23 +191,8 @@ fn physical_core_count() -> Option<u32> {
         return None;
     }
 
-    let mut cores = 0u32;
-    let mut offset = 0usize;
-    while offset + std::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>() <= size as usize {
-        let record = unsafe {
-            &*buffer
-                .as_ptr()
-                .add(offset)
-                .cast::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>()
-        };
-        if record.Size == 0 {
-            break;
-        }
-        if record.Relationship == RelationProcessorCore {
-            cores += 1;
-        }
-        offset += record.Size as usize;
-    }
+    // The second call can shrink `size`; trust it over the buffer length.
+    let cores = count_core_records(&buffer[..(size as usize).min(buffer.len())]);
 
     (cores > 0).then_some(cores)
 }
@@ -232,8 +241,7 @@ mod tests {
     #[test]
     fn a_request_overrides_the_detected_topology() {
         assert_eq!(resolve(Some(3), Some(8), 16), 3);
-        // Fewer threads than physical cores is a legitimate ask: leave headroom for
-        // rendering, or share the box with other models.
+        // Fewer than physical is legitimate: headroom for rendering or co-tenant models.
         assert_eq!(resolve(Some(1), Some(8), 16), 1);
     }
 
@@ -254,6 +262,64 @@ mod tests {
         let siblings = ["0,8", "1,9", "2,10", "8,0"].map(String::from);
         assert_eq!(count_sibling_groups(&siblings), Some(3));
         assert_eq!(count_sibling_groups(&[]), None);
+    }
+
+    /// One `GetLogicalProcessorInformationEx` record: `Relationship`, `Size`, then padding out
+    /// to `size` bytes. A real core record is 48 bytes on x64, well under the 80-byte
+    /// `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX`.
+    fn record(relationship: i32, size: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(size);
+        bytes.extend_from_slice(&relationship.to_ne_bytes());
+        bytes.extend_from_slice(&(size as u32).to_ne_bytes());
+        bytes.resize(size, 0);
+        bytes
+    }
+
+    #[test]
+    fn counts_every_core_record_including_the_last() {
+        // The bug this guards: gating the walk on `size_of::<SYSTEM_LOGICAL_PROCESSOR_..._EX>()`
+        // (80) instead of the 8-byte header drops the final 48-byte record, so an 8-core host
+        // reports 7.
+        for cores in 1..=32usize {
+            let buffer: Vec<u8> = (0..cores)
+                .flat_map(|_| record(RELATION_PROCESSOR_CORE, 48))
+                .collect();
+            assert_eq!(count_core_records(&buffer), cores as u32, "{cores} cores");
+        }
+    }
+
+    #[test]
+    fn skips_records_that_are_not_processor_cores() {
+        let mut buffer = record(RELATION_PROCESSOR_CORE, 48);
+        buffer.extend(record(1, 64)); // RelationNumaNode, a different length
+        buffer.extend(record(RELATION_PROCESSOR_CORE, 48));
+        assert_eq!(count_core_records(&buffer), 2);
+    }
+
+    #[test]
+    fn stops_on_a_truncated_or_degenerate_record() {
+        // `Size` running past the buffer: count what was whole, discard the rest.
+        let mut truncated = record(RELATION_PROCESSOR_CORE, 48);
+        truncated.extend(record(RELATION_PROCESSOR_CORE, 48).into_iter().take(20));
+        assert_eq!(count_core_records(&truncated), 1);
+
+        // `Size` of 0 must terminate rather than spin forever.
+        let mut zero_size = record(RELATION_PROCESSOR_CORE, 48);
+        zero_size.extend(record(RELATION_PROCESSOR_CORE, 0));
+        zero_size.resize(zero_size.len() + 48, 0);
+        assert_eq!(count_core_records(&zero_size), 1);
+
+        assert_eq!(count_core_records(&[]), 0);
+        assert_eq!(count_core_records(&[0u8; 4]), 0); // shorter than one header
+    }
+
+    #[test]
+    fn walks_records_at_unaligned_offsets() {
+        // Record lengths are only guaranteed 4-byte multiples, so a later record can land off
+        // an 8-byte boundary; the reads must not assume alignment.
+        let mut buffer = record(RELATION_PROCESSOR_CORE, 12);
+        buffer.extend(record(RELATION_PROCESSOR_CORE, 48));
+        assert_eq!(count_core_records(&buffer), 2);
     }
 
     #[test]

--- a/nobodywho/core/src/cpu.rs
+++ b/nobodywho/core/src/cpu.rs
@@ -1,0 +1,276 @@
+//! CPU topology detection for choosing llama.cpp thread counts.
+//!
+//! `std::thread::available_parallelism()` counts *logical* CPUs: SMT siblings on x86 and
+//! efficiency cores on Apple silicon. ggml synchronizes every graph node on a spin
+//! barrier, so the slowest thread paces the whole operation — running one thread per
+//! logical CPU makes two threads fight over a single core's vector units, or parks work
+//! on an E-core that everyone else then waits for.
+//!
+//! llama.cpp's own tooling avoids this by defaulting to physical cores
+//! (`common_cpu_get_num_physical_cores()` in `common/common.cpp`), but that helper is not
+//! reachable from Rust: `llama-cpp-sys-2`'s bindgen allowlist only covers `ggml_*`,
+//! `gguf_*`, `llama_*` and `mtmd_*`, so `common_*` symbols are never bound. This module
+//! is a port of that function — same platform order, same fallbacks — so our default
+//! matches what `llama-cli` would pick on the same host.
+
+use tracing::{info, warn};
+
+/// Environment variable that overrides the detected thread count.
+const N_THREADS_ENV: &str = "NOBODYWHO_N_THREADS";
+
+/// Number of threads to use for llama.cpp inference.
+///
+/// Prefers physical cores (performance cores on Apple silicon). Set
+/// `NOBODYWHO_N_THREADS` to override. Never returns 0, and never exceeds the logical CPU
+/// count.
+pub fn inference_thread_count() -> u32 {
+    let explicit = std::env::var(N_THREADS_ENV)
+        .ok()
+        .and_then(|value| parse_count(&value));
+    let logical = logical_core_count();
+    let physical = physical_core_count();
+    let n_threads = resolve(explicit, physical, logical);
+
+    if physical.is_none() && explicit.is_none() {
+        warn!(
+            logical,
+            n_threads,
+            "Could not read CPU topology; guessing the physical core count. Set \
+             NOBODYWHO_N_THREADS if inference is slower than expected."
+        );
+    }
+    info!(
+        n_threads,
+        explicit, physical, logical, "Selected inference thread count"
+    );
+    n_threads
+}
+
+/// Pick a thread count from the detected topology.
+///
+/// Precedence: explicit override, then physical cores, then llama.cpp's last-ditch
+/// heuristic. Always clamped into `1..=logical`.
+///
+/// That heuristic — keep every CPU on hosts with 4 or fewer, otherwise halve — is
+/// upstream's verbatim (`n_threads <= 4 ? n_threads : n_threads / 2`, the tail of
+/// `common_cpu_get_num_physical_cores()`), and it assumes the host is x86 with SMT, so
+/// halving lands on one thread per physical core. It is *wrong* on a non-SMT host whose
+/// topology we failed to read — an ARM server or a mobile device with restricted sysfs —
+/// where it under-provisions by 2x. We keep it anyway because the platforms that reach
+/// this branch at all (BSD and other unhandled OSes, plus Windows when
+/// `GetLogicalProcessorInformationEx` fails) skew x86-with-SMT, and because diverging from
+/// upstream here would be trading a measured default for a guess. Detection failure is
+/// logged at `warn` so it can be recognised in the field, and `NOBODYWHO_N_THREADS`
+/// overrides it.
+fn resolve(explicit: Option<u32>, physical: Option<u32>, logical: u32) -> u32 {
+    let logical = logical.max(1);
+    let chosen = explicit.or(physical).unwrap_or(if logical <= 4 {
+        logical
+    } else {
+        logical / 2
+    });
+    chosen.clamp(1, logical)
+}
+
+/// Parse a thread count from an environment variable. Rejects zero and garbage.
+fn parse_count(value: &str) -> Option<u32> {
+    match value.trim().parse::<u32>() {
+        Ok(0) | Err(_) => None,
+        Ok(count) => Some(count),
+    }
+}
+
+/// Number of logical CPUs, falling back to `GGML_DEFAULT_N_THREADS`.
+fn logical_core_count() -> u32 {
+    std::thread::available_parallelism()
+        .map(|count| count.get() as u32)
+        .unwrap_or(4)
+}
+
+/// Count distinct sibling groups. Each entry is the raw contents of one CPU's
+/// `thread_siblings` file, so SMT siblings share an identical string and collapse into a
+/// single group.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn count_sibling_groups(siblings: &[String]) -> Option<u32> {
+    let unique: std::collections::HashSet<&str> =
+        siblings.iter().map(|entry| entry.trim()).collect();
+    (!unique.is_empty()).then(|| unique.len() as u32)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn physical_core_count() -> Option<u32> {
+    // Enumerate /sys/devices/system/cpu/cpuN/topology/thread_siblings until a CPU is
+    // missing; the number of distinct sibling masks is the number of physical cores.
+    // `thread_siblings` is a hex mask and `thread_siblings_list` the human-readable form —
+    // either works for equality comparison, so accept whichever is present.
+    let mut siblings = Vec::new();
+    for cpu in 0.. {
+        let directory = format!("/sys/devices/system/cpu/cpu{cpu}/topology");
+        if !std::path::Path::new(&directory).exists() {
+            break;
+        }
+        let entry = std::fs::read_to_string(format!("{directory}/thread_siblings"))
+            .or_else(|_| std::fs::read_to_string(format!("{directory}/thread_siblings_list")));
+        match entry {
+            Ok(mask) => siblings.push(mask),
+            // A CPU can be offline (topology files unreadable) while later ones are
+            // online, so keep scanning rather than bailing out.
+            Err(error) => tracing::debug!(cpu, %error, "Could not read CPU sibling mask"),
+        }
+    }
+    count_sibling_groups(&siblings)
+}
+
+#[cfg(target_vendor = "apple")]
+fn physical_core_count() -> Option<u32> {
+    fn sysctl_i32(name: &[u8]) -> Option<u32> {
+        let mut value = 0i32;
+        let mut size = std::mem::size_of::<i32>();
+        let result = unsafe {
+            libc::sysctlbyname(
+                name.as_ptr().cast(),
+                (&raw mut value).cast::<std::ffi::c_void>(),
+                &raw mut size,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if result != 0 || value <= 0 {
+            return None;
+        }
+        Some(value as u32)
+    }
+
+    // `hw.perflevel0.physicalcpu` is the performance-core count on Apple silicon; it does
+    // not exist on Intel Macs, where `hw.physicalcpu` already excludes SMT siblings.
+    sysctl_i32(b"hw.perflevel0.physicalcpu\0").or_else(|| sysctl_i32(b"hw.physicalcpu\0"))
+}
+
+#[cfg(target_os = "windows")]
+fn physical_core_count() -> Option<u32> {
+    use windows_sys::Win32::System::SystemInformation::{
+        GetLogicalProcessorInformationEx, RelationProcessorCore,
+        SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+    };
+
+    // First call with a null buffer to learn the required size, then walk the returned
+    // blob: the records are variable-length, each carrying its own `Size`.
+    let mut size = 0u32;
+    if unsafe {
+        GetLogicalProcessorInformationEx(RelationProcessorCore, std::ptr::null_mut(), &raw mut size)
+    } != 0
+        || size == 0
+    {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; size as usize];
+    if unsafe {
+        GetLogicalProcessorInformationEx(
+            RelationProcessorCore,
+            buffer.as_mut_ptr().cast(),
+            &raw mut size,
+        )
+    } == 0
+    {
+        return None;
+    }
+
+    let mut cores = 0u32;
+    let mut offset = 0usize;
+    while offset + std::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>() <= size as usize {
+        let record = unsafe {
+            &*buffer
+                .as_ptr()
+                .add(offset)
+                .cast::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>()
+        };
+        if record.Size == 0 {
+            break;
+        }
+        if record.Relationship == RelationProcessorCore {
+            cores += 1;
+        }
+        offset += record.Size as usize;
+    }
+
+    (cores > 0).then_some(cores)
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple",
+    target_os = "windows"
+)))]
+fn physical_core_count() -> Option<u32> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_override_wins_over_detected_topology() {
+        assert_eq!(resolve(Some(3), Some(8), 16), 3);
+    }
+
+    #[test]
+    fn physical_count_is_preferred_over_logical() {
+        assert_eq!(resolve(None, Some(8), 16), 8);
+    }
+
+    #[test]
+    fn falls_back_to_half_the_logical_count() {
+        assert_eq!(resolve(None, None, 16), 8);
+    }
+
+    #[test]
+    fn small_hosts_keep_every_logical_cpu() {
+        assert_eq!(resolve(None, None, 4), 4);
+        assert_eq!(resolve(None, None, 1), 1);
+    }
+
+    #[test]
+    fn counts_are_clamped_to_the_logical_cpu_count() {
+        assert_eq!(resolve(Some(999), None, 8), 8);
+        // A bogus topology report must not oversubscribe either.
+        assert_eq!(resolve(None, Some(64), 8), 8);
+    }
+
+    #[test]
+    fn never_returns_zero_threads() {
+        assert_eq!(resolve(None, Some(0), 0), 1);
+    }
+
+    #[test]
+    fn parse_count_rejects_zero_and_garbage() {
+        assert_eq!(parse_count("8"), Some(8));
+        assert_eq!(parse_count(" 8 "), Some(8));
+        assert_eq!(parse_count("0"), None);
+        assert_eq!(parse_count("-1"), None);
+        assert_eq!(parse_count("eight"), None);
+        assert_eq!(parse_count(""), None);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn sibling_groups_collapse_smt_pairs() {
+        let siblings = ["0,8", "1,9", "2,10", "8,0"].map(String::from);
+        assert_eq!(count_sibling_groups(&siblings), Some(3));
+        assert_eq!(count_sibling_groups(&[]), None);
+    }
+
+    #[test]
+    fn detects_a_usable_thread_count_on_this_host() {
+        let logical = logical_core_count();
+        let n_threads = inference_thread_count();
+        println!(
+            "logical={logical} physical={:?} n_threads={n_threads}",
+            physical_core_count()
+        );
+        assert!(n_threads >= 1);
+        assert!(n_threads <= logical);
+    }
+}

--- a/nobodywho/core/src/cpu.rs
+++ b/nobodywho/core/src/cpu.rs
@@ -15,76 +15,67 @@
 
 use tracing::{info, warn};
 
-/// Environment variable that overrides the detected thread count.
-const N_THREADS_ENV: &str = "NOBODYWHO_N_THREADS";
+/// Fallback thread count, mirroring ggml's `GGML_DEFAULT_N_THREADS`.
+const GGML_DEFAULT_N_THREADS: u32 = 4;
 
 /// Number of threads to use for llama.cpp inference.
 ///
-/// Prefers physical cores (performance cores on Apple silicon). Set
-/// `NOBODYWHO_N_THREADS` to override. Never returns 0, and never exceeds the logical CPU
-/// count.
-pub fn inference_thread_count() -> u32 {
-    let explicit = std::env::var(N_THREADS_ENV)
-        .ok()
-        .and_then(|value| parse_count(&value));
+/// Pass `Some(n)` to request a specific count, or `None` to detect one — which prefers
+/// physical cores (performance cores on Apple silicon). Either way the result is clamped
+/// into `1..=logical`, so this never returns 0 and never oversubscribes the host.
+pub fn inference_thread_count(requested: Option<u32>) -> u32 {
     let logical = logical_core_count();
     let physical = physical_core_count();
-    let n_threads = resolve(explicit, physical, logical);
+    let n_threads = resolve(requested, physical, logical);
 
-    if physical.is_none() && explicit.is_none() {
-        warn!(
-            logical,
-            n_threads,
-            "Could not read CPU topology; guessing the physical core count. Set \
-             NOBODYWHO_N_THREADS if inference is slower than expected."
-        );
+    match requested {
+        Some(requested) if requested != n_threads => warn!(
+            requested,
+            n_threads, logical, "Requested thread count is out of range; clamped it"
+        ),
+        Some(_) => info!(n_threads, logical, "Using the requested thread count"),
+        None => {
+            if physical.is_none() {
+                warn!(
+                    logical,
+                    n_threads, "Could not read CPU topology; guessing the physical core count"
+                );
+            }
+            info!(
+                n_threads,
+                physical, logical, "Selected inference thread count"
+            );
+        }
     }
-    info!(
-        n_threads,
-        explicit, physical, logical, "Selected inference thread count"
-    );
     n_threads
 }
 
-/// Pick a thread count from the detected topology.
-///
-/// Precedence: explicit override, then physical cores, then llama.cpp's last-ditch
-/// heuristic. Always clamped into `1..=logical`.
+/// Pick a thread count: an explicit request wins, otherwise the detected topology, otherwise
+/// llama.cpp's last-ditch heuristic. Always clamped into `1..=logical`.
 ///
 /// That heuristic — keep every CPU on hosts with 4 or fewer, otherwise halve — is
 /// upstream's verbatim (`n_threads <= 4 ? n_threads : n_threads / 2`, the tail of
 /// `common_cpu_get_num_physical_cores()`), and it assumes the host is x86 with SMT, so
 /// halving lands on one thread per physical core. It is *wrong* on a non-SMT host whose
 /// topology we failed to read — an ARM server or a mobile device with restricted sysfs —
-/// where it under-provisions by 2x. We keep it anyway because the platforms that reach
-/// this branch at all (BSD and other unhandled OSes, plus Windows when
+/// where it under-provisions by 2x. We keep it anyway because the platforms that reach this
+/// branch at all (BSD and other unhandled OSes, plus Windows when
 /// `GetLogicalProcessorInformationEx` fails) skew x86-with-SMT, and because diverging from
 /// upstream here would be trading a measured default for a guess. Detection failure is
-/// logged at `warn` so it can be recognised in the field, and `NOBODYWHO_N_THREADS`
-/// overrides it.
-fn resolve(explicit: Option<u32>, physical: Option<u32>, logical: u32) -> u32 {
+/// logged at `warn` so it can be recognised in the field.
+fn resolve(requested: Option<u32>, physical: Option<u32>, logical: u32) -> u32 {
     let logical = logical.max(1);
-    let chosen = explicit.or(physical).unwrap_or(if logical <= 4 {
-        logical
-    } else {
-        logical / 2
-    });
+    let chosen = requested
+        .or(physical)
+        .unwrap_or(if logical <= 4 { logical } else { logical / 2 });
     chosen.clamp(1, logical)
-}
-
-/// Parse a thread count from an environment variable. Rejects zero and garbage.
-fn parse_count(value: &str) -> Option<u32> {
-    match value.trim().parse::<u32>() {
-        Ok(0) | Err(_) => None,
-        Ok(count) => Some(count),
-    }
 }
 
 /// Number of logical CPUs, falling back to `GGML_DEFAULT_N_THREADS`.
 fn logical_core_count() -> u32 {
     std::thread::available_parallelism()
         .map(|count| count.get() as u32)
-        .unwrap_or(4)
+        .unwrap_or(GGML_DEFAULT_N_THREADS)
 }
 
 /// Count distinct sibling groups. Each entry is the raw contents of one CPU's
@@ -212,11 +203,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn explicit_override_wins_over_detected_topology() {
-        assert_eq!(resolve(Some(3), Some(8), 16), 3);
-    }
-
-    #[test]
     fn physical_count_is_preferred_over_logical() {
         assert_eq!(resolve(None, Some(8), 16), 8);
     }
@@ -234,8 +220,7 @@ mod tests {
 
     #[test]
     fn counts_are_clamped_to_the_logical_cpu_count() {
-        assert_eq!(resolve(Some(999), None, 8), 8);
-        // A bogus topology report must not oversubscribe either.
+        // A bogus topology report must not oversubscribe.
         assert_eq!(resolve(None, Some(64), 8), 8);
     }
 
@@ -245,13 +230,22 @@ mod tests {
     }
 
     #[test]
-    fn parse_count_rejects_zero_and_garbage() {
-        assert_eq!(parse_count("8"), Some(8));
-        assert_eq!(parse_count(" 8 "), Some(8));
-        assert_eq!(parse_count("0"), None);
-        assert_eq!(parse_count("-1"), None);
-        assert_eq!(parse_count("eight"), None);
-        assert_eq!(parse_count(""), None);
+    fn a_request_overrides_the_detected_topology() {
+        assert_eq!(resolve(Some(3), Some(8), 16), 3);
+        // Fewer threads than physical cores is a legitimate ask: leave headroom for
+        // rendering, or share the box with other models.
+        assert_eq!(resolve(Some(1), Some(8), 16), 1);
+    }
+
+    #[test]
+    fn a_request_cannot_oversubscribe_the_host() {
+        assert_eq!(resolve(Some(999), Some(8), 12), 12);
+        assert_eq!(resolve(Some(13), None, 12), 12);
+    }
+
+    #[test]
+    fn a_zero_request_is_treated_as_one_thread() {
+        assert_eq!(resolve(Some(0), Some(8), 12), 1);
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -265,12 +259,18 @@ mod tests {
     #[test]
     fn detects_a_usable_thread_count_on_this_host() {
         let logical = logical_core_count();
-        let n_threads = inference_thread_count();
+        let n_threads = inference_thread_count(None);
         println!(
             "logical={logical} physical={:?} n_threads={n_threads}",
             physical_core_count()
         );
         assert!(n_threads >= 1);
         assert!(n_threads <= logical);
+    }
+
+    #[test]
+    fn honours_a_request_on_this_host() {
+        assert_eq!(inference_thread_count(Some(1)), 1);
+        assert_eq!(inference_thread_count(Some(u32::MAX)), logical_core_count());
     }
 }

--- a/nobodywho/core/src/cpu.rs
+++ b/nobodywho/core/src/cpu.rs
@@ -114,12 +114,12 @@ fn physical_core_count() -> Option<u32> {
 
 #[cfg(target_vendor = "apple")]
 fn physical_core_count() -> Option<u32> {
-    fn sysctl_i32(name: &[u8]) -> Option<u32> {
+    fn sysctl_i32(name: &std::ffi::CStr) -> Option<u32> {
         let mut value = 0i32;
         let mut size = std::mem::size_of::<i32>();
         let result = unsafe {
             libc::sysctlbyname(
-                name.as_ptr().cast(),
+                name.as_ptr(),
                 (&raw mut value).cast::<std::ffi::c_void>(),
                 &raw mut size,
                 std::ptr::null_mut(),
@@ -134,7 +134,7 @@ fn physical_core_count() -> Option<u32> {
 
     // `hw.perflevel0.physicalcpu` is the performance-core count on Apple silicon; it does
     // not exist on Intel Macs, where `hw.physicalcpu` already excludes SMT siblings.
-    sysctl_i32(b"hw.perflevel0.physicalcpu\0").or_else(|| sysctl_i32(b"hw.physicalcpu\0"))
+    sysctl_i32(c"hw.perflevel0.physicalcpu").or_else(|| sysctl_i32(c"hw.physicalcpu"))
 }
 
 #[cfg(target_os = "windows")]

--- a/nobodywho/core/src/cpu.rs
+++ b/nobodywho/core/src/cpu.rs
@@ -59,11 +59,13 @@ fn logical_core_count() -> u32 {
 
 /// Distinct sibling-mask count. SMT siblings share an identical `thread_siblings` string,
 /// so they collapse into one group.
-#[cfg(any(target_os = "linux", target_os = "android"))]
+/// Compiled under `test` on every platform, not just Linux, so the logic is linted and
+/// exercised everywhere — same reason as [`count_core_records`].
+#[cfg(any(target_os = "linux", target_os = "android", test))]
 fn count_sibling_groups(siblings: &[String]) -> Option<u32> {
     let unique: std::collections::HashSet<&str> =
         siblings.iter().map(|entry| entry.trim()).collect();
-    (!unique.is_empty()).then(|| unique.len() as u32)
+    (!unique.is_empty()).then_some(unique.len() as u32)
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -256,11 +258,25 @@ mod tests {
         assert_eq!(resolve(Some(0), Some(8), 12), 1);
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[test]
     fn sibling_groups_collapse_smt_pairs() {
-        let siblings = ["0,8", "1,9", "2,10", "8,0"].map(String::from);
-        assert_eq!(count_sibling_groups(&siblings), Some(3));
+        // `thread_siblings` is a fixed-width hex mask, so every CPU in a group writes the
+        // identical string: 4 SMT pairs over 8 logical CPUs collapse to 4 physical cores.
+        let pairs = [
+            "00000003", "00000003", "0000000c", "0000000c", "00000030", "00000030", "000000c0",
+            "000000c0",
+        ]
+        .map(String::from);
+        assert_eq!(count_sibling_groups(&pairs), Some(4));
+
+        // No SMT (or an E-core): every mask is its own group.
+        let singles = ["00000001", "00000002", "00000004"].map(String::from);
+        assert_eq!(count_sibling_groups(&singles), Some(3));
+
+        // `read_to_string` keeps the trailing newline; it must not split a group in two.
+        let newlines = ["00000003\n", "00000003"].map(String::from);
+        assert_eq!(count_sibling_groups(&newlines), Some(1));
+
         assert_eq!(count_sibling_groups(&[]), None);
     }
 

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -137,7 +137,7 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         model: &llm::Model,
         n_ctx: u32,
     ) -> Result<Worker<'_, CrossEncoderWorker>, InitWorkerError> {
-        Worker::new_with_type(model, n_ctx, true, None, CrossEncoderWorker {})
+        Worker::new_with_type(model, n_ctx, true, None, None, CrossEncoderWorker {})
     }
 
     pub fn get_classification_score(&self) -> Result<f32, CrossEncoderWorkerError> {

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -107,7 +107,7 @@ impl<'a> Worker<'a, EncoderWorker> {
             .and_then(|val| val.parse::<i32>().ok())
             .map(LlamaPoolingType::from)
             .unwrap_or(LlamaPoolingType::Unspecified);
-        Worker::new_with_type(model, n_ctx, true, None, EncoderWorker { pooling })
+        Worker::new_with_type(model, n_ctx, true, None, None, EncoderWorker { pooling })
     }
 
     pub fn get_embedding(&self) -> Result<Vec<f32>, llama_cpp_2::EmbeddingsError> {

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -1,3 +1,10 @@
+// `miette`'s `Diagnostic` derive (we're on miette 5) expands `#[error(..)]` /
+// `#[diagnostic(help(..))]` format arguments into assignments that rustc 1.92+ reports as
+// `unused_assignments`, pointing at the enum's own field declarations. The lint is a
+// macro-expansion artifact — there is nothing to fix at these sites — and it fails
+// `cargo clippy -- -D warnings`. Drop this once miette is upgraded.
+#![allow(unused_assignments)]
+
 use llama_cpp_2::{context::kv_cache::KvCacheConversionError, TokenToStringError};
 use std::path::PathBuf;
 

--- a/nobodywho/core/src/host_memory.rs
+++ b/nobodywho/core/src/host_memory.rs
@@ -228,7 +228,7 @@ fn platform_memory() -> Result<HostMemory, MemoryDetectionError> {
         let mut total_size = std::mem::size_of::<u64>();
         let result = unsafe {
             libc::sysctlbyname(
-                b"hw.memsize\0".as_ptr().cast(),
+                c"hw.memsize".as_ptr(),
                 (&raw mut total_bytes).cast::<c_void>(),
                 &raw mut total_size,
                 std::ptr::null_mut(),

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod chat;
+pub mod cpu;
 pub mod crossencoder;
 pub mod encoder;
 pub mod errors;

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -316,14 +316,17 @@ where
         n_ctx: u32,
         use_embeddings: bool,
         mtp: Option<crate::chat::MtpConfig>,
+        n_threads: Option<u32>,
         extra: T,
     ) -> Result<Worker<'a, T>, InitWorkerError> {
         info!("Initializing worker");
 
         let projection_model = model.projection_model.as_ref();
 
-        // Set up context parameters using available parallelism
-        let n_threads = std::thread::available_parallelism()?.get() as i32;
+        // Set up context parameters. Without an explicit request this uses physical cores
+        // rather than logical ones: hyperthread siblings and efficiency cores slow down
+        // ggml's per-node barrier.
+        let n_threads = crate::cpu::inference_thread_count(n_threads) as i32;
         let ctx_plan = memory::plan_context(
             std::cmp::min(n_ctx, model.language_model.n_ctx_train()),
             projection_model.is_some(),

--- a/nobodywho/core/src/tokenizer.rs
+++ b/nobodywho/core/src/tokenizer.rs
@@ -377,9 +377,9 @@ impl ProjectionModel {
         parent_model: &LlamaModel,
         use_gpu: bool,
     ) -> Result<Self, MultimodalError> {
-        let n_threads = std::thread::available_parallelism()
-            .map(|p| p.get() as i32)
-            .unwrap_or(4);
+        // The projection model is built during model load, before any chat exists, so it
+        // always uses the detected count rather than a per-chat request.
+        let n_threads = crate::cpu::inference_thread_count(None) as i32;
 
         let media_marker = llama_cpp_2::mtmd::mtmd_default_marker().to_string();
 

--- a/nobodywho/flutter/nobodywho/lib/nobodywho.dart
+++ b/nobodywho/flutter/nobodywho/lib/nobodywho.dart
@@ -577,6 +577,10 @@ class Chat {
   /// final model = Model.load("model.gguf", projectionModelPath: "mmproj.gguf");
   /// final chat = Chat(model: model);
   /// ```
+  /// [threadCount] is the number of CPU threads used for inference. Leave it null to
+  /// detect the device's physical core count (performance cores only, on Apple silicon) —
+  /// hyperthreads and efficiency cores make inference slower, not faster. Lower it to leave
+  /// CPU headroom for the rest of the app.
   factory Chat({
     required nobodywho.Model model,
     String? systemPrompt,
@@ -586,6 +590,7 @@ class Chat {
     List<Tool> tools = const [],
     nobodywho.SamplerConfig? sampler,
     nobodywho.MtpConfig? mtp,
+    int? threadCount,
   }) {
     final chat = nobodywho.RustChat(
       model: model,
@@ -596,6 +601,7 @@ class Chat {
       tools: tools.map((t) => t._internalTool).toList(),
       sampler: sampler,
       mtp: mtp,
+      threadCount: threadCount,
     );
     return Chat._(chat);
   }
@@ -612,6 +618,11 @@ class Chat {
   /// completion. It is not invoked for cached/local files. The callback may
   /// be sync or async; awaiting slow work inside it will stall the download
   /// thread.
+  ///
+  /// [threadCount] is the number of CPU threads used for inference. Leave it null to
+  /// detect the device's physical core count (performance cores only, on Apple silicon) —
+  /// hyperthreads and efficiency cores make inference slower, not faster. Lower it to leave
+  /// CPU headroom for the rest of the app.
   static Future<Chat> fromPath({
     required String modelPath,
     String? projectionModelPath,
@@ -624,6 +635,7 @@ class Chat {
     nobodywho.SamplerConfig? sampler,
     bool useGpu = true,
     nobodywho.MtpConfig? mtp,
+    int? threadCount,
     FutureOr<void> Function(int downloaded, int total) onDownloadProgress =
         nobodywho.noopOnDownloadProgress,
   }) async {
@@ -640,6 +652,7 @@ class Chat {
       sampler: sampler,
       useGpu: useGpu,
       mtp: mtp,
+      threadCount: threadCount,
     );
     return Chat._(chat);
   }

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -156,6 +156,7 @@ abstract class NobodyWhoApi extends BaseApi {
     SamplerConfig? sampler = null,
     bool useGpu = true,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   });
 
   Future<List<Message>> crateRustChatGetChatHistory({required RustChat that});
@@ -181,6 +182,7 @@ abstract class NobodyWhoApi extends BaseApi {
     List<RustTool> tools = const [],
     SamplerConfig? sampler = null,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   });
 
   Future<void> crateRustChatResetContext({
@@ -1102,6 +1104,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     SamplerConfig? sampler = null,
     bool useGpu = true,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1128,6 +1131,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_bool(useGpu, serializer);
           sse_encode_opt_box_autoadd_mtp_config(mtp, serializer);
+          sse_encode_opt_box_autoadd_u_32(threadCount, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1154,6 +1158,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sampler,
           useGpu,
           mtp,
+          threadCount,
         ],
         apiImpl: this,
       ),
@@ -1175,6 +1180,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       "sampler",
       "useGpu",
       "mtp",
+      "threadCount",
     ],
   );
 
@@ -1400,6 +1406,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     List<RustTool> tools = const [],
     SamplerConfig? sampler = null,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   }) {
     return handler.executeSync(
       SyncTask(
@@ -1422,6 +1429,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_opt_box_autoadd_mtp_config(mtp, serializer);
+          sse_encode_opt_box_autoadd_u_32(threadCount, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
@@ -1439,6 +1447,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           tools,
           sampler,
           mtp,
+          threadCount,
         ],
         apiImpl: this,
       ),
@@ -1456,6 +1465,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       "tools",
       "sampler",
       "mtp",
+      "threadCount",
     ],
   );
 

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -226,6 +226,10 @@ abstract class RustChat implements RustOpaqueInterface {
   ///     tools: List of Tool instances the model can call
   ///     sampler: SamplerConfig for token selection. Pass null to use default sampler.
   ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
+  ///     thread_count: CPU threads used for inference. Defaults to null, which detects the
+  ///         device's physical core count (performance cores only, on Apple silicon) —
+  ///         hyperthreads and efficiency cores make inference slower. Lower it to leave CPU
+  ///         headroom for the rest of the app. Clamped to the CPU count.
   static Future<RustChat> fromPath({
     required String modelPath,
     FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
@@ -240,6 +244,7 @@ abstract class RustChat implements RustOpaqueInterface {
     SamplerConfig? sampler = null,
     bool useGpu = true,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   }) => NobodyWho.instance.api.crateRustChatFromPath(
     modelPath: modelPath,
     onDownloadProgress: onDownloadProgress,
@@ -253,6 +258,7 @@ abstract class RustChat implements RustOpaqueInterface {
     sampler: sampler,
     useGpu: useGpu,
     mtp: mtp,
+    threadCount: threadCount,
   );
 
   Future<List<Message>> getChatHistory();
@@ -287,6 +293,10 @@ abstract class RustChat implements RustOpaqueInterface {
   ///     mtp: Optional MtpConfig to enable MTP speculative decoding. Requires the
   ///         Model to have been loaded with a compatible `draft_model_path`. Adds
   ///         around 5% to VRAM usage. Defaults to null (disabled).
+  ///     thread_count: CPU threads used for inference. Defaults to null, which detects the
+  ///         device's physical core count (performance cores only, on Apple silicon) —
+  ///         hyperthreads and efficiency cores make inference slower. Lower it to leave CPU
+  ///         headroom for the rest of the app. Clamped to the CPU count.
   factory RustChat({
     required Model model,
     String? systemPrompt = null,
@@ -296,6 +306,7 @@ abstract class RustChat implements RustOpaqueInterface {
     List<RustTool> tools = const [],
     SamplerConfig? sampler = null,
     MtpConfig? mtp = null,
+    int? threadCount = null,
   }) => NobodyWho.instance.api.crateRustChatNew(
     model: model,
     systemPrompt: systemPrompt,
@@ -305,6 +316,7 @@ abstract class RustChat implements RustOpaqueInterface {
     tools: tools,
     sampler: sampler,
     mtp: mtp,
+    threadCount: threadCount,
   );
 
   Future<void> resetContext({

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -117,15 +117,22 @@ void main() {
       print("Using ${stats.contextUsed} of ${stats.contextSize} tokens");
     });
 
-    test('chat.md:146', () async {
+    test('chat.md:136', () async {
+      final chat = await nobodywho.Chat.fromPath(
+        modelPath: "./model.gguf",
+        threadCount: 4
+      );
+    });
+
+    test('chat.md:166', () async {
       final model = await nobodywho.Model.load(modelPath: './model.gguf', useGpu: true);
     });
 
-    test('chat.md:150', () async {
+    test('chat.md:170', () async {
       final chat = await nobodywho.Chat.fromPath(modelPath: './model.gguf', useGpu : false);
     });
 
-    test('chat.md:176', () async {
+    test('chat.md:196', () async {
       if (Platform.environment['TEST_MTP_MODEL'] == null) return;
       final chat = await nobodywho.Chat.fromPath(
         modelPath: "./gemma-4-e2b.gguf",
@@ -134,7 +141,7 @@ void main() {
       );
     });
 
-    test('chat.md:198', () async {
+    test('chat.md:218', () async {
       final chat = await nobodywho.Chat.fromPath(
         modelPath: "./model.gguf",
         templateVariables: {"enable_thinking": true}
@@ -153,7 +160,7 @@ void main() {
       print(variables); // {enable_thinking: true, verbose_mode: false}
     });
 
-    test('chat.md:250', () async {
+    test('chat.md:270', () async {
       // Deprecated - use templateVariables instead
       final chat = await nobodywho.Chat.fromPath(
         modelPath: "./model.gguf",
@@ -280,11 +287,11 @@ void main() {
     });
 
     test('embeddings-and-rag.md:166', () async {
-      await _doctest_18();
+      await _doctest_19();
     });
 
     test('embeddings-and-rag.md:216', () async {
-      await _doctest_19();
+      await _doctest_20();
     });
 
     test('embeddings-and-rag.md:263', () async {
@@ -489,7 +496,7 @@ void main() {
 }
 
 // Extracted from embeddings-and-rag.md:166
-Future<void> _doctest_18() async {
+Future<void> _doctest_19() async {
   // Initialize the cross-encoder for document ranking
   final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');
 
@@ -530,7 +537,7 @@ Future<void> _doctest_18() async {
 }
 
 // Extracted from embeddings-and-rag.md:216
-Future<void> _doctest_19() async {
+Future<void> _doctest_20() async {
   final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
   
   final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -693,6 +693,7 @@ fn wire__crate__RustChat_from_path_impl(
             let api_sampler = <Option<SamplerConfig>>::sse_decode(&mut deserializer);
             let api_use_gpu = <bool>::sse_decode(&mut deserializer);
             let api_mtp = <Option<crate::MtpConfig>>::sse_decode(&mut deserializer);
+            let api_thread_count = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -709,6 +710,7 @@ fn wire__crate__RustChat_from_path_impl(
                         api_sampler,
                         api_use_gpu,
                         api_mtp,
+                        api_thread_count,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1082,6 +1084,7 @@ fn wire__crate__RustChat_new_impl(
             let api_tools = <Vec<RustTool>>::sse_decode(&mut deserializer);
             let api_sampler = <Option<SamplerConfig>>::sse_decode(&mut deserializer);
             let api_mtp = <Option<crate::MtpConfig>>::sse_decode(&mut deserializer);
+            let api_thread_count = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, String>((move || {
                 let mut api_model_guard = None;
@@ -1107,6 +1110,7 @@ fn wire__crate__RustChat_new_impl(
                     api_tools,
                     api_sampler,
                     api_mtp,
+                    api_thread_count,
                 )?;
                 Ok(output_ok)
             })())

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -373,7 +373,12 @@ impl RustChat {
     ///     mtp: Optional MtpConfig to enable MTP speculative decoding. Requires the
     ///         Model to have been loaded with a compatible `draft_model_path`. Adds
     ///         around 5% to VRAM usage. Defaults to null (disabled).
+    ///     thread_count: CPU threads used for inference. Defaults to null, which detects the
+    ///         device's physical core count (performance cores only, on Apple silicon) —
+    ///         hyperthreads and efficiency cores make inference slower. Lower it to leave CPU
+    ///         headroom for the rest of the app. Clamped to the CPU count.
     #[flutter_rust_bridge::frb(sync)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         model: &Model,
         #[frb(default = "null")] system_prompt: Option<String>,
@@ -383,6 +388,7 @@ impl RustChat {
         #[frb(default = "const []")] tools: Vec<RustTool>,
         #[frb(default = "null")] sampler: Option<SamplerConfig>,
         #[frb(default = "null")] mtp: Option<MtpConfig>,
+        #[frb(default = "null")] thread_count: Option<u32>,
     ) -> Result<Self, String> {
         let sampler_config = sampler.map(|s| s.sampler_config).unwrap_or_default();
 
@@ -405,6 +411,9 @@ impl RustChat {
         if let Some(mtp) = mtp {
             builder = builder.with_mtp(mtp.into());
         }
+        if let Some(thread_count) = thread_count {
+            builder = builder.with_n_threads(thread_count);
+        }
         let chat = builder
             .build_async()
             .map_err(|e| nobodywho::render_miette(&e))?;
@@ -425,6 +434,10 @@ impl RustChat {
     ///     tools: List of Tool instances the model can call
     ///     sampler: SamplerConfig for token selection. Pass null to use default sampler.
     ///     use_gpu: Whether to use GPU acceleration. Defaults to true.
+    ///     thread_count: CPU threads used for inference. Defaults to null, which detects the
+    ///         device's physical core count (performance cores only, on Apple silicon) —
+    ///         hyperthreads and efficiency cores make inference slower. Lower it to leave CPU
+    ///         headroom for the rest of the app. Clamped to the CPU count.
     #[flutter_rust_bridge::frb]
     #[allow(clippy::too_many_arguments)]
     pub fn from_path(
@@ -443,6 +456,7 @@ impl RustChat {
         #[frb(default = "null")] sampler: Option<SamplerConfig>,
         #[frb(default = true)] use_gpu: bool,
         #[frb(default = "null")] mtp: Option<MtpConfig>,
+        #[frb(default = "null")] thread_count: Option<u32>,
     ) -> Result<Self, String> {
         let model = nobodywho::llm::get_model(
             model_path,
@@ -472,6 +486,9 @@ impl RustChat {
             .with_sampler(sampler_config);
         if let Some(mtp) = mtp {
             builder = builder.with_mtp(mtp.into());
+        }
+        if let Some(thread_count) = thread_count {
+            builder = builder.with_n_threads(thread_count);
         }
         let chat = builder
             .build_async()

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -656,6 +656,13 @@ struct NobodyWhoChat {
     context_length: u32,
 
     #[export]
+    /// Number of CPU threads used for inference. Leave at 0 to detect the machine's physical
+    /// core count (performance cores only, on Apple silicon) — hyperthreads and efficiency
+    /// cores make inference slower, not faster. Lower it to leave CPU headroom for rendering
+    /// and game logic. Values above the CPU count are clamped.
+    thread_count: u32,
+
+    #[export]
     /// Enable MTP speculative decoding for this chat. Requires the
     /// linked `NobodyWhoModel` to have a `draft_model_path` set.
     /// Adds around 5% to VRAM usage.
@@ -690,6 +697,9 @@ impl INode for NobodyWhoChat {
             tools: default_config.tools,
             system_prompt: GString::from(""),
             context_length: default_config.n_ctx,
+            // `n_threads` on ChatConfig is Option<u32>; 0 is the exported spelling of
+            // "detect it", since the Godot inspector has no null for ints.
+            thread_count: default_config.n_threads.unwrap_or(0),
             allow_thinking: true,
             // `mtp` on ChatConfig is now Option<MtpConfig>; expose the flattened
             // toggle + tuning as separate exported properties, off by default.
@@ -706,6 +716,19 @@ impl INode for NobodyWhoChat {
     }
 }
 
+/// Everything `NobodyWhoChat` needs to build its worker, snapshotted synchronously before
+/// the async spawn. A named struct rather than a tuple on purpose: several fields are `u32`,
+/// and a transposed pair would compile silently.
+struct ChatWorkerConfig {
+    model_node: Gd<NobodyWhoModel>,
+    system_prompt: String,
+    tools: Vec<nobodywho::tool_calling::Tool>,
+    n_ctx: u32,
+    n_threads: Option<u32>,
+    allow_thinking: bool,
+    mtp: Option<nobodywho::chat::MtpConfig>,
+}
+
 #[godot_api]
 impl NobodyWhoChat {
     /// Load the model and create the chat worker. `me.bind_mut()` below must run
@@ -715,30 +738,26 @@ impl NobodyWhoChat {
     /// forces a single executor round-trip so the outer borrow always drops first.
     async fn load_and_store_worker(
         mut me: Gd<Self>,
-        model_node: Gd<NobodyWhoModel>,
-        system_prompt: String,
-        tools: Vec<nobodywho::tool_calling::Tool>,
-        n_ctx: u32,
-        allow_thinking: bool,
-        mtp: Option<nobodywho::chat::MtpConfig>,
+        config: ChatWorkerConfig,
     ) -> Result<nobodywho::chat::ChatHandleAsync, GString> {
         tokio::task::yield_now().await;
 
-        let model = NobodyWhoModel::load_model_detached(model_node)
+        let model = NobodyWhoModel::load_model_detached(config.model_node)
             .await
             .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         let mut template_variables = HashMap::new();
-        template_variables.insert("enable_thinking".to_string(), allow_thinking);
+        template_variables.insert("enable_thinking".to_string(), config.allow_thinking);
         let handle = nobodywho::chat::ChatHandleAsync::new(
             model,
             nobodywho::chat::ChatConfig {
-                system_prompt: Some(system_prompt),
-                tools,
-                n_ctx,
+                system_prompt: Some(config.system_prompt),
+                tools: config.tools,
+                n_ctx: config.n_ctx,
                 template_variables,
                 sampler_config: None,
-                mtp,
+                mtp: config.mtp,
+                n_threads: config.n_threads,
             },
         )
         .map_err(|e| GString::from(e.to_string().as_str()))?;
@@ -756,19 +775,7 @@ impl NobodyWhoChat {
 
     /// Synchronously snapshot the config needed for worker init. Returns an error string
     /// if model_node isn't set. Must be called from a `&mut self` (or `&self`) context.
-    fn snapshot_worker_config(
-        &self,
-    ) -> Result<
-        (
-            Gd<NobodyWhoModel>,
-            String,
-            Vec<nobodywho::tool_calling::Tool>,
-            u32,
-            bool,
-            Option<nobodywho::chat::MtpConfig>,
-        ),
-        GString,
-    > {
+    fn snapshot_worker_config(&self) -> Result<ChatWorkerConfig, GString> {
         let Some(model_node) = self.model_node.clone() else {
             return Err(GString::from("Model node was not set"));
         };
@@ -778,14 +785,17 @@ impl NobodyWhoChat {
             k_max: self.mtp_k_max,
             p_min: self.mtp_p_min,
         });
-        Ok((
+        Ok(ChatWorkerConfig {
             model_node,
-            self.system_prompt.to_string(),
-            self.tools.clone(),
-            self.context_length,
-            self.allow_thinking,
+            system_prompt: self.system_prompt.to_string(),
+            tools: self.tools.clone(),
+            n_ctx: self.context_length,
+            // The exported property is a plain int, so 0 spells "detect it" — core takes
+            // `None` for that.
+            n_threads: (self.thread_count > 0).then_some(self.thread_count),
+            allow_thinking: self.allow_thinking,
             mtp,
-        ))
+        })
     }
 
     #[func]
@@ -802,30 +812,19 @@ impl NobodyWhoChat {
             return;
         }
 
-        let (model_node, system_prompt, tools, n_ctx, allow_thinking, mtp) =
-            match self.snapshot_worker_config() {
-                Ok(c) => c,
-                Err(e) => {
-                    godot_error!("Error starting worker: {}", e);
-                    self.signals().worker_failed().emit(&e);
-                    return;
-                }
-            };
+        let config = match self.snapshot_worker_config() {
+            Ok(c) => c,
+            Err(e) => {
+                godot_error!("Error starting worker: {}", e);
+                self.signals().worker_failed().emit(&e);
+                return;
+            }
+        };
 
         let me = self.to_gd();
         godot::task::spawn(async move {
             let me_emit = me.clone();
-            match Self::load_and_store_worker(
-                me,
-                model_node,
-                system_prompt,
-                tools,
-                n_ctx,
-                allow_thinking,
-                mtp,
-            )
-            .await
-            {
+            match Self::load_and_store_worker(me, config).await {
                 Ok(_) => me_emit.signals().worker_started().emit(),
                 Err(e) => {
                     godot_error!("Error running model: {}", e);
@@ -882,19 +881,8 @@ impl NobodyWhoChat {
             let chat_handle = match existing_handle {
                 Some(h) => h,
                 None => {
-                    let (model_node, system_prompt, tools, n_ctx, allow_thinking, mtp) =
-                        load_config.expect("load_config set when no existing handle");
-                    match Self::load_and_store_worker(
-                        me,
-                        model_node,
-                        system_prompt,
-                        tools,
-                        n_ctx,
-                        allow_thinking,
-                        mtp,
-                    )
-                    .await
-                    {
+                    let config = load_config.expect("load_config set when no existing handle");
+                    match Self::load_and_store_worker(me, config).await {
                         Ok(h) => h,
                         Err(e) => {
                             godot_error!("ask() dropped: {}", e);

--- a/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
+++ b/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
@@ -861,7 +861,7 @@ internal object UniffiLib {
 ): Long
 external fun uniffi_nobodywho_uniffi_fn_free_rustchat(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
-external fun uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(`model`: Long,`systemPrompt`: RustBuffer.ByValue,`contextSize`: Int,`templateVariables`: RustBuffer.ByValue,`tools`: RustBuffer.ByValue,`sampler`: RustBuffer.ByValue,`mtp`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+external fun uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(`model`: Long,`systemPrompt`: RustBuffer.ByValue,`contextSize`: Int,`templateVariables`: RustBuffer.ByValue,`tools`: RustBuffer.ByValue,`sampler`: RustBuffer.ByValue,`mtp`: RustBuffer.ByValue,`threadCount`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_nobodywho_uniffi_fn_method_rustchat_ask(`ptr`: Long,`message`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
@@ -1367,7 +1367,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_nobodywho_uniffi_checksum_method_samplerconfig_to_json() != 51798.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 42705.toShort()) {
+    if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 2313.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 9022.toShort()) {
@@ -2079,13 +2079,18 @@ open class RustChat: Disposable, AutoCloseable, RustChatInterface
      * chat; `null` disables it. Requires the `RustModel` to have been
      * loaded with a compatible `draft_model_path`; otherwise construction
      * fails. Adds around 5% to VRAM usage.
+     *
+     * `thread_count` is the number of CPU threads used for inference; `null`
+     * detects the device's physical core count (performance cores only, on
+     * Apple silicon), since hyperthreads and efficiency cores make inference
+     * slower. Clamped to the CPU count.
      */
-    constructor(`model`: RustModel, `systemPrompt`: kotlin.String?, `contextSize`: kotlin.UInt, `templateVariables`: Map<kotlin.String, kotlin.Boolean>?, `tools`: List<RustTool>?, `sampler`: SamplerConfig?, `mtp`: MtpConfig?) :
+    constructor(`model`: RustModel, `systemPrompt`: kotlin.String?, `contextSize`: kotlin.UInt, `templateVariables`: Map<kotlin.String, kotlin.Boolean>?, `tools`: List<RustTool>?, `sampler`: SamplerConfig?, `mtp`: MtpConfig?, `threadCount`: kotlin.UInt?) :
         this(UniffiWithHandle, 
     uniffiRustCallWithError(NobodyWhoException) { _status ->
     UniffiLib.uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(
     
-        FfiConverterTypeRustModel.lower(`model`),FfiConverterOptionalString.lower(`systemPrompt`),FfiConverterUInt.lower(`contextSize`),FfiConverterOptionalMapStringBoolean.lower(`templateVariables`),FfiConverterOptionalSequenceTypeRustTool.lower(`tools`),FfiConverterOptionalTypeSamplerConfig.lower(`sampler`),FfiConverterOptionalTypeMtpConfig.lower(`mtp`),_status)
+        FfiConverterTypeRustModel.lower(`model`),FfiConverterOptionalString.lower(`systemPrompt`),FfiConverterUInt.lower(`contextSize`),FfiConverterOptionalMapStringBoolean.lower(`templateVariables`),FfiConverterOptionalSequenceTypeRustTool.lower(`tools`),FfiConverterOptionalTypeSamplerConfig.lower(`sampler`),FfiConverterOptionalTypeMtpConfig.lower(`mtp`),FfiConverterOptionalUInt.lower(`threadCount`),_status)
 }
     )
 

--- a/nobodywho/kotlin/common/src/Chat.kt
+++ b/nobodywho/kotlin/common/src/Chat.kt
@@ -27,7 +27,13 @@ class Chat(
     templateVariables: Map<String, Boolean>? = null,
     tools: List<Tool>? = null,
     sampler: SamplerConfig? = null,
-    mtp: MtpConfig? = null
+    mtp: MtpConfig? = null,
+    /**
+     * CPU threads used for inference. Leave null to detect the device's physical core count
+     * (performance cores only, on Apple silicon) — hyperthreads and efficiency cores make
+     * inference slower, not faster. Lower it to leave CPU headroom for the rest of the app.
+     */
+    threadCount: UInt? = null
 ) : Closeable {
     private val inner: InternalRustChat = InternalRustChat(
         model.inner,
@@ -36,7 +42,8 @@ class Chat(
         templateVariables,
         tools?.map { it.inner },
         sampler,
-        mtp
+        mtp,
+        threadCount
     )
 
     companion object {
@@ -52,10 +59,11 @@ class Chat(
             tools: List<Tool>? = null,
             sampler: SamplerConfig? = null,
             mtp: MtpConfig? = null,
+            threadCount: UInt? = null,
             onDownloadProgress: ((downloaded: ULong, total: ULong) -> Unit)? = null
         ): Chat {
             val model = Model.load(modelPath, useGpu, projectionModelPath, draftModelPath, onDownloadProgress)
-            return Chat(model, systemPrompt, contextSize, templateVariables, tools, sampler, mtp)
+            return Chat(model, systemPrompt, contextSize, templateVariables, tools, sampler, mtp, threadCount)
         }
     }
 

--- a/nobodywho/python/PYPI_DESCRIPTION.md
+++ b/nobodywho/python/PYPI_DESCRIPTION.md
@@ -19,8 +19,8 @@ NobodyWho is a lightweight, open-source inference engine that makes it simple to
 ```python
 from nobodywho import Chat
 
-chat = Chat('./model.gguf')
-response = chat.ask('Hello world?').completed()
+chat = Chat("./model.gguf")
+response = chat.ask("Hello world?").completed()
 print(response)
 ```
 

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -46,6 +46,7 @@ class Chat:
         sampler: "SamplerConfig | None" = None,
         allow_thinking: "bool | None" = None,
         mtp: "MtpConfig | None" = None,
+        n_threads: "int | None" = None,
     ) -> "Chat":
         """
         Create a new Chat instance for conversational text generation.
@@ -63,6 +64,10 @@ class Chat:
             mtp: Optional MtpConfig to enable MTP speculative decoding on this chat.
                 Requires the `Model` to have been loaded with a compatible
                 `draft_model_path`. Adds around 5% to VRAM usage. Defaults to None.
+            n_threads: Number of CPU threads to use for inference. Defaults to None, which
+                detects the host's physical core count (performance cores only, on Apple
+                silicon) — hyperthreads and efficiency cores slow inference down. Set it
+                lower to leave CPU headroom for other work. Clamped to the logical CPU count.
 
         Returns:
             A Chat instance
@@ -274,6 +279,7 @@ class ChatAsync:
         sampler: "SamplerConfig | None" = None,
         allow_thinking: "bool | None" = None,
         mtp: "MtpConfig | None" = None,
+        n_threads: "int | None" = None,
     ) -> "ChatAsync":
         """
         Create a new async Chat instance for conversational text generation.
@@ -291,6 +297,10 @@ class ChatAsync:
             mtp: Optional MtpConfig to enable MTP speculative decoding on this chat.
                 Requires the `Model` to have been loaded with a compatible
                 `draft_model_path`. Adds around 5% to VRAM usage. Defaults to None.
+            n_threads: Number of CPU threads to use for inference. Defaults to None, which
+                detects the host's physical core count (performance cores only, on Apple
+                silicon) — hyperthreads and efficiency cores slow inference down. Set it
+                lower to leave CPU headroom for other work. Clamped to the logical CPU count.
 
         Returns:
             A ChatAsync instance

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -1061,6 +1061,10 @@ impl Chat {
     ///     mtp: Optional MtpConfig to enable MTP speculative decoding on this chat.
     ///         Requires the `Model` to have been loaded with a compatible
     ///         `draft_model_path`. Adds around 5% to VRAM usage. Defaults to None.
+    ///     n_threads: Number of CPU threads to use for inference. Defaults to None, which
+    ///         detects the host's physical core count (performance cores only, on Apple
+    ///         silicon) — hyperthreads and efficiency cores slow inference down. Set it
+    ///         lower to leave CPU headroom for other work. Clamped to the logical CPU count.
     ///
     /// Returns:
     ///     A Chat instance
@@ -1069,7 +1073,7 @@ impl Chat {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None, mtp: "MtpConfig | None" = None) -> "Chat")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = Vec::<Tool>::new(), sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None, mtp: "MtpConfig | None" = None, n_threads: "int | None" = None) -> "Chat")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
@@ -1079,6 +1083,7 @@ impl Chat {
         sampler: Option<SamplerConfig>,
         allow_thinking: Option<bool>,
         mtp: Option<MtpConfig>,
+        n_threads: Option<u32>,
         py: Python<'_>,
     ) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
@@ -1107,6 +1112,9 @@ impl Chat {
                 .with_system_prompt(system_prompt);
             if let Some(mtp) = mtp {
                 builder = builder.with_mtp(mtp.into());
+            }
+            if let Some(n_threads) = n_threads {
+                builder = builder.with_n_threads(n_threads);
             }
             // When no sampler is given, leave it unset so the worker falls back
             // to sampling settings embedded in the GGUF (general.sampling.*),
@@ -1486,6 +1494,10 @@ impl ChatAsync {
     ///     mtp: Optional MtpConfig to enable MTP speculative decoding on this chat.
     ///         Requires the `Model` to have been loaded with a compatible
     ///         `draft_model_path`. Adds around 5% to VRAM usage. Defaults to None.
+    ///     n_threads: Number of CPU threads to use for inference. Defaults to None, which
+    ///         detects the host's physical core count (performance cores only, on Apple
+    ///         silicon) — hyperthreads and efficiency cores slow inference down. Set it
+    ///         lower to leave CPU headroom for other work. Clamped to the logical CPU count.
     ///
     /// Returns:
     ///     A ChatAsync instance
@@ -1494,7 +1506,7 @@ impl ChatAsync {
     ///     RuntimeError: If the model cannot be loaded
 
     #[new]
-    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None, mtp: "MtpConfig | None" = None) -> "ChatAsync")]
+    #[pyo3(signature = (model: "Model | os.PathLike | str", n_ctx = 4096, system_prompt = None, template_variables: "dict[str, bool]" = std::collections::HashMap::<String, bool>::new(), tools: "list[Tool]" = vec![], sampler: "SamplerConfig | None" = None, allow_thinking: "bool | None" = None, mtp: "MtpConfig | None" = None, n_threads: "int | None" = None) -> "ChatAsync")]
     pub fn new(
         model: ModelOrPath,
         n_ctx: u32,
@@ -1504,6 +1516,7 @@ impl ChatAsync {
         sampler: Option<SamplerConfig>,
         allow_thinking: Option<bool>,
         mtp: Option<MtpConfig>,
+        n_threads: Option<u32>,
         py: Python<'_>,
     ) -> PyResult<Self> {
         let nw_model = model.get_inner_model()?;
@@ -1532,6 +1545,9 @@ impl ChatAsync {
                 .with_system_prompt(system_prompt);
             if let Some(mtp) = mtp {
                 builder = builder.with_mtp(mtp.into());
+            }
+            if let Some(n_threads) = n_threads {
+                builder = builder.with_n_threads(n_threads);
             }
             // When no sampler is given, leave it unset so the worker falls back
             // to sampling settings embedded in the GGUF (general.sampling.*),

--- a/nobodywho/python/tests/test_nobodywho.py
+++ b/nobodywho/python/tests/test_nobodywho.py
@@ -310,6 +310,21 @@ def test_stats(model):
     assert stats.context_used <= n_ctx
 
 
+def test_explicit_thread_count(model):
+    # n_threads is not readable back through stats(), so this asserts the option is accepted
+    # and that generation still works with a non-default pool size. Core clamps the value,
+    # so an absurd request must not fail either.
+    for n_threads in (1, 1_000_000):
+        chat = nobodywho.Chat(
+            model,
+            n_ctx=1024,
+            n_threads=n_threads,
+            template_variables={"enable_thinking": False},
+        )
+        response = chat.ask("What is the capital of Denmark?").completed()
+        assert "Copenhagen" in response
+
+
 def test_set_and_get_chat_history(chat):
     chat_history = [
         {"role": "user", "content": "What's 2 + 2?"},

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -119,7 +119,7 @@ void uniffi_nobodywho_uniffi_fn_free_rustchat(
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(
     /*handle*/ uint64_t model, RustBuffer system_prompt, uint32_t context_size,
     RustBuffer template_variables, RustBuffer tools, RustBuffer sampler,
-    RustBuffer mtp, RustCallStatus *uniffi_out_err);
+    RustBuffer mtp, RustBuffer thread_count, RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_method_rustchat_ask(
     /*handle*/ uint64_t ptr, RustBuffer message,
     RustCallStatus *uniffi_out_err);
@@ -2740,7 +2740,7 @@ NativeNobodywho::NativeNobodywho(
           rt,
           jsi::PropNameID::forAscii(
               rt, "ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustchat_new"),
-          7,
+          8,
           [this](jsi::Runtime &rt, const jsi::Value &thisVal,
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this
@@ -5766,6 +5766,7 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[4]),
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[5]),
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[6]),
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[7]),
       &status);
   uniffi::nobodywho::Bridging<RustCallStatus>::copyIntoJs(
       rt, callInvoker, status, args[count - 1]);

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -20,7 +20,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_internal_fn_func_ffi__arraybuffer_to_string(buffer: Uint8Array, uniffi_out_err: UniffiRustCallStatus): string;
     ubrn_uniffi_nobodywho_uniffi_fn_clone_rustchat(handle: bigint, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_free_rustchat(handle: bigint, uniffi_out_err: UniffiRustCallStatus): void;
-    ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(model: bigint, systemPrompt: Uint8Array, contextSize: number, templateVariables: Uint8Array, tools: Uint8Array, sampler: Uint8Array, mtp: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(model: bigint, systemPrompt: Uint8Array, contextSize: number, templateVariables: Uint8Array, tools: Uint8Array, sampler: Uint8Array, mtp: Uint8Array, threadCount: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_method_rustchat_ask(ptr: bigint, message: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_method_rustchat_ask_with_json_prompt(ptr: bigint, json: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_method_rustchat_ask_with_prompt(ptr: bigint, parts: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -1560,8 +1560,13 @@ export class RustChat extends UniffiAbstractObject implements RustChatInterface 
      * chat; `null` disables it. Requires the `RustModel` to have been
      * loaded with a compatible `draft_model_path`; otherwise construction
      * fails. Adds around 5% to VRAM usage.
+     *
+     * `thread_count` is the number of CPU threads used for inference; `null`
+     * detects the device's physical core count (performance cores only, on
+     * Apple silicon), since hyperthreads and efficiency cores make inference
+     * slower. Clamped to the CPU count.
      */
-    constructor(model: RustModelInterface, systemPrompt: string | undefined, contextSize: /*u32*/number, templateVariables: Map<string, boolean> | undefined, tools: Array<RustToolInterface> | undefined, sampler: SamplerConfigInterface | undefined, mtp: MtpConfig | undefined) /*throws*/ {
+    constructor(model: RustModelInterface, systemPrompt: string | undefined, contextSize: /*u32*/number, templateVariables: Map<string, boolean> | undefined, tools: Array<RustToolInterface> | undefined, sampler: SamplerConfigInterface | undefined, mtp: MtpConfig | undefined, threadCount: /*u32*/number | undefined) /*throws*/ {
         super();
         const pointer =
             
@@ -1576,6 +1581,7 @@ export class RustChat extends UniffiAbstractObject implements RustChatInterface 
         FfiConverterOptionalArrayTypeRustTool.lower(tools),
         FfiConverterOptionalTypeSamplerConfig.lower(sampler),
         FfiConverterOptionalTypeMtpConfig.lower(mtp),
+        FfiConverterOptionalUInt32.lower(threadCount),
                 callStatus);
             },
             /*liftString:*/ FfiConverterString.lift,
@@ -4303,7 +4309,7 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_samplerconfig_to_json() !== 51798) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_samplerconfig_to_json");
     }
-    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() !== 42705) {
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() !== 2313) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() !== 9022) {

--- a/nobodywho/react-native/src/chat.ts
+++ b/nobodywho/react-native/src/chat.ts
@@ -32,6 +32,12 @@ export class Chat {
   /** @internal */
   private readonly _inner: RustChat;
 
+  /**
+   * `threadCount` is the number of CPU threads used for inference. Omit it to detect the
+   * device's physical core count (performance cores only, on Apple silicon) — hyperthreads
+   * and efficiency cores make inference slower, not faster. Lower it to leave CPU headroom
+   * for the rest of the app.
+   */
   constructor(opts: {
     model: Model;
     systemPrompt?: string;
@@ -40,6 +46,7 @@ export class Chat {
     tools?: Tool[];
     sampler?: SamplerConfig;
     mtp?: Partial<MtpConfig>;
+    threadCount?: number;
   }) {
     this._inner = new RustChat(
       opts.model._inner,
@@ -49,6 +56,7 @@ export class Chat {
       opts.tools?.map((t) => t._inner) ?? undefined,
       opts.sampler ?? undefined,
       opts.mtp !== undefined ? MtpConfig.create(opts.mtp) : undefined,
+      opts.threadCount ?? undefined,
     );
   }
 
@@ -75,6 +83,7 @@ export class Chat {
     tools?: Tool[];
     sampler?: SamplerConfig;
     mtp?: Partial<MtpConfig>;
+    threadCount?: number;
     onDownloadProgress?: (downloaded: number, total: number) => void;
   }): Promise<Chat> {
     const model = await Model.load({

--- a/nobodywho/swift/generated/nobodywho.swift
+++ b/nobodywho/swift/generated/nobodywho.swift
@@ -741,8 +741,13 @@ open class RustChat: RustChatProtocol, @unchecked Sendable {
      * chat; `null` disables it. Requires the `RustModel` to have been
      * loaded with a compatible `draft_model_path`; otherwise construction
      * fails. Adds around 5% to VRAM usage.
+     *
+     * `thread_count` is the number of CPU threads used for inference; `null`
+     * detects the device's physical core count (performance cores only, on
+     * Apple silicon), since hyperthreads and efficiency cores make inference
+     * slower. Clamped to the CPU count.
      */
-public convenience init(model: RustModel, systemPrompt: String?, contextSize: UInt32, templateVariables: [String: Bool]?, tools: [RustTool]?, sampler: SamplerConfig?, mtp: MtpConfig?)throws  {
+public convenience init(model: RustModel, systemPrompt: String?, contextSize: UInt32, templateVariables: [String: Bool]?, tools: [RustTool]?, sampler: SamplerConfig?, mtp: MtpConfig?, threadCount: UInt32?)throws  {
     let handle =
         try rustCallWithError(FfiConverterTypeNobodyWhoError_lift) {
     uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(
@@ -752,7 +757,8 @@ public convenience init(model: RustModel, systemPrompt: String?, contextSize: UI
         FfiConverterOptionDictionaryStringBool.lower(templateVariables),
         FfiConverterOptionSequenceTypeRustTool.lower(tools),
         FfiConverterOptionTypeSamplerConfig.lower(sampler),
-        FfiConverterOptionTypeMtpConfig.lower(mtp),$0
+        FfiConverterOptionTypeMtpConfig.lower(mtp),
+        FfiConverterOptionUInt32.lower(threadCount),$0
     )
 }
     self.init(unsafeFromHandle: handle)
@@ -4882,7 +4888,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_nobodywho_uniffi_checksum_method_samplerconfig_to_json() != 51798) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 42705) {
+    if (uniffi_nobodywho_uniffi_checksum_constructor_rustchat_new() != 2313) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_constructor_rustcrossencoder_new() != 9022) {

--- a/nobodywho/swift/generated/nobodywhoFFI.h
+++ b/nobodywho/swift/generated/nobodywhoFFI.h
@@ -287,7 +287,7 @@ void uniffi_nobodywho_uniffi_fn_free_rustchat(uint64_t handle, RustCallStatus *_
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_CONSTRUCTOR_RUSTCHAT_NEW
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_CONSTRUCTOR_RUSTCHAT_NEW
-uint64_t uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(uint64_t model, RustBuffer system_prompt, uint32_t context_size, RustBuffer template_variables, RustBuffer tools, RustBuffer sampler, RustBuffer mtp, RustCallStatus *_Nonnull out_status
+uint64_t uniffi_nobodywho_uniffi_fn_constructor_rustchat_new(uint64_t model, RustBuffer system_prompt, uint32_t context_size, RustBuffer template_variables, RustBuffer tools, RustBuffer sampler, RustBuffer mtp, RustBuffer thread_count, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_METHOD_RUSTCHAT_ASK

--- a/nobodywho/swift/src/Chat.swift
+++ b/nobodywho/swift/src/Chat.swift
@@ -15,6 +15,10 @@ import NobodyWhoGenerated
 public class Chat {
     private let inner: RustChat
 
+    /// `threadCount` is the number of CPU threads used for inference. Leave it `nil` to
+    /// detect the device's physical core count (performance cores only, on Apple silicon) —
+    /// hyperthreads and efficiency cores make inference slower, not faster. Lower it to leave
+    /// CPU headroom for the rest of the app.
     public init(
         model: Model,
         systemPrompt: String? = nil,
@@ -22,7 +26,8 @@ public class Chat {
         templateVariables: [String: Bool]? = nil,
         tools: [Tool]? = nil,
         sampler: SamplerConfig? = nil,
-        mtp: MtpConfig? = nil
+        mtp: MtpConfig? = nil,
+        threadCount: UInt32? = nil
     ) throws {
         self.inner = try RustChat(
             model: model.inner,
@@ -31,7 +36,8 @@ public class Chat {
             templateVariables: templateVariables,
             tools: tools?.map { $0.inner },
             sampler: sampler,
-            mtp: mtp
+            mtp: mtp,
+            threadCount: threadCount
         )
     }
 
@@ -48,6 +54,7 @@ public class Chat {
         tools: [Tool]? = nil,
         sampler: SamplerConfig? = nil,
         mtp: MtpConfig? = nil,
+        threadCount: UInt32? = nil,
         onDownloadProgress: ((UInt64, UInt64) -> Void)? = nil
     ) async throws -> Chat {
         let model = try await Model.load(
@@ -64,7 +71,8 @@ public class Chat {
             templateVariables: templateVariables,
             tools: tools,
             sampler: sampler,
-            mtp: mtp
+            mtp: mtp,
+            threadCount: threadCount
         )
     }
 

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -327,7 +327,13 @@ impl RustChat {
     /// chat; `null` disables it. Requires the `RustModel` to have been
     /// loaded with a compatible `draft_model_path`; otherwise construction
     /// fails. Adds around 5% to VRAM usage.
+    ///
+    /// `thread_count` is the number of CPU threads used for inference; `null`
+    /// detects the device's physical core count (performance cores only, on
+    /// Apple silicon), since hyperthreads and efficiency cores make inference
+    /// slower. Clamped to the CPU count.
     #[uniffi::constructor]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         model: &RustModel,
         system_prompt: Option<String>,
@@ -336,6 +342,7 @@ impl RustChat {
         tools: Option<Vec<Arc<RustTool>>>,
         sampler: Option<Arc<SamplerConfig>>,
         mtp: Option<MtpConfig>,
+        thread_count: Option<u32>,
     ) -> Result<Arc<Self>, NobodyWhoError> {
         let core_tools: Vec<nobodywho::tool_calling::Tool> = tools
             .unwrap_or_default()
@@ -353,6 +360,9 @@ impl RustChat {
             .with_sampler(sampler_config);
         if let Some(mtp) = mtp {
             builder = builder.with_mtp(mtp.into());
+        }
+        if let Some(thread_count) = thread_count {
+            builder = builder.with_n_threads(thread_count);
         }
         let chat = builder.build_async().map_err(|e| NobodyWhoError::Error {
             message: nobodywho::render_miette(&e),


### PR DESCRIPTION
Mirrors the thread count logic in llama.cpp upstream:

compared to llama-cpp-python's implementation (replicated in #651), which just does `cpu_count() // 2`, this also accounts for when to select performance cores and stuff by reading in `/proc/cpu`

this is a literal cpp-to-rust translation of the logic in llama.cpp, we might want to replace this with a binding in to the llama.cpp function via llama-cpp-rs bindings