### PR TITLE
fix: Stt load method

### DIFF
--- a/docs/docs-flutter/speech-to-text.md
+++ b/docs/docs-flutter/speech-to-text.md
@@ -10,7 +10,7 @@ To transcribe audio into text, NobodyWho provides an integration with the Whispe
 import 'package:nobodywho/nobodywho.dart' as nobodywho;
 
 // ... after NobodyWho.init().
-final stt = nobodywho.Stt(source: 'hf://onnx-community/whisper-base');
+final stt = await nobodywho.Stt.load(source: 'hf://onnx-community/whisper-base');
 
 final text = await stt.transcribeFile('recording.mp3').completed();
 print(text);
@@ -39,7 +39,7 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```dart
-final stt = nobodywho.Stt(
+final stt = await nobodywho.Stt.load(
   source: 'hf://onnx-community/whisper-base',
   quantization: 'q4',
 );
@@ -50,7 +50,7 @@ final stt = nobodywho.Stt(
 By default, Whisper auto-detects the spoken language, which costs a bit of extra processing. If you already know the language, pass its ISO 639-1 code as `language` to skip detection and improve performance:
 
 ```dart
-final stt = nobodywho.Stt(
+final stt = await nobodywho.Stt.load(
   source: 'hf://onnx-community/whisper-base',
   language: 'en',
 );

--- a/docs/docs-kotlin/speech-to-text.md
+++ b/docs/docs-kotlin/speech-to-text.md
@@ -9,7 +9,7 @@ To transcribe audio into text, NobodyWho provides an integration with the Whispe
 ```kotlin
 import ai.nobodywho.Stt
 
-val stt = Stt(source = "hf://onnx-community/whisper-base")
+val stt = Stt.load(source = "hf://onnx-community/whisper-base")
 
 val text = stt.transcribeFile("recording.mp3").completed()
 println(text)
@@ -38,7 +38,7 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```kotlin
-val stt = Stt(
+val stt = Stt.load(
     source = "hf://onnx-community/whisper-base",
     quantization = "q4"
 )
@@ -49,7 +49,7 @@ val stt = Stt(
 By default, Whisper auto-detects the spoken language, which costs a bit of extra processing. If you already know the language, pass its ISO 639-1 code as `language` to skip detection and improve performance:
 
 ```kotlin
-val stt = Stt(
+val stt = Stt.load(
     source = "hf://onnx-community/whisper-base",
     language = "en"
 )

--- a/docs/docs-react-native/speech-to-text.md
+++ b/docs/docs-react-native/speech-to-text.md
@@ -9,7 +9,7 @@ To transcribe audio into text, NobodyWho provides an integration with the Whispe
 ```typescript
 import { STT } from "react-native-nobodywho";
 
-const stt = new STT({
+const stt = await STT.load({
   source: "hf://onnx-community/whisper-base",
 });
 
@@ -40,7 +40,7 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```typescript
-const stt = new STT({
+const stt = await STT.load({
   source: "hf://onnx-community/whisper-base",
   quantization: "int8",
 });
@@ -51,7 +51,7 @@ const stt = new STT({
 By default, Whisper auto-detects the spoken language, which costs a bit of extra processing. If you already know the language, pass its ISO 639-1 code as `language` to skip detection and improve performance:
 
 ```typescript
-const stt = new STT({
+const stt = await STT.load({
   source: "hf://onnx-community/whisper-base",
   language: "en",
 });

--- a/docs/docs-swift/speech-to-text.md
+++ b/docs/docs-swift/speech-to-text.md
@@ -9,7 +9,7 @@ To transcribe audio into text, NobodyWho provides an integration with the Whispe
 ```swift
 import NobodyWho
 
-let stt = try STT(source: "hf://onnx-community/whisper-base")
+let stt = try await STT.load(source: "hf://onnx-community/whisper-base")
 
 let text = try await stt.transcribeFile(path: "recording.mp3").completed()
 print(text)
@@ -38,7 +38,7 @@ NobodyWho only supports Whisper models in **ONNX** format. `source` is a Hugging
 You can also pick a `quantization` variant of the model to download and load. Lower-precision variants are smaller and faster, but can lose some transcription accuracy. Supported values are `default`, `fp16`, `int8`, `uint8`, `bnb4`, `q4`, `q4f16`, and `quantized`. Defaults to `default`.
 
 ```swift
-let stt = try STT(source: "hf://onnx-community/whisper-base", quantization: "q4")
+let stt = try await STT.load(source: "hf://onnx-community/whisper-base", quantization: "q4")
 ```
 
 ## Improving performance
@@ -46,5 +46,5 @@ let stt = try STT(source: "hf://onnx-community/whisper-base", quantization: "q4"
 By default, Whisper auto-detects the spoken language, which costs a bit of extra processing. If you already know the language, pass its ISO 639-1 code as `language` to skip detection and improve performance:
 
 ```swift
-let stt = try STT(source: "hf://onnx-community/whisper-base", language: "en")
+let stt = try await STT.load(source: "hf://onnx-community/whisper-base", language: "en")
 ```

--- a/nobodywho/flutter/nobodywho/lib/nobodywho.dart
+++ b/nobodywho/flutter/nobodywho/lib/nobodywho.dart
@@ -789,18 +789,18 @@ class Stt {
 
   Stt._(this._stt);
 
-  /// Create an STT handle.
+  /// Load an STT handle.
   ///
   /// [source] — HuggingFace repo (`hf://owner/repo`, e.g. `"hf://onnx-community/whisper-base"`) or local dir.
   /// [language] — ISO 639-1 code (e.g. `"en"`); omit for auto-detect.
   /// [quantization] — ONNX precision variant to download and load: one of
   /// `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`; omit to use `"default"`.
-  factory Stt({
+  static Future<Stt> load({
     required String source,
     String? language,
     String? quantization,
-  }) {
-    final stt = nobodywho.RustStt.new_(
+  }) async {
+    final stt = await nobodywho.RustStt.load(
       source: source,
       language: language,
       quantization: quantization,

--- a/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class NobodyWho
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 829442270;
+  int get rustContentHash => 1715708007;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -252,7 +252,7 @@ abstract class NobodyWhoApi extends BaseApi {
 
   Future<String?> crateRustSttStreamNextToken({required RustSttStream that});
 
-  RustStt crateRustSttNew({
+  Future<RustStt> crateRustSttLoad({
     required String source,
     String? language = null,
     String? quantization = null,
@@ -2082,34 +2082,39 @@ class NobodyWhoApiImpl extends NobodyWhoApiImplPlatform
       );
 
   @override
-  RustStt crateRustSttNew({
+  Future<RustStt> crateRustSttLoad({
     required String source,
     String? language = null,
     String? quantization = null,
   }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(source, serializer);
           sse_encode_opt_String(language, serializer);
           sse_encode_opt_String(quantization, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 37,
+            port: port_,
+          );
         },
         codec: SseCodec(
           decodeSuccessData:
               sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustSTT,
           decodeErrorData: sse_decode_String,
         ),
-        constMeta: kCrateRustSttNewConstMeta,
+        constMeta: kCrateRustSttLoadConstMeta,
         argValues: [source, language, quantization],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateRustSttNewConstMeta => const TaskConstMeta(
-    debugName: "RustStt_new_",
+  TaskConstMeta get kCrateRustSttLoadConstMeta => const TaskConstMeta(
+    debugName: "RustStt_load",
     argNames: ["source", "language", "quantization"],
   );
 

--- a/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
+++ b/nobodywho/flutter/nobodywho/lib/src/rust/lib.dart
@@ -358,11 +358,11 @@ abstract class RustStt implements RustOpaqueInterface {
   /// `quantization` — ONNX precision variant to download and load: one of
   /// `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`; pass `None`
   /// to use `"default"`.
-  static RustStt new_({
+  static Future<RustStt> load({
     required String source,
     String? language = null,
     String? quantization = null,
-  }) => NobodyWho.instance.api.crateRustSttNew(
+  }) => NobodyWho.instance.api.crateRustSttLoad(
     source: source,
     language: language,
     quantization: quantization,

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -400,14 +400,14 @@ void main() {
     });
 
     test('speech-to-text.md:41', () async {
-      final stt = nobodywho.Stt(
+      final stt = await nobodywho.Stt.load(
         source: 'hf://onnx-community/whisper-base',
         quantization: 'q4',
       );
     });
 
     test('speech-to-text.md:52', () async {
-      final stt = nobodywho.Stt(
+      final stt = await nobodywho.Stt.load(
         source: 'hf://onnx-community/whisper-base',
         language: 'en',
       );

--- a/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
+++ b/nobodywho/flutter/nobodywho/test/nobodywho_test.dart
@@ -738,7 +738,7 @@ void main() {
       }
       // Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
       // "Billy" as "Bailey", while fp32 gets it right.
-      final stt = nobodywho.Stt(source: whisperModel, quantization: 'default');
+      final stt = await nobodywho.Stt.load(source: whisperModel, quantization: 'default');
       final stream = stt.transcribeFile(audioFile);
       final text = await stream.completed();
       expect(text.toLowerCase(), contains('ron'));

--- a/nobodywho/flutter/rust/src/frb_generated.rs
+++ b/nobodywho/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 829442270;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1715708007;
 
 // Section: executor
 
@@ -2042,16 +2042,17 @@ fn wire__crate__RustSttStream_next_token_impl(
         },
     )
 }
-fn wire__crate__RustStt_new__impl(
+fn wire__crate__RustStt_load_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "RustStt_new_",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+            debug_name: "RustStt_load",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
             let message = unsafe {
@@ -2067,10 +2068,13 @@ fn wire__crate__RustStt_new__impl(
             let api_language = <Option<String>>::sse_decode(&mut deserializer);
             let api_quantization = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, String>((move || {
-                let output_ok = crate::RustSTT::new_(api_source, api_language, api_quantization)?;
-                Ok(output_ok)
-            })())
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::RustSTT::load(api_source, api_language, api_quantization)?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -5305,6 +5309,7 @@ fn pde_ffi_dispatcher_primary_impl(
         34 => wire__crate__RustSttStream_completed_impl(port, ptr, rust_vec_len, data_len),
         35 => wire__crate__RustSttStream_iter_impl(port, ptr, rust_vec_len, data_len),
         36 => wire__crate__RustSttStream_next_token_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__RustStt_load_impl(port, ptr, rust_vec_len, data_len),
         40 => wire__crate__RustTokenStream_completed_impl(port, ptr, rust_vec_len, data_len),
         41 => wire__crate__RustTokenStream_iter_impl(port, ptr, rust_vec_len, data_len),
         42 => wire__crate__RustTokenStream_next_token_impl(port, ptr, rust_vec_len, data_len),
@@ -5331,7 +5336,6 @@ fn pde_ffi_dispatcher_sync_impl(
         13 => wire__crate__RustChat_ask_with_prompt_impl(ptr, rust_vec_len, data_len),
         21 => wire__crate__RustChat_new_impl(ptr, rust_vec_len, data_len),
         31 => wire__crate__RustChat_stop_generation_impl(ptr, rust_vec_len, data_len),
-        37 => wire__crate__RustStt_new__impl(ptr, rust_vec_len, data_len),
         38 => wire__crate__RustStt_transcribe_file_impl(ptr, rust_vec_len, data_len),
         39 => wire__crate__RustStt_transcribe_pcm_impl(ptr, rust_vec_len, data_len),
         43 => wire__crate__RustTool_get_schema_json_impl(ptr, rust_vec_len, data_len),

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -715,7 +715,7 @@ impl RustTokenStream {
 // STT
 // ---------------------------------------------------------------------------
 
-/// Speech-to-text handle. Create with `RustSTT.new_()`, then call
+/// Speech-to-text handle. Create with `RustSTT.load()`, then call
 /// `transcribeFile` or `transcribePcm` to get a `RustSTTStream`.
 #[flutter_rust_bridge::frb(opaque)]
 pub struct RustSTT {
@@ -729,8 +729,8 @@ impl RustSTT {
     /// `quantization` — ONNX precision variant to download and load: one of
     /// `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`; pass `None`
     /// to use `"default"`.
-    #[flutter_rust_bridge::frb(sync)]
-    pub fn new_(
+    #[flutter_rust_bridge::frb]
+    pub fn load(
         source: String,
         #[frb(default = "null")] language: Option<String>,
         #[frb(default = "null")] quantization: Option<String>,

--- a/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
+++ b/nobodywho/kotlin/common/generated/uniffi/nobodywho/nobodywho.kt
@@ -693,6 +693,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_nobodywho_uniffi_checksum_func_load_model(
     ): Short
+    external fun uniffi_nobodywho_uniffi_checksum_func_load_stt(
+    ): Short
     external fun uniffi_nobodywho_uniffi_checksum_func_load_tts(
     ): Short
     external fun uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_grammar(
@@ -1033,6 +1035,8 @@ external fun uniffi_nobodywho_uniffi_fn_func_get_cached_models(uniffi_out_err: U
 ): RustBuffer.ByValue
 external fun uniffi_nobodywho_uniffi_fn_func_load_model(`modelPath`: RustBuffer.ByValue,`useGpu`: Byte,`projectionModelPath`: RustBuffer.ByValue,`draftModelPath`: RustBuffer.ByValue,`onDownloadProgress`: RustBuffer.ByValue,
 ): Long
+external fun uniffi_nobodywho_uniffi_fn_func_load_stt(`source`: RustBuffer.ByValue,`language`: RustBuffer.ByValue,`quantization`: RustBuffer.ByValue,
+): Long
 external fun uniffi_nobodywho_uniffi_fn_func_load_tts(`source`: RustBuffer.ByValue,`architecture`: RustBuffer.ByValue,`voice`: RustBuffer.ByValue,`language`: RustBuffer.ByValue,`speed`: RustBuffer.ByValue,`steps`: RustBuffer.ByValue,`silenceDuration`: RustBuffer.ByValue,`precision`: RustBuffer.ByValue,`temperature`: RustBuffer.ByValue,`huggingfaceToken`: RustBuffer.ByValue,`device`: RustBuffer.ByValue,
 ): Long
 external fun uniffi_nobodywho_uniffi_fn_func_sampler_preset_constrain_with_grammar(`grammar`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1186,6 +1190,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_func_load_model() != 22964.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_nobodywho_uniffi_checksum_func_load_stt() != 9096.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nobodywho_uniffi_checksum_func_load_tts() != 26587.toShort()) {
@@ -7435,6 +7442,29 @@ public object FfiConverterMapStringString: FfiConverterRustBuffer<Map<kotlin.Str
         { future -> UniffiLib.ffi_nobodywho_uniffi_rust_future_free_u64(future) },
         // lift function
         { FfiConverterTypeRustModel.lift(it) },
+        // Error FFI converter
+        NobodyWhoException.ErrorHandler,
+    )
+    }
+
+        /**
+         * Create an STT handle. `source` is a HuggingFace repo (`hf://owner/repo`,
+         * e.g. `"hf://onnx-community/whisper-base"`) or a local directory path.
+         * `language` is an ISO 639-1 code (e.g. `"en"`); pass `None` to auto-detect.
+         * `quantization` selects the ONNX precision variant to download and load:
+         * one of `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+         * pass `None` to use `"default"`.
+         */
+    @Throws(NobodyWhoException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+     suspend fun `loadStt`(`source`: kotlin.String, `language`: kotlin.String?, `quantization`: kotlin.String?) : RustStt {
+        return uniffiRustCallAsync(
+        UniffiLib.uniffi_nobodywho_uniffi_fn_func_load_stt(FfiConverterString.lower(`source`),FfiConverterOptionalString.lower(`language`),FfiConverterOptionalString.lower(`quantization`),),
+        { future, callback, continuation -> UniffiLib.ffi_nobodywho_uniffi_rust_future_poll_u64(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_nobodywho_uniffi_rust_future_complete_u64(future, continuation) },
+        { future -> UniffiLib.ffi_nobodywho_uniffi_rust_future_free_u64(future) },
+        // lift function
+        { FfiConverterTypeRustSTT.lift(it) },
         // Error FFI converter
         NobodyWhoException.ErrorHandler,
     )

--- a/nobodywho/kotlin/common/src/Stt.kt
+++ b/nobodywho/kotlin/common/src/Stt.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import uniffi.nobodywho.RustStt as InternalStt
 import uniffi.nobodywho.RustSttStream as InternalSttStream
+import uniffi.nobodywho.loadStt
 
 /**
  * A stream of transcript tokens from a Whisper STT run.
@@ -44,20 +45,31 @@ class SttStream internal constructor(
  * Speech-to-text handle that transcribes audio using Whisper models in ONNX format.
  *
  * ```kotlin
- * val stt = Stt(source = "hf://onnx-community/whisper-base")
+ * val stt = Stt.load(source = "hf://onnx-community/whisper-base")
  * val text = stt.transcribeFile("recording.mp3").completed()
  * ```
  */
-class Stt(
-    source: String,
-    language: String? = null,
-    quantization: String? = null
+class Stt internal constructor(
+    private val inner: InternalStt
 ) : Closeable {
-    private val inner: InternalStt = InternalStt(
-        source = source,
-        language = language,
-        quantization = quantization
-    )
+    companion object {
+        /**
+         * Load a Whisper STT model.
+         *
+         * @param source HuggingFace repo (`hf://owner/repo`, e.g. `"hf://onnx-community/whisper-base"`) or a local directory path.
+         * @param language ISO 639-1 code (e.g. `"en"`); pass `null` to auto-detect.
+         * @param quantization ONNX precision variant to download and load: one of
+         *   `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+         *   pass `null` to use `"default"`.
+         */
+        suspend fun load(
+            source: String,
+            language: String? = null,
+            quantization: String? = null
+        ): Stt {
+            return Stt(loadStt(source = source, language = language, quantization = quantization))
+        }
+    }
 
     /**
      * Start transcribing an audio file (WAV / MP3 / FLAC).

--- a/nobodywho/python/nobodywho.pyi
+++ b/nobodywho/python/nobodywho.pyi
@@ -877,6 +877,30 @@ class STT:
         language: str | None = None,
         quantization: str | None = None,
     ) -> STT: ...
+    @staticmethod
+    async def load(
+        source: str, language: str | None = None, quantization: str | None = None
+    ) -> STT:
+        """
+        Asynchronously load an STT model.
+
+        This static method loads the model asynchronously, which is useful for loading large models
+        without blocking the async event loop. The blocking model load operation is offloaded to
+        a background thread, allowing other async tasks to continue running.
+
+        Args:
+            source: HuggingFace repo (`hf://owner/repo`) or a local directory path.
+            language: ISO 639-1 code (e.g. `"en"`); omit or pass `None` to auto-detect.
+            quantization: ONNX precision variant to download and load: one of
+                `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+                omit or pass `None` to use `"default"`.
+
+        Returns:
+            An STT instance wrapped in an awaitable (async function returns a coroutine)
+
+        Raises:
+            RuntimeError: If the model cannot be loaded
+        """
     def transcribe_file(self, /, path: str) -> TokenStream:
         """
         Transcribe an audio file (WAV / MP3). Returns a `TokenStream`.
@@ -900,6 +924,30 @@ class STTAsync:
         language: str | None = None,
         quantization: str | None = None,
     ) -> STTAsync: ...
+    @staticmethod
+    async def load(
+        source: str, language: str | None = None, quantization: str | None = None
+    ) -> STTAsync:
+        """
+        Asynchronously load an STT model.
+
+        This static method loads the model asynchronously, which is useful for loading large models
+        without blocking the async event loop. The blocking model load operation is offloaded to
+        a background thread, allowing other async tasks to continue running.
+
+        Args:
+            source: HuggingFace repo (`hf://owner/repo`) or a local directory path.
+            language: ISO 639-1 code (e.g. `"en"`); omit or pass `None` to auto-detect.
+            quantization: ONNX precision variant to download and load: one of
+                `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+                omit or pass `None` to use `"default"`.
+
+        Returns:
+            An STTAsync instance wrapped in an awaitable (async function returns a coroutine)
+
+        Raises:
+            RuntimeError: If the model cannot be loaded
+        """
     def transcribe_file(self, /, path: str) -> TokenStreamAsync: ...
     def transcribe_pcm(
         self, /, samples: Sequence[int], sample_rate: int

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -283,6 +283,47 @@ impl STT {
         Ok(Self { stt })
     }
 
+    /// Asynchronously load an STT model.
+    ///
+    /// This static method loads the model asynchronously, which is useful for loading large models
+    /// without blocking the async event loop. The blocking model load operation is offloaded to
+    /// a background thread, allowing other async tasks to continue running.
+    ///
+    /// Args:
+    ///     source: HuggingFace repo (`hf://owner/repo`) or a local directory path.
+    ///     language: ISO 639-1 code (e.g. `"en"`); omit or pass `None` to auto-detect.
+    ///     quantization: ONNX precision variant to download and load: one of
+    ///         `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+    ///         omit or pass `None` to use `"default"`.
+    ///
+    /// Returns:
+    ///     An STT instance wrapped in an awaitable (async function returns a coroutine)
+    ///
+    /// Raises:
+    ///     RuntimeError: If the model cannot be loaded
+    #[staticmethod]
+    #[pyo3(signature = (source, language = None, quantization = None))]
+    pub async fn load(
+        source: String,
+        language: Option<String>,
+        quantization: Option<String>,
+    ) -> PyResult<Self> {
+        tokio::task::spawn_blocking(move || {
+            let mut cfg = nobodywho::stt::WhisperConfig::new(&source);
+            cfg.language = language;
+            if let Some(quantization) = quantization {
+                cfg.quantization = quantization;
+            }
+            nobodywho::stt::Stt::new(nobodywho::stt::SttConfig::Whisper(cfg))
+        })
+        .await
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("STT load task panicked: {e}"))
+        })?
+        .map(|stt| Self { stt })
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
     /// Transcribe an audio file (WAV / MP3). Returns a `TokenStream`.
     pub fn transcribe_file(&self, path: &str, py: Python) -> PyResult<TokenStream> {
         let stream = py
@@ -334,6 +375,47 @@ impl STTAsync {
             .detach(|| nobodywho::stt::Stt::new(nobodywho::stt::SttConfig::Whisper(cfg)))
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         Ok(Self { stt })
+    }
+
+    /// Asynchronously load an STT model.
+    ///
+    /// This static method loads the model asynchronously, which is useful for loading large models
+    /// without blocking the async event loop. The blocking model load operation is offloaded to
+    /// a background thread, allowing other async tasks to continue running.
+    ///
+    /// Args:
+    ///     source: HuggingFace repo (`hf://owner/repo`) or a local directory path.
+    ///     language: ISO 639-1 code (e.g. `"en"`); omit or pass `None` to auto-detect.
+    ///     quantization: ONNX precision variant to download and load: one of
+    ///         `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+    ///         omit or pass `None` to use `"default"`.
+    ///
+    /// Returns:
+    ///     An STTAsync instance wrapped in an awaitable (async function returns a coroutine)
+    ///
+    /// Raises:
+    ///     RuntimeError: If the model cannot be loaded
+    #[staticmethod]
+    #[pyo3(signature = (source, language = None, quantization = None))]
+    pub async fn load(
+        source: String,
+        language: Option<String>,
+        quantization: Option<String>,
+    ) -> PyResult<Self> {
+        tokio::task::spawn_blocking(move || {
+            let mut cfg = nobodywho::stt::WhisperConfig::new(&source);
+            cfg.language = language;
+            if let Some(quantization) = quantization {
+                cfg.quantization = quantization;
+            }
+            nobodywho::stt::Stt::new(nobodywho::stt::SttConfig::Whisper(cfg))
+        })
+        .await
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("STT load task panicked: {e}"))
+        })?
+        .map(|stt| Self { stt })
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
     pub fn transcribe_file(&self, path: String) -> PyResult<TokenStreamAsync> {

--- a/nobodywho/react-native/generated/cpp/nobodywho.cpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.cpp
@@ -328,6 +328,9 @@ RustBuffer uniffi_nobodywho_uniffi_fn_func_get_cached_models(
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(
     RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path,
     RustBuffer draft_model_path, RustBuffer on_download_progress);
+/*handle*/ uint64_t
+uniffi_nobodywho_uniffi_fn_func_load_stt(RustBuffer source, RustBuffer language,
+                                         RustBuffer quantization);
 /*handle*/ uint64_t uniffi_nobodywho_uniffi_fn_func_load_tts(
     RustBuffer source, RustBuffer architecture, RustBuffer voice,
     RustBuffer language, RustBuffer speed, RustBuffer steps,
@@ -481,6 +484,7 @@ uint16_t uniffi_nobodywho_uniffi_checksum_func_cosine_similarity();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_download_model();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_get_cached_models();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_load_model();
+uint16_t uniffi_nobodywho_uniffi_checksum_func_load_stt();
 uint16_t uniffi_nobodywho_uniffi_checksum_func_load_tts();
 uint16_t
 uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_grammar();
@@ -3747,6 +3751,17 @@ NativeNobodywho::NativeNobodywho(
             return this->cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
                 rt, thisVal, args, count);
           });
+  props["ubrn_uniffi_nobodywho_uniffi_fn_func_load_stt"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_nobodywho_uniffi_fn_func_load_stt"),
+          3,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_nobodywho_uniffi_fn_func_load_stt(
+                rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_nobodywho_uniffi_fn_func_load_tts"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -4469,6 +4484,17 @@ NativeNobodywho::NativeNobodywho(
           [this](jsi::Runtime &rt, const jsi::Value &thisVal,
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_nobodywho_uniffi_checksum_func_load_model(
+                rt, thisVal, args, count);
+          });
+  props["ubrn_uniffi_nobodywho_uniffi_checksum_func_load_stt"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_nobodywho_uniffi_checksum_func_load_stt"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_nobodywho_uniffi_checksum_func_load_stt(
                 rt, thisVal, args, count);
           });
   props["ubrn_uniffi_nobodywho_uniffi_checksum_func_load_tts"] =
@@ -7051,6 +7077,18 @@ jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
   return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker,
                                                          value);
 }
+jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_load_stt(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_nobodywho_uniffi_fn_func_load_stt(
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[0]),
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]),
+      uniffi::nobodywho::Bridging<RustBuffer>::fromJs(rt, callInvoker,
+                                                      args[2]));
+
+  return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker,
+                                                         value);
+}
 jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_fn_func_load_tts(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
@@ -7804,6 +7842,13 @@ NativeNobodywho::cpp_uniffi_nobodywho_uniffi_checksum_func_load_model(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_nobodywho_uniffi_checksum_func_load_model();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeNobodywho::cpp_uniffi_nobodywho_uniffi_checksum_func_load_stt(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_nobodywho_uniffi_checksum_func_load_stt();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/nobodywho/react-native/generated/cpp/nobodywho.hpp
+++ b/nobodywho/react-native/generated/cpp/nobodywho.hpp
@@ -298,6 +298,9 @@ protected:
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_load_model(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
+  jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_load_stt(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_fn_func_load_tts(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -491,6 +494,9 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_load_model(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_load_stt(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_nobodywho_uniffi_checksum_func_load_tts(

--- a/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho-ffi.ts
@@ -105,6 +105,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_fn_func_download_model(modelPath: Uint8Array, headers: Uint8Array, onDownloadProgress: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_get_cached_models(uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     ubrn_uniffi_nobodywho_uniffi_fn_func_load_model(modelPath: Uint8Array, useGpu: number, projectionModelPath: Uint8Array, draftModelPath: Uint8Array, onDownloadProgress: Uint8Array): bigint;
+    ubrn_uniffi_nobodywho_uniffi_fn_func_load_stt(source: Uint8Array, language: Uint8Array, quantization: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_load_tts(source: Uint8Array, architecture: Uint8Array, voice: Uint8Array, language: Uint8Array, speed: Uint8Array, steps: Uint8Array, silenceDuration: Uint8Array, precision: Uint8Array, temperature: Uint8Array, huggingfaceToken: Uint8Array, device: Uint8Array): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_constrain_with_grammar(grammar: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     ubrn_uniffi_nobodywho_uniffi_fn_func_sampler_preset_constrain_with_json_schema(schema: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -169,6 +170,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_nobodywho_uniffi_checksum_func_download_model(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_get_cached_models(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model(): number;
+    ubrn_uniffi_nobodywho_uniffi_checksum_func_load_stt(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_load_tts(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_grammar(): number;
     ubrn_uniffi_nobodywho_uniffi_checksum_func_sampler_preset_constrain_with_json_schema(): number;

--- a/nobodywho/react-native/generated/ts/nobodywho.ts
+++ b/nobodywho/react-native/generated/ts/nobodywho.ts
@@ -186,6 +186,39 @@ export async function loadModel(modelPath: string, useGpu: boolean, projectionMo
     }
     }
 /**
+ * Create an STT handle. `source` is a HuggingFace repo (`hf://owner/repo`,
+ * e.g. `"hf://onnx-community/whisper-base"`) or a local directory path.
+ * `language` is an ISO 639-1 code (e.g. `"en"`); pass `None` to auto-detect.
+ * `quantization` selects the ONNX precision variant to download and load:
+ * one of `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+ * pass `None` to use `"default"`.
+ */
+export async function loadStt(source: string, language: string | undefined, quantization: string | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustSttInterface> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().ubrn_uniffi_nobodywho_uniffi_fn_func_load_stt(FfiConverterString.lower(source),FfiConverterOptionalString.lower(language),FfiConverterOptionalString.lower(quantization)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_poll_u64,
+            /*cancelFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_cancel_u64,
+            /*completeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_complete_u64,
+            /*freeFunc:*/ nativeModule().ubrn_ffi_nobodywho_uniffi_rust_future_free_u64,
+            /*liftFunc:*/ FfiConverterTypeRustSTT.lift.bind(FfiConverterTypeRustSTT),
+            /*liftString:*/ FfiConverterString.lift,
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeNobodyWhoError.lift.bind(FfiConverterTypeNobodyWhoError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+/**
  * Create a TTS synthesizer.
  */
 export async function loadTts(source: string, architecture: string | undefined, voice: string | undefined, language: string | undefined, speed: /*f32*/number | undefined, steps: /*u32*/number | undefined, silenceDuration: /*f32*/number | undefined, precision: string | undefined, temperature: /*f32*/number | undefined, huggingfaceToken: string | undefined, device: string | undefined, asyncOpts_?: { signal: AbortSignal }): Promise<RustTtsInterface> /*throws*/ {
@@ -4164,6 +4197,9 @@ function uniffiEnsureInitialized() {
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_model() !== 22964) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_model");
+    }
+    if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_stt() !== 9096) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_stt");
     }
     if (nativeModule().ubrn_uniffi_nobodywho_uniffi_checksum_func_load_tts() !== 26587) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_nobodywho_uniffi_checksum_func_load_tts");

--- a/nobodywho/react-native/src/stt.ts
+++ b/nobodywho/react-native/src/stt.ts
@@ -13,7 +13,7 @@ export type SttOptions = {
  *
  * @example
  * ```typescript
- * const stt = new STT({
+ * const stt = await STT.load({
  *   source: "hf://onnx-community/whisper-base",
  *   language: "en",
  * });
@@ -30,15 +30,23 @@ export class STT {
   /** @internal */
   private readonly _inner: RustSttInterface;
 
+  /** @internal */
+  private constructor(inner: RustSttInterface) {
+    this._inner = inner;
+  }
+
   /**
+   * Load a Whisper STT model.
+   *
    * @param opts - See {@link SttOptions}.
    */
-  constructor(opts: SttOptions) {
-    this._inner = new nobodywho.RustStt(
+  static async load(opts: SttOptions): Promise<STT> {
+    const inner = await nobodywho.loadStt(
       opts.source,
       opts.language,
       opts.quantization,
     );
+    return new STT(inner);
   }
 
   /**

--- a/nobodywho/swift/generated/nobodywho.swift
+++ b/nobodywho/swift/generated/nobodywho.swift
@@ -4608,6 +4608,28 @@ public func loadModel(modelPath: String, useGpu: Bool, projectionModelPath: Stri
         )
 }
 /**
+ * Create an STT handle. `source` is a HuggingFace repo (`hf://owner/repo`,
+ * e.g. `"hf://onnx-community/whisper-base"`) or a local directory path.
+ * `language` is an ISO 639-1 code (e.g. `"en"`); pass `None` to auto-detect.
+ * `quantization` selects the ONNX precision variant to download and load:
+ * one of `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+ * pass `None` to use `"default"`.
+ */
+public func loadStt(source: String, language: String?, quantization: String?)async throws  -> RustStt  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_nobodywho_uniffi_fn_func_load_stt(FfiConverterString.lower(source),FfiConverterOptionString.lower(language),FfiConverterOptionString.lower(quantization)
+                )
+            },
+            pollFunc: ffi_nobodywho_uniffi_rust_future_poll_u64,
+            completeFunc: ffi_nobodywho_uniffi_rust_future_complete_u64,
+            freeFunc: ffi_nobodywho_uniffi_rust_future_free_u64,
+            liftFunc: FfiConverterTypeRustSTT_lift,
+            errorHandler: FfiConverterTypeNobodyWhoError_lift
+        )
+}
+/**
  * Create a TTS synthesizer.
  */
 public func loadTts(source: String, architecture: String?, voice: String?, language: String?, speed: Float?, steps: UInt32?, silenceDuration: Float?, precision: String?, temperature: Float?, huggingfaceToken: String?, device: String?)async throws  -> RustTts  {
@@ -4753,6 +4775,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_func_load_model() != 22964) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nobodywho_uniffi_checksum_func_load_stt() != 9096) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nobodywho_uniffi_checksum_func_load_tts() != 26587) {

--- a/nobodywho/swift/generated/nobodywhoFFI.h
+++ b/nobodywho/swift/generated/nobodywhoFFI.h
@@ -712,6 +712,11 @@ RustBuffer uniffi_nobodywho_uniffi_fn_func_get_cached_models(RustCallStatus *_No
 uint64_t uniffi_nobodywho_uniffi_fn_func_load_model(RustBuffer model_path, int8_t use_gpu, RustBuffer projection_model_path, RustBuffer draft_model_path, RustBuffer on_download_progress
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_STT
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_STT
+uint64_t uniffi_nobodywho_uniffi_fn_func_load_stt(RustBuffer source, RustBuffer language, RustBuffer quantization
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_TTS
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_FN_FUNC_LOAD_TTS
 uint64_t uniffi_nobodywho_uniffi_fn_func_load_tts(RustBuffer source, RustBuffer architecture, RustBuffer voice, RustBuffer language, RustBuffer speed, RustBuffer steps, RustBuffer silence_duration, RustBuffer precision, RustBuffer temperature, RustBuffer huggingface_token, RustBuffer device
@@ -1057,6 +1062,12 @@ uint16_t uniffi_nobodywho_uniffi_checksum_func_get_cached_models(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_LOAD_MODEL
 #define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_LOAD_MODEL
 uint16_t uniffi_nobodywho_uniffi_checksum_func_load_model(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_LOAD_STT
+#define UNIFFI_FFIDEF_UNIFFI_NOBODYWHO_UNIFFI_CHECKSUM_FUNC_LOAD_STT
+uint16_t uniffi_nobodywho_uniffi_checksum_func_load_stt(void
     
 );
 #endif

--- a/nobodywho/swift/src/STT.swift
+++ b/nobodywho/swift/src/STT.swift
@@ -50,7 +50,7 @@ public struct SttStream: AsyncSequence {
 /// downloaded and cached on first use.
 ///
 /// ```swift
-/// let stt = try STT(source: "hf://onnx-community/whisper-base")
+/// let stt = try await STT.load(source: "hf://onnx-community/whisper-base")
 /// let text = try await stt.transcribeFile(path: "recording.mp3").completed()
 ///
 /// // Stream tokens as they arrive:
@@ -61,14 +61,21 @@ public struct SttStream: AsyncSequence {
 public class STT {
     private let inner: RustStt
 
+    private init(inner: RustStt) {
+        self.inner = inner
+    }
+
+    /// Load a Whisper STT model.
+    ///
     /// - Parameters:
     ///   - source: HuggingFace repo ID or local directory path.
     ///   - language: ISO 639-1 language code (e.g. `"en"`). Pass `nil` to auto-detect.
     ///   - quantization: ONNX precision variant to download and load: one of
     ///     `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`.
     ///     Pass `nil` to use `"default"`.
-    public init(source: String, language: String? = nil, quantization: String? = nil) throws {
-        self.inner = try RustStt(source: source, language: language, quantization: quantization)
+    public static func load(source: String, language: String? = nil, quantization: String? = nil) async throws -> STT {
+        let inner = try await NobodyWhoGenerated.loadStt(source: source, language: language, quantization: quantization)
+        return STT(inner: inner)
     }
 
     /// Transcribe an audio file (WAV / MP3). Returns an `SttStream`.

--- a/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
+++ b/nobodywho/swift/tests/NobodyWhoTests/NobodyWhoTests.swift
@@ -183,7 +183,7 @@ final class NobodyWhoTests: XCTestCase {
 
         // Use fp32 ("default"): the q4 whisper-base encoder mis-transcribes
         // "Billy" as "Bailey", while fp32 gets it right.
-        let stt = try STT(source: model, quantization: "default")
+        let stt = try await STT.load(source: model, quantization: "default")
         let text = try await stt.transcribeFile(path: audioFile).completed()
         XCTAssertTrue(text.lowercased().contains("ron"))
         XCTAssertTrue(text.lowercased().contains("billy"))

--- a/nobodywho/uniffi/WRAPPERSTRATEGY.md
+++ b/nobodywho/uniffi/WRAPPERSTRATEGY.md
@@ -19,6 +19,8 @@ These types are intentionally thin FFI wrappers. Each target language must provi
 | `RustToolCallback` | (internal) | Implemented by the `Tool` wrapper internally, never exposed to consumers |
 | `RustEncoder` | `Encoder` | Convenience factory (`Encoder.fromPath()`), resource cleanup |
 | `RustCrossEncoder` | `CrossEncoder` | Convenience factory (`CrossEncoder.fromPath()`), `rankAndSort()` JSON parsing, resource cleanup |
+| `RustTts` | `Tts` | Async factory (`Tts.load()`), also keeps a sync constructor for cheap re-wrapping |
+| `RustSTT` | `Stt` / `STT` | Async factory (`Stt.load()`), also keeps a sync constructor for cheap re-wrapping |
 
 ### What each wrapper should provide
 
@@ -28,6 +30,8 @@ These types are intentionally thin FFI wrappers. Each target language must provi
 - **`Tool`**: Accepts a user-friendly parameter definition (name, description, ordered parameter array with JSON Schema properties, callback). Arguments from the LLM are passed positionally to the callback in parameter array order, so any regular function can be used directly. Internally constructs `RustTool` and handles JSON parsing and type coercion.
 - **`Encoder`**: `Encoder.fromPath(opts)` factory. `encode(text)` returns embeddings. `destroy()`.
 - **`CrossEncoder`**: `CrossEncoder.fromPath(opts)` factory. `rank()` and `rankAndSort()` (parses JSON tuples). `destroy()`.
+- **`Tts`**: `Tts.load(opts)` async factory (wraps `load_tts` free function).
+- **`Stt`/`STT`**: `Stt.load(opts)` async factory (wraps `load_stt` free function).
 
 ## Direct Re-exports (no wrapper needed)
 
@@ -52,6 +56,8 @@ These types are used internally by the wrapper layer but should not be exposed t
 | `PromptPart` | Enum | Implementation detail of `Prompt` wrapper class. |
 | `ToolParameter` | Record | Implementation detail of `Tool` wrapper. Consumers declare parameters as an ordered array. |
 | `load_model` | Function | Replaced by `Model.load()` factory. |
+| `load_tts` | Function | Replaced by `Tts.load()` factory. |
+| `load_stt` | Function | Replaced by `Stt.load()` / `STT.load()` factory. |
 
 ## Adding a New Type
 

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -618,6 +618,48 @@ pub struct RustSTT {
     inner: nobodywho::stt::Stt,
 }
 
+fn create_stt(
+    source: String,
+    language: Option<String>,
+    quantization: Option<String>,
+) -> Result<Arc<RustSTT>, NobodyWhoError> {
+    let mut cfg = nobodywho::stt::WhisperConfig::new(&source);
+    cfg.language = language;
+    if let Some(quantization) = quantization {
+        cfg.quantization = quantization;
+    }
+    let inner = nobodywho::stt::Stt::new(nobodywho::stt::SttConfig::Whisper(cfg)).map_err(|e| {
+        NobodyWhoError::Error {
+            message: e.to_string(),
+        }
+    })?;
+    Ok(Arc::new(RustSTT { inner }))
+}
+
+/// Create an STT handle. `source` is a HuggingFace repo (`hf://owner/repo`,
+/// e.g. `"hf://onnx-community/whisper-base"`) or a local directory path.
+/// `language` is an ISO 639-1 code (e.g. `"en"`); pass `None` to auto-detect.
+/// `quantization` selects the ONNX precision variant to download and load:
+/// one of `"default"`, `"fp16"`, `"int8"`, `"uint8"`, `"bnb4"`, `"q4"`, `"q4f16"`, `"quantized"`;
+/// pass `None` to use `"default"`.
+#[uniffi::export]
+pub async fn load_stt(
+    source: String,
+    language: Option<String>,
+    quantization: Option<String>,
+) -> Result<Arc<RustSTT>, NobodyWhoError> {
+    // Use std::thread::spawn + tokio channel instead of tokio::task::spawn_blocking,
+    // because UniFFI's async bridge doesn't provide a Tokio runtime.
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    std::thread::spawn(move || {
+        let result = create_stt(source, language, quantization);
+        let _ = tx.blocking_send(result);
+    });
+    rx.recv().await.ok_or_else(|| NobodyWhoError::Error {
+        message: "STT load thread terminated unexpectedly".into(),
+    })?
+}
+
 #[uniffi::export]
 impl RustSTT {
     /// Create an STT handle. `source` is a HuggingFace repo (`hf://owner/repo`,
@@ -632,18 +674,7 @@ impl RustSTT {
         language: Option<String>,
         quantization: Option<String>,
     ) -> Result<Arc<Self>, NobodyWhoError> {
-        let mut cfg = nobodywho::stt::WhisperConfig::new(&source);
-        cfg.language = language;
-        if let Some(quantization) = quantization {
-            cfg.quantization = quantization;
-        }
-        let inner =
-            nobodywho::stt::Stt::new(nobodywho::stt::SttConfig::Whisper(cfg)).map_err(|e| {
-                NobodyWhoError::Error {
-                    message: e.to_string(),
-                }
-            })?;
-        Ok(Arc::new(Self { inner }))
+        create_stt(source, language, quantization)
     }
 
     /// Start transcribing an audio file (WAV / MP3).


### PR DESCRIPTION
```
new Stt() -> Stt.load()
```
to match how is it everywhere else