### PR TITLE
fix: Package in libc and onnxruntime .so files

### DIFF
--- a/nobodywho/flutter/nobodywho/android/build.gradle.kts
+++ b/nobodywho/flutter/nobodywho/android/build.gradle.kts
@@ -111,25 +111,9 @@ val resolveNativeLibraries by tasks.registering {
             return stdout.toString().trim()
         }
 
-        targetAbis.forEach { abi ->
-            val abiOutputDir = jniLibsDir.get().dir(abi).asFile
-            abiOutputDir.mkdirs()
-
-            // Copy the resolved library to jniLibs
-            val resolvedLibPath = resolveLibrary(abi, "main")
-            logger.lifecycle("[$abi] Resolved library: $resolvedLibPath")
-            copy {
-                from(resolvedLibPath)
-                into(abiOutputDir)
-                rename { "libnobodywho_flutter.so" }
-            }
-
-            // Copy libc++_shared.so from the NDK. libnobodywho_flutter.so links
-            // against it dynamically (llama-cpp-2's "android-static-stdcxx"
-            // feature does not fully statically embed libc++ - confirmed via
-            // `objdump -p` showing a NEEDED libc++_shared.so entry), so it must
-            // ship alongside the plugin's own library or the app fails to load
-            // it at runtime with a dlopen UnsatisfiedLinkError.
+        // libnobodywho_flutter.so dynamically needs libc++_shared.so at runtime
+        // (android-static-stdcxx doesn't fully embed it - confirmed via `objdump -p`).
+        fun copyLibcxxShared(abi: String, abiOutputDir: File) {
             val ndkDir = android.ndkDirectory
             val ndkTriple = abiToNdkTriple[abi]
                 ?: throw GradleException("Unknown ABI: $abi")
@@ -151,14 +135,25 @@ val resolveNativeLibraries by tasks.registering {
             } else {
                 throw GradleException("libc++_shared.so not found at: ${libcxxShared.absolutePath}")
             }
+        }
 
-            // x86_64 links against onnxruntime as a genuinely separate shared
-            // library (Microsoft's official onnxruntime-android prebuild has
-            // no static archive for x86_64, so `ort` links it dynamically
-            // there). arm64-v8a statically embeds onnxruntime directly into
-            // libnobodywho_flutter.so (confirmed via `objdump -p`: no
-            // NEEDED libonnxruntime.so, and no separate .so produced by the
-            // Rust build), so no separate file is needed for that ABI.
+        targetAbis.forEach { abi ->
+            val abiOutputDir = jniLibsDir.get().dir(abi).asFile
+            abiOutputDir.mkdirs()
+
+            // Copy the resolved library to jniLibs
+            val resolvedLibPath = resolveLibrary(abi, "main")
+            logger.lifecycle("[$abi] Resolved library: $resolvedLibPath")
+            copy {
+                from(resolvedLibPath)
+                into(abiOutputDir)
+                rename { "libnobodywho_flutter.so" }
+            }
+
+            copyLibcxxShared(abi, abiOutputDir)
+
+            // Only x86_64 needs onnxruntime as a separate .so (Microsoft ships
+            // no static build for it); arm64 statically embeds it (see objdump -p).
             if (abi == "x86_64") {
                 val resolvedOrtPath = resolveLibrary(abi, "onnxruntime")
                 logger.lifecycle("[$abi] Resolved onnxruntime library: $resolvedOrtPath")

--- a/nobodywho/flutter/nobodywho/android/build.gradle.kts
+++ b/nobodywho/flutter/nobodywho/android/build.gradle.kts
@@ -21,9 +21,18 @@ version = "1.0"
 // Supported ABIs (32-bit not supported due to llama.cpp build issues)
 val targetAbis = listOf("arm64-v8a", "x86_64")
 
+// Map Android ABI to NDK triple (for finding libc++_shared.so)
+val abiToNdkTriple = mapOf(
+    "arm64-v8a" to "aarch64-linux-android",
+    "x86_64" to "x86_64-linux-android"
+)
+
 android {
     namespace = "ooo.nobodywho.nobodywho"
     compileSdk = 36
+
+    // NDK version can be configured by downstream apps via gradle.properties
+    findProperty("android.ndkVersion")?.let { ndkVersion = it.toString() }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -69,11 +78,8 @@ val resolveNativeLibraries by tasks.registering {
         val toolDir = file("${projectDir}/../tool")
         val workingDir = file("${projectDir}/..")
 
-        targetAbis.forEach { abi ->
-            val abiOutputDir = jniLibsDir.get().dir(abi).asFile
-            abiOutputDir.mkdirs()
-
-            // Run the Dart script to resolve the library path
+        // Runs resolve_binary.dart for the given ABI/component and returns the resolved path.
+        fun resolveLibrary(abi: String, component: String): String {
             val stdout = ByteArrayOutputStream()
             val stderr = ByteArrayOutputStream()
 
@@ -83,7 +89,8 @@ val resolveNativeLibraries by tasks.registering {
                     "--platform=android",
                     "--arch=$abi",
                     "--build-type=release",
-                    "--cache-dir=${cacheDir.get().asFile.absolutePath}"
+                    "--cache-dir=${cacheDir.get().asFile.absolutePath}",
+                    "--component=$component"
                 )
                 setWorkingDir(workingDir)
                 standardOutput = stdout
@@ -98,17 +105,68 @@ val resolveNativeLibraries by tasks.registering {
             }
 
             if (execResult.exitValue != 0) {
-                throw GradleException("Failed to resolve NobodyWho library for $abi:\n$stderrText")
+                throw GradleException("Failed to resolve $component library for $abi:\n$stderrText")
             }
 
-            val resolvedLibPath = stdout.toString().trim()
-            logger.lifecycle("[$abi] Resolved library: $resolvedLibPath")
+            return stdout.toString().trim()
+        }
+
+        targetAbis.forEach { abi ->
+            val abiOutputDir = jniLibsDir.get().dir(abi).asFile
+            abiOutputDir.mkdirs()
 
             // Copy the resolved library to jniLibs
+            val resolvedLibPath = resolveLibrary(abi, "main")
+            logger.lifecycle("[$abi] Resolved library: $resolvedLibPath")
             copy {
                 from(resolvedLibPath)
                 into(abiOutputDir)
                 rename { "libnobodywho_flutter.so" }
+            }
+
+            // Copy libc++_shared.so from the NDK. libnobodywho_flutter.so links
+            // against it dynamically (llama-cpp-2's "android-static-stdcxx"
+            // feature does not fully statically embed libc++ - confirmed via
+            // `objdump -p` showing a NEEDED libc++_shared.so entry), so it must
+            // ship alongside the plugin's own library or the app fails to load
+            // it at runtime with a dlopen UnsatisfiedLinkError.
+            val ndkDir = android.ndkDirectory
+            val ndkTriple = abiToNdkTriple[abi]
+                ?: throw GradleException("Unknown ABI: $abi")
+
+            // Find the prebuilt directory (works on any host platform)
+            val prebuiltDir = file("${ndkDir}/toolchains/llvm/prebuilt")
+                .listFiles()
+                ?.firstOrNull { it.isDirectory }
+                ?: throw GradleException("Could not find NDK prebuilt directory")
+
+            val libcxxShared = file("${prebuiltDir}/sysroot/usr/lib/${ndkTriple}/libc++_shared.so")
+
+            if (libcxxShared.exists()) {
+                logger.lifecycle("[$abi] Copying libc++_shared.so")
+                copy {
+                    from(libcxxShared)
+                    into(abiOutputDir)
+                }
+            } else {
+                throw GradleException("libc++_shared.so not found at: ${libcxxShared.absolutePath}")
+            }
+
+            // x86_64 links against onnxruntime as a genuinely separate shared
+            // library (Microsoft's official onnxruntime-android prebuild has
+            // no static archive for x86_64, so `ort` links it dynamically
+            // there). arm64-v8a statically embeds onnxruntime directly into
+            // libnobodywho_flutter.so (confirmed via `objdump -p`: no
+            // NEEDED libonnxruntime.so, and no separate .so produced by the
+            // Rust build), so no separate file is needed for that ABI.
+            if (abi == "x86_64") {
+                val resolvedOrtPath = resolveLibrary(abi, "onnxruntime")
+                logger.lifecycle("[$abi] Resolved onnxruntime library: $resolvedOrtPath")
+                copy {
+                    from(resolvedOrtPath)
+                    into(abiOutputDir)
+                    rename { "libonnxruntime.so" }
+                }
             }
         }
     }

--- a/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
+++ b/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
@@ -6,7 +6,12 @@
 // 3. Cached download
 // 4. Download from GitHub releases
 
+import 'dart:async';
 import 'dart:io';
+
+// Applied to HttpClient.connectionTimeout and as an overall timeout on
+// request.close(), so a stalled download fails fast instead of hanging.
+const httpTimeout = Duration(seconds: 30);
 
 // onnxruntime is a separate .so only on Android x86_64 (Microsoft ships no
 // static build for it there); arm64 links it statically into the main lib.
@@ -191,10 +196,10 @@ Future<String> resolveOnnxRuntime(Config config) async {
   await cacheDirObj.create(recursive: true);
   final aarFile = File('$cacheBasePath/onnxruntime-android-$onnxRuntimeVersion.aar');
 
+  final httpClient = HttpClient()..connectionTimeout = httpTimeout;
   try {
-    final httpClient = HttpClient();
     final request = await httpClient.getUrl(Uri.parse(url));
-    final response = await request.close();
+    final response = await request.close().timeout(httpTimeout);
 
     if (response.statusCode != 200) {
       throw Exception('Failed to download onnxruntime AAR: HTTP ${response.statusCode}\nURL: $url');
@@ -203,7 +208,6 @@ Future<String> resolveOnnxRuntime(Config config) async {
     final sink = aarFile.openWrite();
     await response.pipe(sink);
     await sink.close();
-    httpClient.close();
 
     stderr.writeln('Extracting jni/${config.arch}/libonnxruntime.so...');
     final unzipResult = await Process.run('unzip', [
@@ -229,7 +233,15 @@ Future<String> resolveOnnxRuntime(Config config) async {
     if (aarFile.existsSync()) {
       aarFile.deleteSync();
     }
+    if (e is TimeoutException) {
+      throw Exception('Timed out downloading onnxruntime AAR from $url');
+    }
+    if (e is SocketException) {
+      throw Exception('Network error downloading onnxruntime AAR from $url: $e');
+    }
     rethrow;
+  } finally {
+    httpClient.close(force: true);
   }
 }
 
@@ -397,10 +409,10 @@ Future<String> downloadLibrary(Config config, String version) async {
 
   stderr.writeln('Downloading: $url');
 
+  final httpClient = HttpClient()..connectionTimeout = httpTimeout;
   try {
-    final httpClient = HttpClient();
     final request = await httpClient.getUrl(Uri.parse(url));
-    final response = await request.close();
+    final response = await request.close().timeout(httpTimeout);
 
     if (response.statusCode != 200) {
       throw Exception(
@@ -413,7 +425,6 @@ Future<String> downloadLibrary(Config config, String version) async {
     final sink = outputFile.openWrite();
     await response.pipe(sink);
     await sink.close();
-    httpClient.close();
 
     stderr.writeln('Downloaded to: $outputPath');
     return outputFile.absolute.path;
@@ -422,7 +433,15 @@ Future<String> downloadLibrary(Config config, String version) async {
     if (outputFile.existsSync()) {
       outputFile.deleteSync();
     }
+    if (e is TimeoutException) {
+      throw Exception('Timed out downloading library from $url');
+    }
+    if (e is SocketException) {
+      throw Exception('Network error downloading library from $url: $e');
+    }
     rethrow;
+  } finally {
+    httpClient.close(force: true);
   }
 }
 
@@ -442,10 +461,10 @@ Future<String> downloadXCFramework(Config config, String version) async {
 
   stderr.writeln('Downloading: $url');
 
+  final httpClient = HttpClient()..connectionTimeout = httpTimeout;
   try {
-    final httpClient = HttpClient();
     final request = await httpClient.getUrl(Uri.parse(url));
-    final response = await request.close();
+    final response = await request.close().timeout(httpTimeout);
 
     if (response.statusCode != 200) {
       throw Exception(
@@ -458,7 +477,6 @@ Future<String> downloadXCFramework(Config config, String version) async {
     final sink = zipFile.openWrite();
     await response.pipe(sink);
     await sink.close();
-    httpClient.close();
 
     stderr.writeln('Downloaded to: $zipPath');
 
@@ -492,7 +510,15 @@ Future<String> downloadXCFramework(Config config, String version) async {
     if (Directory(xcframeworkPath).existsSync()) {
       Directory(xcframeworkPath).deleteSync(recursive: true);
     }
+    if (e is TimeoutException) {
+      throw Exception('Timed out downloading xcframework from $url');
+    }
+    if (e is SocketException) {
+      throw Exception('Network error downloading xcframework from $url: $e');
+    }
     rethrow;
+  } finally {
+    httpClient.close(force: true);
   }
 }
 

--- a/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
+++ b/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
@@ -8,15 +8,9 @@
 
 import 'dart:io';
 
-// onnxruntime is only ever a genuinely separate shared library on Android
-// x86_64 - Microsoft's official onnxruntime-android prebuild has no static
-// archive for that ABI, so `ort` links it dynamically there (see
-// `[target.'cfg(target_os = "android")'.dependencies]` in core/Cargo.toml
-// and the x86_64 branch of the cargo-build-android job in
-// .github/workflows/build.yml). On arm64-v8a, onnxruntime is statically
-// linked directly into libnobodywho_flutter.so, so no separate file exists.
-//
-// Keep this in sync with ORT_VERSION in .github/workflows/build.yml.
+// onnxruntime is a separate .so only on Android x86_64 (Microsoft ships no
+// static build for it there); arm64 links it statically into the main lib.
+// Keep onnxRuntimeVersion in sync with ORT_VERSION in .github/workflows/build.yml.
 const onnxRuntimeVersion = '1.24.2';
 const onnxRuntimeArches = {
   'android': ['x86_64'],
@@ -187,11 +181,8 @@ Future<String> resolveOnnxRuntime(Config config) async {
     return cachedFile.absolute.path;
   }
 
-  // Strategy 2: download Microsoft's official prebuilt AAR from Maven Central
-  // and extract just the .so for this ABI. This is the same artifact CI uses
-  // to link `nobodywho-flutter` for x86_64 Android (see build.yml), fetched
-  // independently of our own release process since it's versioned by the
-  // upstream ONNX Runtime release, not by the nobodywho package version.
+  // Strategy 2: download Microsoft's prebuilt AAR from Maven Central and
+  // extract the .so - same artifact CI uses to link x86_64 (see build.yml).
   final url = 'https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/'
       '$onnxRuntimeVersion/onnxruntime-android-$onnxRuntimeVersion.aar';
   stderr.writeln('Downloading onnxruntime AAR: $url');

--- a/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
+++ b/nobodywho/flutter/nobodywho/tool/resolve_binary.dart
@@ -8,6 +8,20 @@
 
 import 'dart:io';
 
+// onnxruntime is only ever a genuinely separate shared library on Android
+// x86_64 - Microsoft's official onnxruntime-android prebuild has no static
+// archive for that ABI, so `ort` links it dynamically there (see
+// `[target.'cfg(target_os = "android")'.dependencies]` in core/Cargo.toml
+// and the x86_64 branch of the cargo-build-android job in
+// .github/workflows/build.yml). On arm64-v8a, onnxruntime is statically
+// linked directly into libnobodywho_flutter.so, so no separate file exists.
+//
+// Keep this in sync with ORT_VERSION in .github/workflows/build.yml.
+const onnxRuntimeVersion = '1.24.2';
+const onnxRuntimeArches = {
+  'android': ['x86_64'],
+};
+
 // Platform/architecture mappings to Rust triples and library names
 const platformMappings = {
   'linux': {
@@ -42,7 +56,9 @@ const platformMappings = {
 void main(List<String> arguments) async {
   try {
     final config = parseArguments(arguments);
-    final resolvedPath = await resolveBinary(config);
+    final resolvedPath = config.component == 'onnxruntime'
+        ? await resolveOnnxRuntime(config)
+        : await resolveBinary(config);
     stdout.writeln(resolvedPath);
     exit(0);
   } catch (e) {
@@ -56,12 +72,14 @@ class Config {
   final String? arch;
   final String buildType;
   final String cacheDir;
+  final String component;
 
   Config({
     required this.platform,
     this.arch,
     required this.buildType,
     required this.cacheDir,
+    this.component = 'main',
   });
 
   bool get isApplePlatform => platform == 'ios' || platform == 'macos';
@@ -72,6 +90,7 @@ Config parseArguments(List<String> args) {
   String? arch;
   String? buildType;
   String? cacheDir;
+  String component = 'main';
 
   for (int i = 0; i < args.length; i++) {
     if (args[i].startsWith('--')) {
@@ -91,6 +110,9 @@ Config parseArguments(List<String> args) {
           break;
         case 'cache-dir':
           cacheDir = value;
+          break;
+        case 'component':
+          component = value ?? 'main';
           break;
       }
     }
@@ -120,6 +142,7 @@ Config parseArguments(List<String> args) {
     arch: arch,
     buildType: buildType,
     cacheDir: cacheDir,
+    component: component,
   );
 }
 
@@ -144,6 +167,79 @@ Future<String> resolveBinary(Config config) async {
 
   // Strategy 4: Download from GitHub
   return await downloadFromGitHub(config);
+}
+
+Future<String> resolveOnnxRuntime(Config config) async {
+  final needsIt = onnxRuntimeArches[config.platform]?.contains(config.arch) ?? false;
+  if (!needsIt) {
+    throw Exception(
+      'onnxruntime component was requested for ${config.platform}/${config.arch}, '
+      'but it is only needed on: '
+      '${onnxRuntimeArches.entries.map((e) => '${e.key}/${e.value.join(",")}').join("; ")}'
+    );
+  }
+
+  // Strategy 1: cached extraction from a previous run
+  final cacheBasePath = '${config.cacheDir}/onnxruntime/$onnxRuntimeVersion/${config.platform}-${config.arch}';
+  final cachedFile = File('$cacheBasePath/libonnxruntime.so');
+  if (cachedFile.existsSync()) {
+    stderr.writeln('Using cached onnxruntime library: ${cachedFile.path}');
+    return cachedFile.absolute.path;
+  }
+
+  // Strategy 2: download Microsoft's official prebuilt AAR from Maven Central
+  // and extract just the .so for this ABI. This is the same artifact CI uses
+  // to link `nobodywho-flutter` for x86_64 Android (see build.yml), fetched
+  // independently of our own release process since it's versioned by the
+  // upstream ONNX Runtime release, not by the nobodywho package version.
+  final url = 'https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/'
+      '$onnxRuntimeVersion/onnxruntime-android-$onnxRuntimeVersion.aar';
+  stderr.writeln('Downloading onnxruntime AAR: $url');
+
+  final cacheDirObj = Directory(cacheBasePath);
+  await cacheDirObj.create(recursive: true);
+  final aarFile = File('$cacheBasePath/onnxruntime-android-$onnxRuntimeVersion.aar');
+
+  try {
+    final httpClient = HttpClient();
+    final request = await httpClient.getUrl(Uri.parse(url));
+    final response = await request.close();
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to download onnxruntime AAR: HTTP ${response.statusCode}\nURL: $url');
+    }
+
+    final sink = aarFile.openWrite();
+    await response.pipe(sink);
+    await sink.close();
+    httpClient.close();
+
+    stderr.writeln('Extracting jni/${config.arch}/libonnxruntime.so...');
+    final unzipResult = await Process.run('unzip', [
+      '-j', '-o', '-q',
+      aarFile.path,
+      'jni/${config.arch}/libonnxruntime.so',
+      '-d', cacheBasePath,
+    ]);
+
+    if (unzipResult.exitCode != 0) {
+      throw Exception('Failed to extract libonnxruntime.so from AAR: ${unzipResult.stderr}');
+    }
+
+    aarFile.deleteSync();
+
+    if (!cachedFile.existsSync()) {
+      throw Exception('libonnxruntime.so not found in AAR after extraction: ${cachedFile.path}');
+    }
+
+    stderr.writeln('Extracted to: ${cachedFile.path}');
+    return cachedFile.absolute.path;
+  } catch (e) {
+    if (aarFile.existsSync()) {
+      aarFile.deleteSync();
+    }
+    rethrow;
+  }
 }
 
 String? checkEnvironmentOverride(Config config) {


### PR DESCRIPTION
Flutter builds for Android are now unusable because they are missing .so dependencies that were left behind and not packaged.