### PR TITLE
Batch encoder and cross-encoder inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added
+
+- Batch embedding through `Encoder.encode_batch()`. Available for all bindings.
+
+### Changed
+
+- `CrossEncoder.rank()` now batches documents internally making re-raking faster. Affects all bindings.
+
 ## [Python v1.7.0, Flutter v2.5.0, Godot v9.6.0, Kotlin v2.2.0, React Native v2.5.0, Swift v2.3.0] - 2026-07-30
 
 ### Added

--- a/docs/docs-flutter/embeddings-and-rag.md
+++ b/docs/docs-flutter/embeddings-and-rag.md
@@ -28,6 +28,18 @@ print("Vector with ${embedding.length} dimensions");
 
 The resulting embedding is a `Float32List` (typically 384 or 768 dimensions depending on the model).
 
+### Batch Encoding
+
+Use `encodeBatch` for multiple texts. It returns a `List<Float32List>` in input order:
+
+```dart continuation
+final texts = [
+  "Paris is the capital of France.",
+  "Berlin is the capital of Germany.",
+];
+final embeddings = await encoder.encodeBatch(texts: texts);
+```
+
 ### Comparing Embeddings
 
 To measure how similar two pieces of text are, compare their embeddings using cosine similarity:
@@ -73,11 +85,8 @@ final documents = [
   "Git is a version control system for tracking changes in source code"
 ];
 
-// Pre-compute document embeddings
-final docEmbeddings = <Float32List>[];
-for (final doc in documents) {
-  docEmbeddings.add(await encoder.encode(text: doc));
-}
+// Pre-compute document embeddings in a batch
+final docEmbeddings = await encoder.encodeBatch(texts: documents);
 
 // Search query
 final query = "What language should I use for database queries?";
@@ -291,10 +300,7 @@ Future<void> main() async {
   ];
 
   // Precompute embeddings for all documents
-  final docEmbeddings = <Float32List>[];
-  for (final doc in knowledgeBase) {
-    docEmbeddings.add(await encoder.encode(text: doc));
-  }
+  final docEmbeddings = await encoder.encodeBatch(texts: knowledgeBase);
 
   Future<String> search({required String query}) async {
     // Stage 1: Fast filtering with embeddings

--- a/docs/docs-godot/embeddings-and-rag.md
+++ b/docs/docs-godot/embeddings-and-rag.md
@@ -29,6 +29,15 @@ Embedding models are different from chat models. You need a model specifically t
 
 We normally use [bge-small-en-v1.5-q8_0.gguf](https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf).
 
+Use `encode_batch` when encoding multiple texts. It returns an `Array[PackedFloat32Array]` in input order:
+
+```gdscript
+var texts = PackedStringArray([
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany.",
+])
+var embeddings = await encode_batch(texts)
+```
 
 ### Practical Example: Quest & Reputation System
 
@@ -97,17 +106,8 @@ Generate embeddings for all your reference statements:
 
 ```gdscript
 func precompute_all_embeddings():
-    # Generate embeddings for helpful statements
-    for statement in quest_triggers:
-        encode(statement)
-        var embedding = await self.encoding_finished
-        helpful_embeddings.append(embedding)
-
-    # Generate embeddings for hostile statements
-    for statement in hostile_statements:
-        encode(statement)
-        var embedding = await self.encoding_finished
-        hostile_embeddings.append(embedding)
+    helpful_embeddings = await encode_batch(PackedStringArray(quest_triggers))
+    hostile_embeddings = await encode_batch(PackedStringArray(hostile_statements))
 ```
 
 

--- a/docs/docs-kotlin/embeddings-and-rag.md
+++ b/docs/docs-kotlin/embeddings-and-rag.md
@@ -24,6 +24,16 @@ val embedding = encoder.encode("What is the weather like?")
 println("Vector with ${embedding.size} dimensions")
 ```
 
+Use `encodeBatch` for multiple texts. It returns embeddings in input order:
+
+```kotlin
+val texts = listOf(
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany."
+)
+val embeddings = encoder.encodeBatch(texts = texts)
+```
+
 ### Comparing Embeddings
 
 Measure how similar two pieces of text are with cosine similarity:

--- a/docs/docs-python/embeddings-and-rag.md
+++ b/docs/docs-python/embeddings-and-rag.md
@@ -28,6 +28,18 @@ print(f"Vector with {len(embedding)} dimensions")
 
 The resulting embedding is a list of floats (typically 384 or 768 dimensions depending on the model).
 
+### Batch Encoding
+
+Use `encode_batch` when encoding multiple texts. It batches the work internally and returns one embedding per text in input order.
+
+```python continuation
+texts = [
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany.",
+]
+embeddings = encoder.encode_batch(texts)
+```
+
 ### Comparing Embeddings
 
 To measure how similar two pieces of text are, compare their embeddings using cosine similarity:
@@ -65,8 +77,8 @@ documents = [
     "Git is a version control system for tracking changes in source code"
 ]
 
-# Pre-compute document embeddings
-doc_embeddings = [encoder.encode(doc) for doc in documents]
+# Pre-compute document embeddings in a batch
+doc_embeddings = encoder.encode_batch(documents)
 
 # Search query
 query = "What language should I use for database queries?"
@@ -195,7 +207,10 @@ async def main():
     crossencoder = CrossEncoderAsync('./reranker-model.gguf')
     
     # Generate embeddings asynchronously
-    embedding = await encoder.encode("What is the weather?")
+    embeddings = await encoder.encode_batch([
+        "What is the weather?",
+        "What is the return policy?",
+    ])
     
     # Rank documents asynchronously
     query = "What is our refund policy?"
@@ -255,7 +270,7 @@ knowledge_base = [
 ]
 
 # Precompute embeddings for all documents
-doc_embeddings = [encoder.encode(doc) for doc in knowledge_base]
+doc_embeddings = encoder.encode_batch(knowledge_base)
 
 @tool(description="Search the knowledge base for information relevant to the query")
 def search(query: str) -> str:

--- a/docs/docs-react-native/embeddings-and-rag.md
+++ b/docs/docs-react-native/embeddings-and-rag.md
@@ -30,6 +30,18 @@ console.log(`Vector with ${embedding.length} dimensions`);
 
 The resulting embedding is an array of numbers (typically 384 or 768 dimensions depending on the model).
 
+### Batch Encoding
+
+Use `encodeBatch` for multiple texts. It returns embeddings in input order:
+
+```typescript
+const texts = [
+  "Paris is the capital of France.",
+  "Berlin is the capital of Germany.",
+];
+const embeddings = await encoder.encodeBatch(texts);
+```
+
 ### Comparing Embeddings
 
 To measure how similar two pieces of text are, compare their embeddings using cosine similarity:

--- a/docs/docs-swift/embeddings-and-rag.md
+++ b/docs/docs-swift/embeddings-and-rag.md
@@ -23,6 +23,16 @@ let similar = cosineSimilarity(a: embedding1, b: embedding2)    // High similari
 let different = cosineSimilarity(a: embedding1, b: embedding3)  // Low similarity
 ```
 
+Use `encodeBatch` for multiple texts. It returns embeddings in input order:
+
+```swift
+let texts = [
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany.",
+]
+let embeddings = try await encoder.encodeBatch(texts)
+```
+
 You can also create an encoder from an already-loaded model:
 
 ```swift
@@ -68,7 +78,7 @@ A typical RAG pipeline combines both tools:
 // 1. Embed your documents (do this once, store the results)
 let encoder = try await Encoder.fromPath(modelPath: "/path/to/embeddings.gguf", contextSize: 512, useGpu: true)
 let docs = ["Document 1...", "Document 2...", "Document 3..."]
-let docEmbeddings = try await docs.asyncMap { try await encoder.encode($0) }
+let docEmbeddings = try await encoder.encodeBatch(docs)
 
 // 2. Embed the query and find similar documents
 let queryEmbedding = try await encoder.encode("What is the return policy?")

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -1,4 +1,5 @@
 use crate::errors::{CrossEncoderWorkerError, InitWorkerError};
+use crate::inference::{BatchedReadError, EngineContext};
 use crate::llm;
 use crate::llm::{Worker, WorkerGuard};
 use llama_cpp_2::context::params::LlamaPoolingType;
@@ -112,9 +113,6 @@ fn process_worker_msg(
 ) -> Result<(), CrossEncoderWorkerError> {
     match msg {
         CrossEncoderMsg::Rank(query, documents, respond) => {
-            // Clear context for each cross-encoder operation
-            worker_state.reset_context();
-
             let scores = worker_state.rank(query, documents)?;
 
             let _ = respond.blocking_send(scores);
@@ -138,20 +136,6 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
         n_ctx: u32,
     ) -> Result<Worker<'_, CrossEncoderWorker>, InitWorkerError> {
         Worker::new_with_type(model, n_ctx, true, None, None, CrossEncoderWorker {})
-    }
-
-    pub fn get_classification_score(&self) -> Result<f32, CrossEncoderWorkerError> {
-        // Cross-encoder models process query+document as single sequence, outputting classification scores.
-        // For crossencodering, all tokens have embeddings enabled (logits=true) but only the final token's
-        // embedding contains the relevance score. embeddings_seq_ith(0) gets the sequence's embedding
-        // vector, and embeddings[0] extracts the classification score from the final token.
-        let embeddings = self.engine.ctx.embeddings_seq_ith(0)?;
-
-        if !embeddings.is_empty() {
-            Ok(embeddings[0])
-        } else {
-            Err(CrossEncoderWorkerError::EmptyClassificationHead)
-        }
     }
 
     pub fn rank(
@@ -181,16 +165,30 @@ impl<'a> Worker<'a, CrossEncoderWorker> {
                 "</s>".to_string()
             });
 
-        let mut scores = Vec::new();
-        for document in documents {
-            self.reset_context();
-            // Format as: [CLS] query [SEP] document [SEP]
-            let input = format!("{cls}{query}{sep}{document}{sep}");
-            let score = self.read_string(input)?.get_classification_score()?;
-            scores.push(score);
-        }
-        Ok(scores)
+        let inputs = documents
+            .into_iter()
+            .map(|document| format!("{cls}{query}{sep}{document}{sep}"))
+            .collect();
+
+        self.engine
+            .read_strings_batched(inputs, classification_score_for)
+            .map_err(|error| match error {
+                BatchedReadError::Read(error) => CrossEncoderWorkerError::Read(error),
+                BatchedReadError::Output(error) => error,
+            })
     }
+}
+
+fn classification_score_for(
+    ctx: &EngineContext<'_>,
+    sequence_id: i32,
+) -> Result<f32, CrossEncoderWorkerError> {
+    // Rank pooling returns the classification head for each sequence.
+    let embeddings = ctx.embeddings_seq_ith(sequence_id)?;
+    embeddings
+        .first()
+        .copied()
+        .ok_or(CrossEncoderWorkerError::EmptyClassificationHead)
 }
 
 #[cfg(test)]
@@ -235,6 +233,98 @@ mod tests {
             seen_paris,
             "`Paris is the capital of France.` was not between the best four, the best three were: {}",
             best_docs.join(",")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_crossencoder_batch_matches_individual_scores() -> Result<(), Box<dyn std::error::Error>>
+    {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_crossencoder_model();
+        let encoder = CrossEncoder::new(model, 48);
+        let query = "What is the capital of France?".to_string();
+        let documents = vec![
+            "Paris is the capital of France.".to_string(),
+            "Berlin is the capital of Germany.".to_string(),
+            "The weather is nice today.".to_string(),
+            "The French government is based in Paris.".to_string(),
+        ];
+
+        let individual_scores = documents
+            .iter()
+            .map(|document| {
+                encoder
+                    .rank(query.clone(), vec![document.clone()])
+                    .map(|scores| scores[0])
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let batched_scores = encoder.rank(query, documents)?;
+
+        assert_eq!(individual_scores.len(), batched_scores.len());
+        for (individual_score, batched_score) in individual_scores.iter().zip(&batched_scores) {
+            assert!(
+                (individual_score - batched_score).abs() < 0.05,
+                "Individual score {individual_score} differed from batched score {batched_score}"
+            );
+        }
+
+        let mut individual_order = (0..individual_scores.len()).collect::<Vec<_>>();
+        individual_order.sort_by(|a, b| individual_scores[*b].total_cmp(&individual_scores[*a]));
+        let mut batched_order = (0..batched_scores.len()).collect::<Vec<_>>();
+        batched_order.sort_by(|a, b| batched_scores[*b].total_cmp(&batched_scores[*a]));
+        assert_eq!(individual_order, batched_order);
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "real-model benchmark; run with --ignored --nocapture"]
+    fn benchmark_crossencoder_batching() -> Result<(), Box<dyn std::error::Error>> {
+        let model = test_utils::load_crossencoder_model();
+        let encoder = CrossEncoder::new(model, 4096);
+        let query = "What is the capital of France?".to_string();
+        let documents = (0..40)
+            .map(|index| {
+                format!(
+                    "Document {index}: Paris is the capital of France and the seat of its government."
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let sequential_start = std::time::Instant::now();
+        let sequential_scores = documents
+            .iter()
+            .map(|document| {
+                encoder
+                    .rank(query.clone(), vec![document.clone()])
+                    .map(|scores| scores[0])
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let sequential_elapsed = sequential_start.elapsed();
+
+        let batched_start = std::time::Instant::now();
+        let batched_scores = encoder.rank(query, documents.clone())?;
+        let batched_elapsed = batched_start.elapsed();
+
+        let max_score_difference = sequential_scores
+            .iter()
+            .zip(&batched_scores)
+            .map(|(sequential_score, batched_score)| (sequential_score - batched_score).abs())
+            .fold(0.0, f32::max);
+
+        eprintln!(
+            "Sequential: {} one-document rank calls in {:?}",
+            documents.len(),
+            sequential_elapsed
+        );
+        eprintln!(
+            "Batched: one {}-document rank call in {:?} ({:.2}x faster, max score difference {:.6})",
+            documents.len(),
+            batched_elapsed,
+            sequential_elapsed.as_secs_f64() / batched_elapsed.as_secs_f64(),
+            max_score_difference
         );
 
         Ok(())

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -1,4 +1,5 @@
 use crate::errors::{EncoderWorkerError, InitWorkerError};
+use crate::inference::BatchedReadError;
 use crate::llm;
 use crate::llm::{Worker, WorkerGuard};
 use llama_cpp_2::context::params::LlamaPoolingType;
@@ -23,6 +24,10 @@ impl Encoder {
 
     pub fn encode(&self, text: String) -> Result<Vec<f32>, EncoderWorkerError> {
         futures::executor::block_on(async { self.async_handle.encode(text).await })
+    }
+
+    pub fn encode_batch(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, EncoderWorkerError> {
+        futures::executor::block_on(async { self.async_handle.encode_batch(texts).await })
     }
 }
 
@@ -52,16 +57,27 @@ impl EncoderAsync {
     }
 
     pub async fn encode(&self, text: String) -> Result<Vec<f32>, EncoderWorkerError> {
+        self.encode_batch(vec![text])
+            .await?
+            .pop()
+            .ok_or_else(|| EncoderWorkerError::Encode("Encoder returned no embedding.".into()))
+    }
+
+    pub async fn encode_batch(
+        &self,
+        texts: Vec<String>,
+    ) -> Result<Vec<Vec<f32>>, EncoderWorkerError> {
         let (embedding_tx, mut embedding_rx) = tokio::sync::mpsc::channel(1);
-        self.guard.send(EncoderMsg::Encode(text, embedding_tx));
+        self.guard
+            .send(EncoderMsg::EncodeBatch(texts, embedding_tx));
         embedding_rx.recv().await.ok_or(EncoderWorkerError::Encode(
-            "Could not encode the text. Worker never responded.".into(),
+            "Could not encode the texts. Worker never responded.".into(),
         ))
     }
 }
 
 enum EncoderMsg {
-    Encode(String, tokio::sync::mpsc::Sender<Vec<f32>>),
+    EncodeBatch(Vec<String>, tokio::sync::mpsc::Sender<Vec<Vec<f32>>>),
 }
 
 fn process_worker_msg(
@@ -69,11 +85,23 @@ fn process_worker_msg(
     msg: EncoderMsg,
 ) -> Result<(), EncoderWorkerError> {
     match msg {
-        EncoderMsg::Encode(text, respond) => {
-            worker_state.reset_context();
-
-            let embedding = worker_state.read_string(text)?.get_embedding()?;
-            let _ = respond.blocking_send(embedding);
+        EncoderMsg::EncodeBatch(texts, respond) => {
+            let pooling = worker_state.extra.pooling;
+            let embeddings = worker_state
+                .engine
+                .read_strings_batched(texts, |ctx, sequence_id| {
+                    let embedding = if pooling == LlamaPoolingType::None {
+                        ctx.embeddings_ith(-1)?
+                    } else {
+                        ctx.embeddings_seq_ith(sequence_id)?
+                    };
+                    Ok::<_, llama_cpp_2::EmbeddingsError>(embedding.to_vec())
+                })
+                .map_err(|error| match error {
+                    BatchedReadError::Read(error) => EncoderWorkerError::Read(error),
+                    BatchedReadError::Output(error) => EncoderWorkerError::Embeddings(error),
+                })?;
+            let _ = respond.blocking_send(embeddings);
         }
     }
 
@@ -110,6 +138,7 @@ impl<'a> Worker<'a, EncoderWorker> {
         Worker::new_with_type(model, n_ctx, true, None, None, EncoderWorker { pooling })
     }
 
+    #[cfg(test)]
     pub fn get_embedding(&self) -> Result<Vec<f32>, llama_cpp_2::EmbeddingsError> {
         Ok(self.engine.ctx.embeddings_seq_ith(0)?.to_vec())
     }
@@ -215,6 +244,35 @@ mod tests {
             cosine_similarity(&copenhagen_embedding, &insult_embedding)
                 < cosine_similarity(&copenhagen_embedding, &berlin_embedding)
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encoder_batch_matches_individual_embeddings() -> Result<(), Box<dyn std::error::Error>>
+    {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_embeddings_model();
+        let encoder = Encoder::new(model, 20);
+        let texts = vec![
+            "Copenhagen is the capital of Denmark.".to_string(),
+            "Berlin is the capital of Germany.".to_string(),
+            "The weather is nice today.".to_string(),
+        ];
+
+        let individual = texts
+            .iter()
+            .map(|text| encoder.encode(text.clone()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let batched = encoder.encode_batch(texts)?;
+
+        assert_eq!(individual.len(), batched.len());
+        for (individual_embedding, batched_embedding) in individual.iter().zip(&batched) {
+            assert_eq!(individual_embedding.len(), batched_embedding.len());
+            assert!(individual_embedding.iter().zip(batched_embedding).all(
+                |(individual_value, batched_value)| (individual_value - batched_value).abs() < 1e-5
+            ));
+        }
 
         Ok(())
     }

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -13,6 +13,7 @@ use llama_cpp_2::mtmd::MtmdInputChunks;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::speculative::MtpSpeculative;
 use llama_cpp_2::token::LlamaToken;
+use std::ops::Range;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::MutexGuard;
@@ -101,14 +102,19 @@ impl<'a> EngineContext<'a> {
 }
 
 #[derive(Debug)]
+pub(crate) struct BatchCapacity {
+    pub(crate) tokens: usize,
+    pub(crate) sequences: usize,
+}
+
+#[derive(Debug)]
 pub(crate) struct InferenceEngine<'a> {
     pub(crate) ctx: EngineContext<'a>,
     projection_model: Option<&'a ProjectionModel>,
     n_past: i32,
     tokenizer: Tokenizer<'a>,
-    // The configured n_batch (= planned n_ctx before llama.cpp's internal rounding).
-    // Used to guard against sending more tokens than the context can decode in one batch.
-    n_batch: usize,
+    // Configured limits before llama.cpp's internal rounding.
+    batch_capacity: BatchCapacity,
     big_batch: LlamaBatch<'a>,
     small_batch: LlamaBatch<'a>,
     use_embeddings: bool,
@@ -130,17 +136,17 @@ impl<'a> InferenceEngine<'a> {
         big_batch: LlamaBatch<'a>,
         small_batch: LlamaBatch<'a>,
         projection_model: Option<&'a ProjectionModel>,
-        n_batch: usize,
+        batch_capacity: BatchCapacity,
         tokenizer: Tokenizer<'a>,
         use_embeddings: bool,
     ) -> Self {
         Self {
             n_past: 0,
             ctx,
+            batch_capacity,
             big_batch,
             small_batch,
             projection_model,
-            n_batch,
             tokenizer,
             use_embeddings,
             pending: None,
@@ -160,6 +166,75 @@ impl<'a> InferenceEngine<'a> {
     pub(crate) fn reset_mtp_stats(&mut self) {
         self.mtp_drafts_proposed = 0;
         self.mtp_drafts_accepted = 0;
+    }
+
+    pub(crate) fn read_strings_batched<T, E>(
+        &mut self,
+        texts: Vec<String>,
+        mut output_for_sequence: impl FnMut(&EngineContext<'a>, i32) -> Result<T, E>,
+    ) -> Result<Vec<T>, BatchedReadError<E>> {
+        let tokenized_inputs = texts
+            .into_iter()
+            .map(|text| {
+                let chunks = self.tokenize(text, vec![])?;
+                let mut tokens = vec![];
+                for chunk in chunks {
+                    match chunk {
+                        TokenizerChunk::Text(chunk_tokens, _) => tokens.extend(chunk_tokens),
+                        TokenizerChunk::Image(_, _) | TokenizerChunk::Audio(_, _) => {
+                            unreachable!("text tokenization produced media chunks")
+                        }
+                    }
+                }
+                Ok(tokens)
+            })
+            .collect::<Result<Vec<_>, crate::errors::TokenizationError>>()
+            .map_err(ReadError::FailedToTokenize)?;
+
+        let token_counts = tokenized_inputs.iter().map(Vec::len).collect::<Vec<_>>();
+        let ranges = embedding_batch_ranges(
+            &token_counts,
+            self.batch_capacity.tokens,
+            self.batch_capacity.sequences,
+        )?;
+        let mut outputs = Vec::with_capacity(tokenized_inputs.len());
+
+        for range in ranges {
+            self.big_batch.clear();
+            for (sequence_id, tokens) in tokenized_inputs[range.clone()].iter().enumerate() {
+                self.big_batch
+                    .add_sequence(tokens, sequence_id as i32, true)
+                    .map_err(ReadError::BatchAdd)?;
+            }
+
+            let n_tokens = self.big_batch.n_tokens();
+            let n_sequences = range.len();
+            let inference_lock_token = acquire_inference_lock();
+            self.reset_context();
+
+            let decode_span = debug_span!(
+                "read embedding batch",
+                n_tokens = n_tokens,
+                n_sequences = n_sequences
+            );
+            let decode_guard = decode_span.enter();
+            self.ctx
+                .decode(&mut self.big_batch)
+                .map_err(ReadError::Decode)?;
+            drop(decode_guard);
+
+            for sequence_id in 0..n_sequences {
+                outputs.push(
+                    output_for_sequence(&self.ctx, sequence_id as i32)
+                        .map_err(BatchedReadError::Output)?,
+                );
+            }
+            drop(inference_lock_token);
+
+            debug!(n_tokens, n_sequences, "Completed embedding batch");
+        }
+
+        Ok(outputs)
     }
 
     pub(crate) fn read_chunks(
@@ -233,10 +308,10 @@ impl<'a> InferenceEngine<'a> {
         // can't read nothing
         debug_assert!(!tokens.is_empty());
 
-        if n_tokens > self.n_batch {
+        if n_tokens > self.batch_capacity.tokens {
             return Err(ReadError::InputExceedsContext {
                 n_tokens,
-                n_ctx: self.n_batch,
+                n_ctx: self.batch_capacity.tokens,
             });
         }
 
@@ -523,5 +598,86 @@ impl<'a> InferenceEngine<'a> {
         emitted.push(pending);
         emitted.extend_from_slice(&accepted_drafts);
         Ok(emitted)
+    }
+}
+
+pub(crate) enum BatchedReadError<E> {
+    Read(ReadError),
+    Output(E),
+}
+
+impl<E> From<ReadError> for BatchedReadError<E> {
+    fn from(error: ReadError) -> Self {
+        Self::Read(error)
+    }
+}
+
+fn embedding_batch_ranges(
+    token_counts: &[usize],
+    n_batch: usize,
+    n_seq_max: usize,
+) -> Result<Vec<Range<usize>>, ReadError> {
+    let mut ranges = vec![];
+    let mut start = 0;
+
+    while start < token_counts.len() {
+        let mut end = start;
+        let mut n_tokens = 0;
+
+        while end < token_counts.len() && end - start < n_seq_max.max(1) {
+            let next_tokens = token_counts[end];
+            if next_tokens > n_batch {
+                return Err(ReadError::InputExceedsContext {
+                    n_tokens: next_tokens,
+                    n_ctx: n_batch,
+                });
+            }
+            if end > start && n_tokens + next_tokens > n_batch {
+                break;
+            }
+            n_tokens += next_tokens;
+            end += 1;
+        }
+
+        ranges.push(start..end);
+        start = end;
+    }
+
+    Ok(ranges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedding_batches_respect_token_capacity() {
+        assert_eq!(
+            embedding_batch_ranges(&[3, 4, 5], 7, 10).unwrap(),
+            vec![0..2, 2..3]
+        );
+    }
+
+    #[test]
+    fn embedding_batches_respect_sequence_capacity() {
+        assert_eq!(
+            embedding_batch_ranges(&[1, 1, 1, 1, 1], 10, 2).unwrap(),
+            vec![0..2, 2..4, 4..5]
+        );
+        assert_eq!(
+            embedding_batch_ranges(&[1, 1, 1], 10, 1).unwrap(),
+            vec![0..1, 1..2, 2..3]
+        );
+    }
+
+    #[test]
+    fn embedding_batches_reject_oversized_inputs() {
+        assert!(matches!(
+            embedding_batch_ranges(&[3, 8], 7, 10),
+            Err(ReadError::InputExceedsContext {
+                n_tokens: 8,
+                n_ctx: 7
+            })
+        ));
     }
 }

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -1,6 +1,10 @@
-use crate::errors::{InitWorkerError, LoadModelError, ReadError};
+#[cfg(test)]
+use crate::errors::ReadError;
+use crate::errors::{InitWorkerError, LoadModelError};
 use crate::huggingface::{download_gguf, parse_model_path};
-use crate::inference::{acquire_inference_lock, EngineContext, InferenceEngine};
+#[cfg(test)]
+use crate::inference::acquire_inference_lock;
+use crate::inference::{BatchCapacity, EngineContext, InferenceEngine};
 use crate::memory;
 use crate::model_selection;
 use crate::tokenizer::{ProjectionModel, Tokenizer};
@@ -33,6 +37,10 @@ lazy_static! {
 
 static LLAMA_BACKEND: LazyLock<LlamaBackend> =
     LazyLock::new(|| LlamaBackend::init().expect("Failed to initialize llama backend"));
+
+// llama.cpp rejects contexts above LLAMA_MAX_SEQ; llama_max_parallel_sequences()
+// returns 256 in the pinned version. llama-cpp-2 does not expose that function yet.
+const MAX_EMBEDDING_SEQUENCES: u32 = 256;
 
 #[derive(Debug)]
 pub struct Model {
@@ -338,7 +346,22 @@ where
             },
         )?;
         let planned_n_ctx = ctx_plan.n_ctx;
-        let n_ubatch = ctx_plan.n_ubatch;
+        let pooling_type = extra.pooling_type();
+        let n_seq_max = if use_embeddings
+            && !matches!(
+                pooling_type,
+                LlamaPoolingType::None | LlamaPoolingType::Unspecified
+            ) {
+            planned_n_ctx.min(MAX_EMBEDDING_SEQUENCES)
+        } else {
+            1
+        };
+        // llama.cpp cannot split non-causal embedding batches into micro-batches.
+        let n_ubatch = if n_seq_max > 1 {
+            planned_n_ctx
+        } else {
+            ctx_plan.n_ubatch
+        };
         for w in &ctx_plan.warnings {
             warn!("{}", w);
         }
@@ -347,16 +370,19 @@ where
             .with_n_ctx(std::num::NonZero::new(planned_n_ctx))
             .with_n_batch(planned_n_ctx) // n_batch sets the max size of a batch (i.e. max prompt size)
             .with_n_ubatch(n_ubatch)
+            .with_n_seq_max(n_seq_max)
             .with_n_threads(n_threads)
             .with_n_threads_batch(n_threads)
             .with_embeddings(use_embeddings)
-            .with_pooling_type(extra.pooling_type());
+            .with_pooling_type(pooling_type)
+            .with_kv_unified(n_seq_max > 1);
 
         let ctx = model
             .language_model
             .new_context(&LLAMA_BACKEND, ctx_params)?;
         let n_batch = planned_n_ctx as usize;
 
+        // The batch limit is sequence IDs per token; each embedding token belongs to one sequence.
         let big_batch = LlamaBatch::new(ctx.n_ctx() as usize, 1);
         let small_batch = LlamaBatch::new(1, 1);
 
@@ -404,20 +430,18 @@ where
             big_batch,
             small_batch,
             projection_model,
-            n_batch,
+            BatchCapacity {
+                tokens: n_batch,
+                sequences: n_seq_max as usize,
+            },
             tokenizer,
             use_embeddings,
         );
         Ok(Worker { engine, extra })
     }
 
-    /// Reset the KV cache and token count. Delegates to the inference engine.
-    pub fn reset_context(&mut self) -> &mut Self {
-        self.engine.reset_context();
-        self
-    }
-
     /// Tokenize `text` and read it into the context under the global inference lock.
+    #[cfg(test)]
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn read_string(&mut self, text: String) -> Result<&mut Self, ReadError> {
         let inference_lock_token = acquire_inference_lock();

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class NobodyWho
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -866820231;
+  int get rustContentHash => 829442270;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -104,6 +104,11 @@ abstract class NobodyWhoApi extends BaseApi {
   Future<Float32List> crateEncoderEncode({
     required Encoder that,
     required String text,
+  });
+
+  Future<List<Float32List>> crateEncoderEncodeBatch({
+    required Encoder that,
+    required List<String> texts,
   });
 
   Future<Encoder> crateEncoderFromPath({
@@ -829,6 +834,44 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   );
 
   @override
+  Future<List<Float32List>> crateEncoderEncodeBatch({
+    required Encoder that,
+    required List<String> texts,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEncoder(
+            that,
+            serializer,
+          );
+          sse_encode_list_String(texts, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 6,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_list_prim_f_32_strict,
+          decodeErrorData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEncoderWorkerError,
+        ),
+        constMeta: kCrateEncoderEncodeBatchConstMeta,
+        argValues: [that, texts],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateEncoderEncodeBatchConstMeta => const TaskConstMeta(
+    debugName: "Encoder_encode_batch",
+    argNames: ["that", "texts"],
+  );
+
+  @override
   Future<Encoder> crateEncoderFromPath({
     required String modelPath,
     FutureOr<void> Function(PlatformInt64, PlatformInt64) onDownloadProgress =
@@ -850,7 +893,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -882,7 +925,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_u_32(nCtx, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -925,7 +968,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -971,7 +1014,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -1003,7 +1046,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_String(message, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1036,7 +1079,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_String(json, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1070,7 +1113,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_list_prompt_part(parts, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1135,7 +1178,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -1197,7 +1240,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -1234,7 +1277,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -1270,7 +1313,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -1302,7 +1345,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -1339,7 +1382,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -1374,7 +1417,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -1430,7 +1473,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_opt_box_autoadd_mtp_config(mtp, serializer);
           sse_encode_opt_box_autoadd_u_32(threadCount, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1491,7 +1534,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1525,7 +1568,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1563,7 +1606,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1602,7 +1645,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1644,7 +1687,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1683,7 +1726,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1724,7 +1767,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1763,7 +1806,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1805,7 +1848,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1836,7 +1879,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1872,7 +1915,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1910,7 +1953,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1945,7 +1988,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1982,7 +2025,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 34,
+              funcId: 35,
               port: port_,
             );
           },
@@ -2017,7 +2060,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2051,7 +2094,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_String(source, serializer);
           sse_encode_opt_String(language, serializer);
           sse_encode_opt_String(quantization, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2084,7 +2127,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_String(path, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2119,7 +2162,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_list_prim_i_16_loose(samples, serializer);
           sse_encode_u_32(sampleRate, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2153,7 +2196,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -2191,7 +2234,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 40,
+              funcId: 41,
               port: port_,
             );
           },
@@ -2228,7 +2271,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -2259,7 +2302,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2287,7 +2330,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2326,7 +2369,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_i_32(allowedLength, serializer);
           sse_encode_i_32(penaltyLastN, serializer);
           sse_encode_list_String(seqBreakers, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2377,7 +2420,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_String(grammar, serializer);
           sse_encode_opt_String(triggerOn, serializer);
           sse_encode_String(root, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2406,7 +2449,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2441,7 +2484,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_f_32(minP, serializer);
           sse_encode_u_32(minKeep, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2478,7 +2521,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_f_32(tau, serializer);
           sse_encode_f_32(eta, serializer);
           sse_encode_i_32(m, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2514,7 +2557,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_f_32(tau, serializer);
           sse_encode_f_32(eta, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2540,7 +2583,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2577,7 +2620,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_f_32(penaltyRepeat, serializer);
           sse_encode_f_32(penaltyFreq, serializer);
           sse_encode_f_32(penaltyPresent, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2623,7 +2666,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_u_32(seed, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2656,7 +2699,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_f_32(temperature, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2690,7 +2733,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_i_32(topK, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2725,7 +2768,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_f_32(topP, serializer);
           sse_encode_u_32(minKeep, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2760,7 +2803,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           );
           sse_encode_f_32(typP, serializer);
           sse_encode_u_32(minKeep, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2798,7 +2841,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_f_32(xtcProbability, serializer);
           sse_encode_f_32(xtcThreshold, serializer);
           sse_encode_u_32(minKeep, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2824,7 +2867,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(jsonStr, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2853,7 +2896,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2880,7 +2923,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(grammar, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2909,7 +2952,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(schema, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2938,7 +2981,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(pattern, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2964,7 +3007,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2990,7 +3033,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3014,7 +3057,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(grammar, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3039,7 +3082,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3062,7 +3105,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3086,7 +3129,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_f_32(temperature, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3113,7 +3156,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_32(topK, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3139,7 +3182,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_f_32(topP, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3168,7 +3211,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3198,7 +3241,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3234,7 +3277,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             arguments,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3267,7 +3310,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             serializer,
           );
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3318,7 +3361,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3380,7 +3423,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3411,7 +3454,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_f_32_loose(a, serializer);
           sse_encode_list_prim_f_32_loose(b, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_32,
@@ -3447,7 +3490,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3473,7 +3516,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_record_string_usize,
@@ -3498,7 +3541,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -3523,7 +3566,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_box_autoadd_usize(maxCommands, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3555,7 +3598,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_opt_box_autoadd_u_64(maxDurationSecs, serializer);
           sse_encode_opt_box_autoadd_usize(maxMemoryBytes, serializer);
           sse_encode_opt_box_autoadd_usize(maxRecursionDepth, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3594,7 +3637,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           sse_encode_String(description, serializer);
           sse_encode_String(runtimeType, serializer);
           sse_encode_Map_String_String_None(parameterDescriptions, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3636,7 +3679,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_64(downloaded, serializer);
           sse_encode_i_64(total, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3665,7 +3708,7 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
             toolCall,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4621,6 +4664,14 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  List<Float32List> dco_decode_list_list_prim_f_32_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_list_prim_f_32_strict)
+        .toList();
   }
 
   @protected
@@ -5770,6 +5821,20 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
     var ans_ = <String>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<Float32List> sse_decode_list_list_prim_f_32_strict(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <Float32List>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_list_prim_f_32_strict(deserializer));
     }
     return ans_;
   }
@@ -7122,6 +7187,18 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
   }
 
   @protected
+  void sse_encode_list_list_prim_f_32_strict(
+    List<Float32List> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_list_prim_f_32_strict(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_message(List<Message> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
@@ -7630,6 +7707,10 @@ class EncoderImpl extends RustOpaque implements Encoder {
 
   Future<Float32List> encode({required String text}) =>
       NobodyWho.instance.api.crateEncoderEncode(that: this, text: text);
+
+  /// Encode multiple texts, preserving input order.
+  Future<List<Float32List>> encodeBatch({required List<String> texts}) =>
+      NobodyWho.instance.api.crateEncoderEncodeBatch(that: this, texts: texts);
 }
 
 @sealed

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.io.dart
@@ -524,6 +524,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   List<String> dco_decode_list_String(dynamic raw);
 
   @protected
+  List<Float32List> dco_decode_list_list_prim_f_32_strict(dynamic raw);
+
+  @protected
   List<Message> dco_decode_list_message(dynamic raw);
 
   @protected
@@ -1053,6 +1056,11 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<Float32List> sse_decode_list_list_prim_f_32_strict(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<Message> sse_decode_list_message(SseDeserializer deserializer);
@@ -1676,6 +1684,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_list_prim_f_32_strict(
+    List<Float32List> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_message(List<Message> self, SseSerializer serializer);

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.web.dart
@@ -526,6 +526,9 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
   List<String> dco_decode_list_String(dynamic raw);
 
   @protected
+  List<Float32List> dco_decode_list_list_prim_f_32_strict(dynamic raw);
+
+  @protected
   List<Message> dco_decode_list_message(dynamic raw);
 
   @protected
@@ -1055,6 +1058,11 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<Float32List> sse_decode_list_list_prim_f_32_strict(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<Message> sse_decode_list_message(SseDeserializer deserializer);
@@ -1678,6 +1686,12 @@ abstract class NobodyWhoApiImplPlatform extends BaseApiImpl<NobodyWhoWire> {
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_list_prim_f_32_strict(
+    List<Float32List> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_message(List<Message> self, SseSerializer serializer);

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -133,6 +133,9 @@ abstract class CrossEncoderWorkerError implements RustOpaqueInterface {}
 abstract class Encoder implements RustOpaqueInterface {
   Future<Float32List> encode({required String text});
 
+  /// Encode multiple texts, preserving input order.
+  Future<List<Float32List>> encodeBatch({required List<String> texts});
+
   /// Load an embedding model from a local path, HuggingFace path, or HTTPS URL.
   ///
   /// Args:

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -203,9 +203,14 @@ void main() {
       final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
       final embedding = await encoder.encode(text: "What is the weather like?");
       print("Vector with ${embedding.length} dimensions");
+      final texts = [
+        "Paris is the capital of France.",
+        "Berlin is the capital of Germany.",
+      ];
+      final embeddings = await encoder.encodeBatch(texts: texts);
     });
 
-    test('embeddings-and-rag.md:35', () async {
+    test('embeddings-and-rag.md:47', () async {
       final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
       
       final query = await encoder.encode(text: "How do I reset my password?");
@@ -225,7 +230,7 @@ void main() {
       print("Document 2 similarity: ${similarity2.toStringAsFixed(3)}");  // Lower score
     });
 
-    test('embeddings-and-rag.md:62', () async {
+    test('embeddings-and-rag.md:74', () async {
       final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
       
       // Your knowledge base
@@ -236,11 +241,8 @@ void main() {
         "Git is a version control system for tracking changes in source code"
       ];
       
-      // Pre-compute document embeddings
-      final docEmbeddings = <Float32List>[];
-      for (final doc in documents) {
-        docEmbeddings.add(await encoder.encode(text: doc));
-      }
+      // Pre-compute document embeddings in a batch
+      final docEmbeddings = await encoder.encodeBatch(texts: documents);
       
       // Search query
       final query = "What language should I use for database queries?";
@@ -264,7 +266,7 @@ void main() {
       print("Similarity score: ${maxSimilarity.toStringAsFixed(3)}");
     });
 
-    test('embeddings-and-rag.md:127', () async {
+    test('embeddings-and-rag.md:136', () async {
       // Download a reranking model like bge-reranker-v2-m3-Q8_0.gguf
       final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');
       
@@ -286,15 +288,15 @@ void main() {
       }
     });
 
-    test('embeddings-and-rag.md:166', () async {
+    test('embeddings-and-rag.md:175', () async {
       await _doctest_19();
     });
 
-    test('embeddings-and-rag.md:216', () async {
+    test('embeddings-and-rag.md:225', () async {
       await _doctest_20();
     });
 
-    test('embeddings-and-rag.md:263', () async {
+    test('embeddings-and-rag.md:272', () async {
       // For longer documents, increase context size
       final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
       
@@ -495,7 +497,7 @@ void main() {
   });
 }
 
-// Extracted from embeddings-and-rag.md:166
+// Extracted from embeddings-and-rag.md:175
 Future<void> _doctest_19() async {
   // Initialize the cross-encoder for document ranking
   final crossencoder = await nobodywho.CrossEncoder.fromPath(modelPath: './reranker-model.gguf');
@@ -536,7 +538,7 @@ Future<void> _doctest_19() async {
   print(response);
 }
 
-// Extracted from embeddings-and-rag.md:216
+// Extracted from embeddings-and-rag.md:225
 Future<void> _doctest_20() async {
   final encoder = await nobodywho.Encoder.fromPath(modelPath: './embedding-model.gguf');
   

--- a/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
+++ b/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
@@ -511,11 +511,19 @@ void main() {
 
       final encoder = await nobodywho.Encoder.fromPath(modelPath: modelPath);
       final embeddings = await encoder.encode(text: "Test text for embedding.");
+      final batched = await encoder.encodeBatch(
+        texts: ["Test text for embedding.", "Another text."],
+      );
 
       // Basic checks
       expect(embeddings, isA<List<double>>());
       expect(embeddings.length, greaterThan(0));
       expect(embeddings, isNotEmpty);
+      expect(batched.length, 2);
+      expect(batched.every((embedding) => embedding.length == embeddings.length), isTrue);
+      for (var i = 0; i < embeddings.length; i++) {
+        expect(batched.first[i], closeTo(embeddings[i], 1e-5));
+      }
 
       // Verify self-similarity is close to 1.0 (embeddings make sense)
       final selfSim = nobodywho.cosineSimilarity(a: embeddings, b: embeddings);

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -866820231;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 829442270;
 
 // Section: executor
 
@@ -312,6 +312,63 @@ fn wire__crate__Encoder_encode_impl(
                         }
                         let api_that_guard = api_that_guard.unwrap();
                         let output_ok = crate::Encoder::encode(&*api_that_guard, api_text).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__Encoder_encode_batch_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Encoder_encode_batch",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Encoder>,
+            >>::sse_decode(&mut deserializer);
+            let api_texts = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, EncoderWorkerError>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok =
+                            crate::Encoder::encode_batch(&*api_that_guard, api_texts).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -4819,6 +4876,18 @@ impl SseDecode for Vec<String> {
     }
 }
 
+impl SseDecode for Vec<Vec<f32>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<Vec<f32>>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::Message> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5211,37 +5280,38 @@ fn pde_ffi_dispatcher_primary_impl(
         3 => wire__crate__CrossEncoder_rank_impl(port, ptr, rust_vec_len, data_len),
         4 => wire__crate__CrossEncoder_rank_and_sort_impl(port, ptr, rust_vec_len, data_len),
         5 => wire__crate__Encoder_encode_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__Encoder_from_path_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__Model_load_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__Model_max_ctx_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__RustChat_from_path_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__RustChat_get_chat_history_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__RustChat_get_sampler_config_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__RustChat_get_stats_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__RustChat_get_system_prompt_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__RustChat_get_template_variables_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__RustChat_mtp_acceptance_rate_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__RustChat_reset_context_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__RustChat_reset_history_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__RustChat_set_allow_thinking_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__RustChat_set_chat_history_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__RustChat_set_sampler_config_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__RustChat_set_system_prompt_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__RustChat_set_template_variable_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__RustChat_set_template_variables_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__RustChat_set_tools_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__RustChat_tokenize_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__RustChat_tokenize_with_prompt_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__RustSttStream_completed_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__RustSttStream_iter_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__RustSttStream_next_token_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__RustTokenStream_completed_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__RustTokenStream_iter_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__RustTokenStream_next_token_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__Tts_load_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__Tts_synthesize_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__download_model_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__init_app_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__Encoder_encode_batch_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__Encoder_from_path_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__Model_load_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__Model_max_ctx_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__RustChat_from_path_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__RustChat_get_chat_history_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__RustChat_get_sampler_config_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__RustChat_get_stats_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__RustChat_get_system_prompt_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__RustChat_get_template_variables_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__RustChat_mtp_acceptance_rate_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__RustChat_reset_context_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__RustChat_reset_history_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__RustChat_set_allow_thinking_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__RustChat_set_chat_history_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__RustChat_set_sampler_config_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__RustChat_set_system_prompt_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__RustChat_set_template_variable_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__RustChat_set_template_variables_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__RustChat_set_tools_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__RustChat_tokenize_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__RustChat_tokenize_with_prompt_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__RustSttStream_completed_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__RustSttStream_iter_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__RustSttStream_next_token_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__RustTokenStream_completed_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__RustTokenStream_iter_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__RustTokenStream_next_token_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__Tts_load_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__Tts_synthesize_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__download_model_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__init_app_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5255,57 +5325,57 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__CrossEncoder_new_impl(ptr, rust_vec_len, data_len),
-        7 => wire__crate__Encoder_new_impl(ptr, rust_vec_len, data_len),
-        10 => wire__crate__RustChat_ask_impl(ptr, rust_vec_len, data_len),
-        11 => wire__crate__RustChat_ask_with_json_prompt_impl(ptr, rust_vec_len, data_len),
-        12 => wire__crate__RustChat_ask_with_prompt_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__RustChat_new_impl(ptr, rust_vec_len, data_len),
-        30 => wire__crate__RustChat_stop_generation_impl(ptr, rust_vec_len, data_len),
-        36 => wire__crate__RustStt_new__impl(ptr, rust_vec_len, data_len),
-        37 => wire__crate__RustStt_transcribe_file_impl(ptr, rust_vec_len, data_len),
-        38 => wire__crate__RustStt_transcribe_pcm_impl(ptr, rust_vec_len, data_len),
-        42 => wire__crate__RustTool_get_schema_json_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__SamplerBuilder_dist_impl(ptr, rust_vec_len, data_len),
-        44 => wire__crate__SamplerBuilder_dry_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__SamplerBuilder_grammar_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__SamplerBuilder_greedy_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__SamplerBuilder_min_p_impl(ptr, rust_vec_len, data_len),
-        48 => wire__crate__SamplerBuilder_mirostat_v1_impl(ptr, rust_vec_len, data_len),
-        49 => wire__crate__SamplerBuilder_mirostat_v2_impl(ptr, rust_vec_len, data_len),
-        50 => wire__crate__SamplerBuilder_new_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__SamplerBuilder_penalties_impl(ptr, rust_vec_len, data_len),
-        52 => wire__crate__SamplerBuilder_seed_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__SamplerBuilder_temperature_impl(ptr, rust_vec_len, data_len),
-        54 => wire__crate__SamplerBuilder_top_k_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__SamplerBuilder_top_p_impl(ptr, rust_vec_len, data_len),
-        56 => wire__crate__SamplerBuilder_typical_p_impl(ptr, rust_vec_len, data_len),
-        57 => wire__crate__SamplerBuilder_xtc_impl(ptr, rust_vec_len, data_len),
-        58 => wire__crate__SamplerConfig_from_json_impl(ptr, rust_vec_len, data_len),
-        59 => wire__crate__SamplerConfig_to_json_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__SamplerPresets_constrain_with_grammar_impl(ptr, rust_vec_len, data_len),
-        61 => {
+        8 => wire__crate__Encoder_new_impl(ptr, rust_vec_len, data_len),
+        11 => wire__crate__RustChat_ask_impl(ptr, rust_vec_len, data_len),
+        12 => wire__crate__RustChat_ask_with_json_prompt_impl(ptr, rust_vec_len, data_len),
+        13 => wire__crate__RustChat_ask_with_prompt_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__RustChat_new_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__RustChat_stop_generation_impl(ptr, rust_vec_len, data_len),
+        37 => wire__crate__RustStt_new__impl(ptr, rust_vec_len, data_len),
+        38 => wire__crate__RustStt_transcribe_file_impl(ptr, rust_vec_len, data_len),
+        39 => wire__crate__RustStt_transcribe_pcm_impl(ptr, rust_vec_len, data_len),
+        43 => wire__crate__RustTool_get_schema_json_impl(ptr, rust_vec_len, data_len),
+        44 => wire__crate__SamplerBuilder_dist_impl(ptr, rust_vec_len, data_len),
+        45 => wire__crate__SamplerBuilder_dry_impl(ptr, rust_vec_len, data_len),
+        46 => wire__crate__SamplerBuilder_grammar_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__SamplerBuilder_greedy_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__SamplerBuilder_min_p_impl(ptr, rust_vec_len, data_len),
+        49 => wire__crate__SamplerBuilder_mirostat_v1_impl(ptr, rust_vec_len, data_len),
+        50 => wire__crate__SamplerBuilder_mirostat_v2_impl(ptr, rust_vec_len, data_len),
+        51 => wire__crate__SamplerBuilder_new_impl(ptr, rust_vec_len, data_len),
+        52 => wire__crate__SamplerBuilder_penalties_impl(ptr, rust_vec_len, data_len),
+        53 => wire__crate__SamplerBuilder_seed_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__SamplerBuilder_temperature_impl(ptr, rust_vec_len, data_len),
+        55 => wire__crate__SamplerBuilder_top_k_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__SamplerBuilder_top_p_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__SamplerBuilder_typical_p_impl(ptr, rust_vec_len, data_len),
+        58 => wire__crate__SamplerBuilder_xtc_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__SamplerConfig_from_json_impl(ptr, rust_vec_len, data_len),
+        60 => wire__crate__SamplerConfig_to_json_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__SamplerPresets_constrain_with_grammar_impl(ptr, rust_vec_len, data_len),
+        62 => {
             wire__crate__SamplerPresets_constrain_with_json_schema_impl(ptr, rust_vec_len, data_len)
         }
-        62 => wire__crate__SamplerPresets_constrain_with_regex_impl(ptr, rust_vec_len, data_len),
-        63 => wire__crate__SamplerPresets_default_sampler_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__SamplerPresets_dry_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__SamplerPresets_grammar_impl(ptr, rust_vec_len, data_len),
-        66 => wire__crate__SamplerPresets_greedy_impl(ptr, rust_vec_len, data_len),
-        67 => wire__crate__SamplerPresets_json_impl(ptr, rust_vec_len, data_len),
-        68 => wire__crate__SamplerPresets_temperature_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__SamplerPresets_top_k_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__SamplerPresets_top_p_impl(ptr, rust_vec_len, data_len),
-        71 => wire__crate__ToolCall_auto_accessor_get_arguments_impl(ptr, rust_vec_len, data_len),
-        72 => wire__crate__ToolCall_auto_accessor_get_name_impl(ptr, rust_vec_len, data_len),
-        73 => wire__crate__ToolCall_auto_accessor_set_arguments_impl(ptr, rust_vec_len, data_len),
-        74 => wire__crate__ToolCall_auto_accessor_set_name_impl(ptr, rust_vec_len, data_len),
-        77 => wire__crate__cosine_similarity_impl(ptr, rust_vec_len, data_len),
-        79 => wire__crate__get_cached_models_impl(ptr, rust_vec_len, data_len),
-        81 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
-        82 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
-        83 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
-        84 => wire__crate__noop_on_download_progress_impl(ptr, rust_vec_len, data_len),
-        85 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
+        63 => wire__crate__SamplerPresets_constrain_with_regex_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__SamplerPresets_default_sampler_impl(ptr, rust_vec_len, data_len),
+        65 => wire__crate__SamplerPresets_dry_impl(ptr, rust_vec_len, data_len),
+        66 => wire__crate__SamplerPresets_grammar_impl(ptr, rust_vec_len, data_len),
+        67 => wire__crate__SamplerPresets_greedy_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__SamplerPresets_json_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__SamplerPresets_temperature_impl(ptr, rust_vec_len, data_len),
+        70 => wire__crate__SamplerPresets_top_k_impl(ptr, rust_vec_len, data_len),
+        71 => wire__crate__SamplerPresets_top_p_impl(ptr, rust_vec_len, data_len),
+        72 => wire__crate__ToolCall_auto_accessor_get_arguments_impl(ptr, rust_vec_len, data_len),
+        73 => wire__crate__ToolCall_auto_accessor_get_name_impl(ptr, rust_vec_len, data_len),
+        74 => wire__crate__ToolCall_auto_accessor_set_arguments_impl(ptr, rust_vec_len, data_len),
+        75 => wire__crate__ToolCall_auto_accessor_set_name_impl(ptr, rust_vec_len, data_len),
+        78 => wire__crate__cosine_similarity_impl(ptr, rust_vec_len, data_len),
+        80 => wire__crate__get_cached_models_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__new_bash_tool_impl(ptr, rust_vec_len, data_len),
+        83 => wire__crate__new_python_tool_impl(ptr, rust_vec_len, data_len),
+        84 => wire__crate__new_tool_impl_impl(ptr, rust_vec_len, data_len),
+        85 => wire__crate__noop_on_download_progress_impl(ptr, rust_vec_len, data_len),
+        86 => wire__crate__tool_call_arguments_json_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6249,6 +6319,16 @@ impl SseEncode for Vec<String> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <String>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<Vec<f32>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <Vec<f32>>::sse_encode(item, serializer);
         }
     }
 }

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -852,6 +852,14 @@ impl Encoder {
     ) -> Result<Vec<f32>, nobodywho::errors::EncoderWorkerError> {
         self.handle.encode(text).await
     }
+
+    /// Encode multiple texts, preserving input order.
+    pub async fn encode_batch(
+        &self,
+        texts: Vec<String>,
+    ) -> Result<Vec<Vec<f32>>, nobodywho::errors::EncoderWorkerError> {
+        self.handle.encode_batch(texts).await
+    }
 }
 
 #[flutter_rust_bridge::frb(opaque)]

--- a/nobodywho/godot/integration-test/encoder.gd
+++ b/nobodywho/godot/integration-test/encoder.gd
@@ -14,6 +14,16 @@ func run_test():
 	encode("This doesn't matter.")
 	var irrelevant_enc = await self.encoding_finished
 
+	var batch_texts = PackedStringArray([
+		"The dragon is on the hill.",
+		"The dragon is hungry for humans.",
+	])
+	var batched_embeddings = await encode_batch(batch_texts)
+	assert(batched_embeddings.size() == batch_texts.size())
+	assert(batched_embeddings[0].size() == dragon_hill_enc.size())
+	for index in dragon_hill_enc.size():
+		assert(is_equal_approx(batched_embeddings[0][index], dragon_hill_enc[index]))
+
 	# test similarity
 	var low_similarity = cosine_similarity(irrelevant_enc, dragon_hill_enc)
 	var high_similarity = cosine_similarity(dragon_hill_enc, dragon_hungry_enc) 

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -2454,12 +2454,16 @@ impl NobodyWhoEncoder {
     fn encoding_finished(encoding: PackedFloat32Array);
 
     #[signal]
+    /// Triggered when batch encoding has finished. Returns one encoding per input text.
+    fn batch_encoding_finished(encodings: Array<PackedFloat32Array>);
+
+    #[signal]
     /// Emitted once the encoder worker has finished loading (including any model download)
     /// and is ready to accept `encode()` calls.
     fn worker_started();
 
     #[signal]
-    /// Emitted if loading the model (or setting up the encoder worker) failed.
+    /// Emitted if loading the model, setting up the worker, or encoding failed.
     fn worker_failed(error: GString);
 
     /// Load the model and create the encoder worker. `yield_now()` ensures the
@@ -2573,6 +2577,90 @@ impl NobodyWhoEncoder {
 
         // returns signal, so that you can `var vec = await encode("Hello, world!")`
         godot::builtin::Signal::from_object_signal(&self.base_mut(), "encoding_finished")
+    }
+
+    #[func]
+    /// Generates encodings for multiple texts in input order.
+    /// Returns a signal that emits an Array of PackedFloat32Array values.
+    /// Failures emit `worker_failed` and complete with an empty Array.
+    fn encode_batch(&mut self, texts: PackedStringArray) -> Signal {
+        let existing_handle = self.encoder_handle.clone();
+        let model_node = if existing_handle.is_none() {
+            godot_warn!("Worker was not started yet, starting now... You may want to call `start_worker()` ahead of time to avoid waiting.");
+            match self.model_node.clone() {
+                Some(node) => Some(node),
+                None => {
+                    let error = GString::from("Model node was not set");
+                    godot_error!("encode_batch() dropped: {}", error);
+                    let emit_node = self.to_gd();
+                    godot::task::spawn(async move {
+                        emit_node.signals().worker_failed().emit(&error);
+                        emit_node
+                            .signals()
+                            .batch_encoding_finished()
+                            .emit(&Array::new());
+                    });
+                    return godot::builtin::Signal::from_object_signal(
+                        &self.base_mut(),
+                        "batch_encoding_finished",
+                    );
+                }
+            }
+        } else {
+            None
+        };
+
+        let texts = texts
+            .to_vec()
+            .into_iter()
+            .map(|text| text.to_string())
+            .collect();
+        let me = self.to_gd();
+        let emit_node = me.clone();
+        godot::task::spawn(async move {
+            let encoder_handle = match existing_handle {
+                Some(handle) => handle,
+                None => {
+                    let model_node = model_node.expect("model_node set when no existing handle");
+                    match Self::load_and_store_worker(me, model_node).await {
+                        Ok(handle) => handle,
+                        Err(error) => {
+                            godot_error!("encode_batch() dropped: {}", error);
+                            emit_node.signals().worker_failed().emit(&error);
+                            emit_node
+                                .signals()
+                                .batch_encoding_finished()
+                                .emit(&Array::new());
+                            return;
+                        }
+                    }
+                }
+            };
+            match encoder_handle.encode_batch(texts).await {
+                Ok(encodings) => {
+                    let encodings = encodings
+                        .into_iter()
+                        .map(PackedFloat32Array::from)
+                        .collect::<Array<_>>();
+                    emit_node
+                        .signals()
+                        .batch_encoding_finished()
+                        .emit(&encodings);
+                }
+                Err(error) => {
+                    let error = error.to_string();
+                    let error = GString::from(&error);
+                    godot_error!("Failed generating encodings: {}", error);
+                    emit_node.signals().worker_failed().emit(&error);
+                    emit_node
+                        .signals()
+                        .batch_encoding_finished()
+                        .emit(&Array::new());
+                }
+            }
+        });
+
+        godot::builtin::Signal::from_object_signal(&self.base_mut(), "batch_encoding_finished")
     }
 
     #[func]

--- a/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
+++ b/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
@@ -761,6 +761,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(
     ): Short
+    external fun uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(
+    ): Short
     external fun uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx(
     ): Short
     external fun uniffi_nobodywho_uniffi_checksum_method_ruststt_transcribe_file(
@@ -918,6 +920,8 @@ external fun uniffi_nobodywho_uniffi_fn_free_rustencoder(`handle`: Long,uniffi_o
 external fun uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(`model`: Long,`contextSize`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(`ptr`: Long,`text`: RustBuffer.ByValue,
+): Long
+external fun uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(`ptr`: Long,`texts`: RustBuffer.ByValue,
 ): Long
 external fun uniffi_nobodywho_uniffi_fn_clone_rustmodel(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
@@ -1284,6 +1288,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode() != 52601.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch() != 20675.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx() != 52004.toShort()) {
@@ -3056,6 +3063,11 @@ public interface RustEncoderInterface {
      */
     suspend fun `encode`(`text`: kotlin.String): List<kotlin.Float>
     
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+    suspend fun `encodeBatch`(`texts`: List<kotlin.String>): List<List<kotlin.Float>>
+    
     companion object
 }
 
@@ -3185,6 +3197,30 @@ open class RustEncoder: Disposable, AutoCloseable, RustEncoderInterface
         { future -> UniffiLib.ffi_nobodywho_uniffi_rust_future_free_rust_buffer(future) },
         // lift function
         { FfiConverterSequenceFloat.lift(it) },
+        // Error FFI converter
+        NobodyWhoException.ErrorHandler,
+    )
+    }
+
+    
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+    @Throws(NobodyWhoException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `encodeBatch`(`texts`: List<kotlin.String>) : List<List<kotlin.Float>> {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+                uniffiHandle,
+                FfiConverterSequenceString.lower(`texts`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_nobodywho_uniffi_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_nobodywho_uniffi_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_nobodywho_uniffi_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterSequenceSequenceFloat.lift(it) },
         // Error FFI converter
         NobodyWhoException.ErrorHandler,
     )
@@ -7206,6 +7242,34 @@ public object FfiConverterSequenceOptionalInt: FfiConverterRustBuffer<List<kotli
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterOptionalInt.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceSequenceFloat: FfiConverterRustBuffer<List<List<kotlin.Float>>> {
+    override fun read(buf: ByteBuffer): List<List<kotlin.Float>> {
+        val len = buf.getInt()
+        return List<List<kotlin.Float>>(len) {
+            FfiConverterSequenceFloat.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<List<kotlin.Float>>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterSequenceFloat.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<List<kotlin.Float>>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterSequenceFloat.write(it, buf)
         }
     }
 }

--- a/nobodywho/kotlin/common/src/Encoder.kt
+++ b/nobodywho/kotlin/common/src/Encoder.kt
@@ -28,6 +28,9 @@ class Encoder(
 
     suspend fun encode(text: String): List<Float> = inner.encode(text)
 
+    /** Encode multiple texts, preserving input order. */
+    suspend fun encodeBatch(texts: List<String>): List<List<Float>> = inner.encodeBatch(texts)
+
     /** Free the underlying Rust resources. */
     fun destroy() = inner.destroy()
     override fun close() { destroy() }

--- a/nobodywho/kotlin/common/test/IntegrationTest.kt
+++ b/nobodywho/kotlin/common/test/IntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assume
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
+import kotlin.math.abs
 
 fun ping(): String = "pong"
 suspend fun suspendPing(): String { delay(1); return "async pong" }
@@ -103,6 +104,22 @@ class IntegrationTest {
         val chat = Chat(model = model, templateVariables = mapOf("enable_thinking" to false))
         val tokens = chat.tokenize("Hey!")
         assertEquals(listOf<Int?>(18665, 0), tokens)
+    }
+
+    @Test
+    fun testEncoderBatch() = runBlocking {
+        val modelPath = requireEnv("TEST_EMBEDDINGS_MODEL")
+        val model = Model.load(modelPath = modelPath, useGpu = false)
+        val encoder = Encoder(model = model, contextSize = 1024u)
+        val texts = listOf("Copenhagen is in Denmark.", "Berlin is in Germany.")
+        val individual = texts.map { text -> encoder.encode(text = text) }
+        val batched = encoder.encodeBatch(texts = texts)
+
+        assertEquals(texts.size, batched.size)
+        individual.zip(batched).forEach { (expected, actual) ->
+            assertEquals(expected.size, actual.size)
+            assertTrue(expected.zip(actual).all { (a, b) -> abs(a - b) < 1e-5f })
+        }
     }
 
     @Test

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -626,7 +626,7 @@ class Encoder:
     `Encoder` will let you generate vector representations of text.
     It must be initialized with a model that specifically supports generating embeddings.
     A regular chat/text-generation model will not just work.
-    Once initialized, you can call `.encode()` on a string, which returns a list of 32-bit floats.
+    Once initialized, call `.encode()` for one string or `.encode_batch()` for multiple strings.
     See `EncoderAsync` for the async version of this class.
     """
     def __new__(
@@ -654,6 +654,19 @@ class Encoder:
 
         Returns:
             A list of floats representing the embedding vector
+
+        Raises:
+            RuntimeError: If encoding fails
+        """
+    def encode_batch(self, /, texts: Sequence[str]) -> list[list[float]]:
+        """
+        Generate embedding vectors for multiple texts in input order. This method blocks until complete.
+
+        Args:
+            texts: The texts to encode
+
+        Returns:
+            One embedding vector per input text, in input order
 
         Raises:
             RuntimeError: If encoding fails
@@ -689,6 +702,19 @@ class EncoderAsync:
 
         Returns:
             A list of floats representing the embedding vector
+
+        Raises:
+            RuntimeError: If encoding fails
+        """
+    async def encode_batch(self, /, texts: Sequence[str]) -> list[list[float]]:
+        """
+        Generate embedding vectors for multiple texts asynchronously.
+
+        Args:
+            texts: The texts to encode
+
+        Returns:
+            One embedding vector per input text, in input order
 
         Raises:
             RuntimeError: If encoding fails

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -668,7 +668,7 @@ impl TokenStreamAsync {
 /// `Encoder` will let you generate vector representations of text.
 /// It must be initialized with a model that specifically supports generating embeddings.
 /// A regular chat/text-generation model will not just work.
-/// Once initialized, you can call `.encode()` on a string, which returns a list of 32-bit floats.
+/// Once initialized, call `.encode()` for one string or `.encode_batch()` for multiple strings.
 /// See `EncoderAsync` for the async version of this class.
 #[pyclass]
 pub struct Encoder {
@@ -726,6 +726,24 @@ impl Encoder {
         py.detach(|| {
             self.inner()
                 .encode(text)
+                .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{}", e)))
+        })
+    }
+
+    /// Generate embedding vectors for multiple texts in input order. This method blocks until complete.
+    ///
+    /// Args:
+    ///     texts: The texts to encode
+    ///
+    /// Returns:
+    ///     One embedding vector per input text, in input order
+    ///
+    /// Raises:
+    ///     RuntimeError: If encoding fails
+    pub fn encode_batch(&self, texts: Vec<String>, py: Python) -> PyResult<Vec<Vec<f32>>> {
+        py.detach(|| {
+            self.inner()
+                .encode_batch(texts)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{}", e)))
         })
     }
@@ -790,6 +808,24 @@ impl EncoderAsync {
         self.inner().encode(text).await.map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
                 "Failed to receive embedding: {e}"
+            ))
+        })
+    }
+
+    /// Generate embedding vectors for multiple texts asynchronously.
+    ///
+    /// Args:
+    ///     texts: The texts to encode
+    ///
+    /// Returns:
+    ///     One embedding vector per input text, in input order
+    ///
+    /// Raises:
+    ///     RuntimeError: If encoding fails
+    async fn encode_batch(&self, texts: Vec<String>) -> PyResult<Vec<Vec<f32>>> {
+        self.inner().encode_batch(texts).await.map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to receive embeddings: {e}"
             ))
         })
     }

--- a/nobodywho/python/tests/test_nobodywho.py
+++ b/nobodywho/python/tests/test_nobodywho.py
@@ -141,6 +141,16 @@ def test_encoder_sync(encoder):
     )
 
 
+def test_encoder_batch_sync(encoder):
+    texts = ["Copenhagen is in Denmark.", "Berlin is in Germany."]
+    individual = [encoder.encode(text) for text in texts]
+    batched = encoder.encode_batch(texts)
+
+    assert len(batched) == len(texts)
+    for expected, actual in zip(individual, batched, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-5)
+
+
 @pytest.mark.asyncio
 async def test_encoder_async(encoder_model):
     """Test that encoder can generate embeddings using async API"""
@@ -153,6 +163,18 @@ async def test_encoder_async(encoder_model):
     assert all(isinstance(x, float) for x in embedding), (
         "All embedding values should be floats"
     )
+
+
+@pytest.mark.asyncio
+async def test_encoder_batch_async(encoder_model):
+    encoder = nobodywho.EncoderAsync(encoder_model, n_ctx=1024)
+    texts = ["Copenhagen is in Denmark.", "Berlin is in Germany."]
+    individual = [await encoder.encode(text) for text in texts]
+    batched = await encoder.encode_batch(texts)
+
+    assert len(batched) == len(texts)
+    for expected, actual in zip(individual, batched, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-5)
 
 
 def test_cosine_similarity():

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -190,6 +190,8 @@ void uniffi_nobodywho_uniffi_fn_free_rustencoder(
     RustCallStatus *uniffi_out_err);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(
     /*handle*/ uint64_t ptr, RustBuffer text);
+/*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+    /*handle*/ uint64_t ptr, RustBuffer texts);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_clone_rustmodel(
     /*handle*/ uint64_t handle, RustCallStatus *uniffi_out_err);
 void uniffi_nobodywho_uniffi_fn_free_rustmodel(
@@ -522,6 +524,7 @@ uint16_t uniffi_nobodywho_uniffi_checksum_method_rustcrossencoder_rank();
 uint16_t
 uniffi_nobodywho_uniffi_checksum_method_rustcrossencoder_rank_and_sort_json();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode();
+uint16_t uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_ruststt_transcribe_file();
 uint16_t uniffi_nobodywho_uniffi_checksum_method_ruststt_transcribe_pcm();
@@ -3082,6 +3085,18 @@ NativeNobodywho::NativeNobodywho(
                 ->cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(
                     rt, thisVal, args, count);
           });
+  props["ubrn_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, "ubrn_uniffi_nobodywho_uniffi_fn_"
+                                        "method_rustencoder_encode_batch"),
+          2,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this
+                ->cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+                    rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_nobodywho_uniffi_fn_clone_rustmodel"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -4869,6 +4884,18 @@ NativeNobodywho::NativeNobodywho(
                 ->cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(
                     rt, thisVal, args, count);
           });
+  props["ubrn_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_"
+        "batch"] = jsi::Function::createFromHostFunction(
+      rt,
+      jsi::PropNameID::forAscii(rt, "ubrn_uniffi_nobodywho_uniffi_checksum_"
+                                    "method_rustencoder_encode_batch"),
+      0,
+      [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+             const jsi::Value *args, size_t count) -> jsi::Value {
+        return this
+            ->cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(
+                rt, thisVal, args, count);
+      });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -6152,6 +6179,19 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(
+      uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker,
+                                                        args[0]),
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker,
+                                                      args[1]));
+
+  return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker,
+                                                         value);
+}
+jsi::Value
+NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
       uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker,
                                                         args[0]),
       uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker,
@@ -8053,6 +8093,15 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeNobodywho::
+    cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(
+        jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+        size_t count) {
+  auto value =
+      uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/nobodywho/react-native/generated/cpp/nobodywho.hpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.hpp
@@ -127,6 +127,9 @@ protected:
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
+  jsi::Value cpp_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_clone_rustmodel(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -608,6 +611,10 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value
+  cpp_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx(

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -49,6 +49,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_fn_free_rustencoder(handle: bigint, uniffi_out_err: UniffiRustCallStatus): void;
     ubrn_uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(model: bigint, contextSize: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(ptr: bigint, text: Uint8Array): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(ptr: bigint, texts: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_clone_rustmodel(handle: bigint, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_free_rustmodel(handle: bigint, uniffi_out_err: UniffiRustCallStatus): void;
     ubrn_uniffi_nobodywho_uniffi_fn_method_rustmodel_max_ctx(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): number;
@@ -202,6 +203,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rustcrossencoder_rank(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rustcrossencoder_rank_and_sort_json(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(): number;
+    ubrn_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_ruststt_transcribe_file(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_method_ruststt_transcribe_pcm(): number;

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -2384,6 +2384,10 @@ export interface RustEncoderInterface {
      * Encode text into an embedding vector.
      */
     encode(text: string, asyncOpts_?: { signal: AbortSignal })  /*throws*/: Promise<Array</*f32*/number>>;
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+    encodeBatch(texts: Array<string>, asyncOpts_?: { signal: AbortSignal })  /*throws*/: Promise<Array<Array</*f32*/number>>>;
 }
 
 
@@ -2433,6 +2437,37 @@ async  encode(text: string, asyncOpts_?: { signal: AbortSignal }): Promise<Array
             /*completeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_complete_rust_buffer,
             /*freeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_free_rust_buffer,
             /*liftFunc:*/ FfiConverterArrayFloat32.lift.bind(FfiConverterArrayFloat32),
+            /*liftString:*/ FfiConverterString.lift,
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+    
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+async  encodeBatch(texts: Array<string>, asyncOpts_?: { signal: AbortSignal }): Promise<Array<Array</*f32*/number>>> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+                    uniffiTypeRustEncoderObjectFactory.clonePointer(this),
+                    FfiConverterArrayString.lower(texts)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_poll_rust_buffer,
+            /*cancelFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_cancel_rust_buffer,
+            /*completeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_complete_rust_buffer,
+            /*freeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_free_rust_buffer,
+            /*liftFunc:*/ FfiConverterArrayArrayFloat32.lift.bind(FfiConverterArrayArrayFloat32),
             /*liftString:*/ FfiConverterString.lift,
             /*asyncOpts:*/ asyncOpts_,
             /*errorHandler:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError)
@@ -4093,6 +4128,10 @@ const FfiConverterArrayTypeRustTool = new FfiConverterArray(FfiConverterTypeRust
 const FfiConverterArrayOptionalInt32 = new FfiConverterArray(FfiConverterOptionalInt32);
 
 
+// FfiConverter for Array<Array</*f32*/number>>
+const FfiConverterArrayArrayFloat32 = new FfiConverterArray(FfiConverterArrayFloat32);
+
+
 // FfiConverter for Array<RustToolInterface> | undefined
 const FfiConverterOptionalArrayTypeRustTool = new FfiConverterOptional(FfiConverterArrayTypeRustTool);
 
@@ -4227,6 +4266,9 @@ function uniffiEnsureInitialized() {
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode() !== 52601) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode");
+    }
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch() !== 20675) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx() !== 52004) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx");

--- a/nobodywho/react-native/src/encoder.ts
+++ b/nobodywho/react-native/src/encoder.ts
@@ -46,6 +46,11 @@ export class Encoder {
     return this._inner.encode(text);
   }
 
+  /** Encode multiple texts, preserving input order. */
+  async encodeBatch(texts: string[]): Promise<number[][]> {
+    return this._inner.encodeBatch(texts);
+  }
+
   /**
    * Immediately free the underlying Rust resources.
    * After calling this, the Encoder instance is no longer usable.

--- a/nobodywho/swift/generated/nobodywho.swift
+++ b/nobodywho/swift/generated/nobodywho.swift
@@ -1350,6 +1350,11 @@ public protocol RustEncoderProtocol: AnyObject, Sendable {
      */
     func encode(text: String) async throws  -> [Float]
     
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+    func encodeBatch(texts: [String]) async throws  -> [[Float]]
+    
 }
 open class RustEncoder: RustEncoderProtocol, @unchecked Sendable {
     fileprivate let handle: UInt64
@@ -1427,6 +1432,26 @@ open func encode(text: String)async throws  -> [Float]  {
             completeFunc: ffi_nobodywho_uniffi_rust_future_complete_rust_buffer,
             freeFunc: ffi_nobodywho_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterSequenceFloat.lift,
+            errorHandler: FfiConverterTypeNobodyWhoError_lift
+        )
+}
+    
+    /**
+     * Encode multiple texts into embedding vectors, preserving input order.
+     */
+open func encodeBatch(texts: [String])async throws  -> [[Float]]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(
+                    self.uniffiCloneHandle(),
+                    FfiConverterSequenceString.lower(texts)
+                )
+            },
+            pollFunc: ffi_nobodywho_uniffi_rust_future_poll_rust_buffer,
+            completeFunc: ffi_nobodywho_uniffi_rust_future_complete_rust_buffer,
+            freeFunc: ffi_nobodywho_uniffi_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceSequenceFloat.lift,
             errorHandler: FfiConverterTypeNobodyWhoError_lift
         )
 }
@@ -4389,6 +4414,31 @@ fileprivate struct FfiConverterSequenceOptionInt32: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceSequenceFloat: FfiConverterRustBuffer {
+    typealias SwiftType = [[Float]]
+
+    public static func write(_ value: [[Float]], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterSequenceFloat.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [[Float]] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [[Float]]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterSequenceFloat.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterDictionaryStringBool: FfiConverterRustBuffer {
     public static func write(_ value: [String: Bool], into buf: inout [UInt8]) {
         let len = Int32(value.count)
@@ -4805,6 +4855,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode() != 52601) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch() != 20675) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_method_rustmodel_max_ctx() != 52004) {

--- a/nobodywho/swift/generated/nobodywhoFFI.h
+++ b/nobodywho/swift/generated/nobodywhoFFI.h
@@ -430,6 +430,11 @@ uint64_t uniffi_nobodywho_uniffi_fn_constructor_rustencoder_new(uint64_t model, 
 uint64_t uniffi_nobodywho_uniffi_fn_method_rustencoder_encode(uint64_t ptr, RustBuffer text
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_METHOD_RUSTENCODER_ENCODE_BATCH
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_METHOD_RUSTENCODER_ENCODE_BATCH
+uint64_t uniffi_nobodywho_uniffi_fn_method_rustencoder_encode_batch(uint64_t ptr, RustBuffer texts
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_CLONE_RUSTMODEL
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_CLONE_RUSTMODEL
 uint64_t uniffi_nobodywho_uniffi_fn_clone_rustmodel(uint64_t handle, RustCallStatus *_Nonnull out_status
@@ -1256,6 +1261,12 @@ uint16_t uniffi_nobodywho_uniffi_checksum_method_rustcrossencoder_rank_and_sort_
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_METHOD_RUSTENCODER_ENCODE
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_METHOD_RUSTENCODER_ENCODE
 uint16_t uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_METHOD_RUSTENCODER_ENCODE_BATCH
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_METHOD_RUSTENCODER_ENCODE_BATCH
+uint16_t uniffi_nobodywho_uniffi_checksum_method_rustencoder_encode_batch(void
     
 );
 #endif

--- a/nobodywho/swift/src/Encoder.swift
+++ b/nobodywho/swift/src/Encoder.swift
@@ -31,4 +31,9 @@ public class Encoder {
     public func encode(_ text: String) async throws -> [Float] {
         return try await inner.encode(text: text)
     }
+
+    /// Encode multiple texts, preserving input order.
+    public func encodeBatch(_ texts: [String]) async throws -> [[Float]] {
+        return try await inner.encodeBatch(texts: texts)
+    }
 }

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -109,6 +109,28 @@ final class NobodyWhoTests: XCTestCase {
         XCTAssertEqual(tokens, [18665, 0])
     }
 
+    // MARK: - Encoder
+
+    func testEncoderBatch() async throws {
+        let modelPath = try requireEnv("TEST_EMBEDDINGS_MODEL")
+        let model = try await Model.load(modelPath: modelPath, useGpu: false)
+        let encoder = Encoder(model: model, contextSize: 1024)
+        let texts = ["Copenhagen is in Denmark.", "Berlin is in Germany."]
+        var individual: [[Float]] = []
+        for text in texts {
+            individual.append(try await encoder.encode(text))
+        }
+        let batched = try await encoder.encodeBatch(texts)
+
+        XCTAssertEqual(batched.count, texts.count)
+        for (expected, actual) in zip(individual, batched) {
+            XCTAssertEqual(expected.count, actual.count)
+            for (expectedValue, actualValue) in zip(expected, actual) {
+                XCTAssertEqual(expectedValue, actualValue, accuracy: 1e-5)
+            }
+        }
+    }
+
     // MARK: - Stats
 
     func testStats() async throws {

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -922,6 +922,16 @@ impl RustEncoder {
                 message: e.to_string(),
             })
     }
+
+    /// Encode multiple texts into embedding vectors, preserving input order.
+    pub async fn encode_batch(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, NobodyWhoError> {
+        self.inner
+            .encode_batch(texts)
+            .await
+            .map_err(|e| NobodyWhoError::Error {
+                message: e.to_string(),
+            })
+    }
 }
 
 /// Compute the cosine similarity between two vectors.


### PR DESCRIPTION
- Pack pooled encoder and cross-encoder inputs into llama.cpp multi-sequence batches within token and sequence limits.
- Preserve input order and fall back to single-sequence processing when pooling does not support batching.
- Expose `Encoder.encode_batch()` / `encodeBatch()` for all bindings
- Update docs
- Closes #625
- Closes NOB-144