### PR TITLE
Reduce allocations during chat generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ### Fixed
 
+- Reworked allocation handling during chat inference, reducing allocation calls by 62% and allocated bytes by 91%.
 - Contructor for STT was synchronous, replaced with `load` function to make async and keep conventions
 
 ## [Python v1.7.0, Flutter v2.5.0, Godot v9.6.0, Kotlin v2.2.0, React Native v2.5.0, Swift v2.3.0] - 2026-07-30

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1758,7 +1758,8 @@ impl<'a> Chat<'a> {
         // pre-allocating 4096 bytes for the response string
         // 4096 is a very randomly chosen number. how does this affect performance?
         let mut full_response: String = String::with_capacity(4096);
-        let mut tokens_written_until_now = TokenizerChunks::new();
+        let mut tokens_written_until_now = Vec::new();
+        let mut new_tokens = Vec::new();
 
         self.sampler.reset();
 
@@ -1772,8 +1773,13 @@ impl<'a> Chat<'a> {
                 let deferred_pending = self.engine.take_pending();
                 self.context_shift()?;
                 self.sync_context_with_render(inference_lock_token)?;
-                self.engine
-                    .read_chunks(tokens_written_until_now.clone(), inference_lock_token)?;
+                if !tokens_written_until_now.is_empty() {
+                    let mut generated_chunks = TokenizerChunks::new();
+                    generated_chunks
+                        .append(TokenizerChunk::new_text(tokens_written_until_now.clone()));
+                    self.engine
+                        .read_chunks(generated_chunks, inference_lock_token)?;
+                }
                 self.engine.restore_pending(deferred_pending);
                 // do not update tokens_in_context as this is done later by ask
             }
@@ -1781,20 +1787,19 @@ impl<'a> Chat<'a> {
             // Sample next token(s), no need to use sampler.accept as sample already accepts the token.
             // using sampler.accept() will cause the sampler to crash when using grammar sampling.
             // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let new_tokens = self
-                .engine
-                .sample_and_decode_next_tokens(&mut self.sampler)?;
+            self.engine
+                .sample_and_decode_next_tokens(&mut self.sampler, &mut new_tokens)?;
 
-            tokens_written_until_now.append(TokenizerChunk::new_text(new_tokens.clone()));
+            tokens_written_until_now.extend_from_slice(&new_tokens);
 
             let mut hit_eog = false;
-            for new_token in new_tokens {
+            for &new_token in &new_tokens {
                 // Attempt to convert token(s) to bytes
                 let token_bytes = match self
                     .engine
                     .ctx
                     .model
-                    .token_to_piece_bytes(new_token, 8, true, None)
+                    .token_to_piece_bytes(new_token, 64, true, None)
                 {
                     Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
                         self.engine.ctx.model.token_to_piece_bytes(
@@ -1832,7 +1837,7 @@ impl<'a> Chat<'a> {
                 if !has_eog {
                     full_response.push_str(&token_str);
                     trace!(?token_str, "Sending out token:");
-                    respond(WriteOutput::Token(token_str.to_string()));
+                    respond(WriteOutput::Token(token_str));
                 }
 
                 if has_eog {

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -453,19 +453,22 @@ impl<'a> InferenceEngine<'a> {
     pub(crate) fn sample_and_decode_next_tokens(
         &mut self,
         sampler: &mut ChatSampler,
-    ) -> Result<Vec<LlamaToken>, DecodingError> {
+        output: &mut Vec<LlamaToken>,
+    ) -> Result<(), DecodingError> {
+        output.clear();
         match &self.ctx {
-            EngineContext::Solo(_) => self.sample_and_decode_solo(sampler),
-            EngineContext::Speculative(_) => self.sample_and_decode_speculative(sampler),
+            EngineContext::Solo(_) => self.sample_and_decode_solo(sampler, output),
+            EngineContext::Speculative(_) => self.sample_and_decode_speculative(sampler, output),
         }
     }
 
     fn sample_and_decode_solo(
         &mut self,
         sampler: &mut ChatSampler,
-    ) -> Result<Vec<LlamaToken>, DecodingError> {
+        output: &mut Vec<LlamaToken>,
+    ) -> Result<(), DecodingError> {
         trace!("Applying sampler (solo)");
-        let new_token: LlamaToken = sampler.active().sample(&self.ctx, -1);
+        let new_token = sampler.active().sample(&self.ctx, -1);
         sampler.observe(new_token);
 
         self.small_batch.clear();
@@ -477,13 +480,15 @@ impl<'a> InferenceEngine<'a> {
         drop(decode_guard);
         self.n_past += 1;
 
-        Ok(vec![new_token])
+        output.push(new_token);
+        Ok(())
     }
 
     fn sample_and_decode_speculative(
         &mut self,
         sampler: &mut ChatSampler,
-    ) -> Result<Vec<LlamaToken>, DecodingError> {
+        output: &mut Vec<LlamaToken>,
+    ) -> Result<(), DecodingError> {
         trace!("Applying sampler (MTP speculative, deferred)");
         let pending = match self.pending {
             Some(p) => p,
@@ -493,7 +498,8 @@ impl<'a> InferenceEngine<'a> {
         if self.ctx.model.is_eog_token(pending) {
             trace!(?pending, "MTP: pending is EOG, short-circuiting");
             self.pending = None;
-            return Ok(vec![pending]);
+            output.push(pending);
+            return Ok(());
         }
 
         sampler.observe(pending);
@@ -527,7 +533,8 @@ impl<'a> InferenceEngine<'a> {
             let new_pending = sampler.active().sample(&self.ctx, -1);
             self.n_past += 1;
             self.pending = Some(new_pending);
-            return Ok(vec![pending]);
+            output.push(pending);
+            return Ok(());
         }
 
         self.big_batch.clear();
@@ -543,7 +550,7 @@ impl<'a> InferenceEngine<'a> {
         }
         self.ctx.mtp_process(&self.big_batch)?;
 
-        let mut accepted_drafts: Vec<LlamaToken> = Vec::with_capacity(k_max);
+        let mut accepted_count = 0;
         let mut new_pending = None;
         for (i, &draft) in drafts.iter().enumerate() {
             let ti = sampler.active().sample(&self.ctx, i as i32);
@@ -556,15 +563,14 @@ impl<'a> InferenceEngine<'a> {
                 new_pending = Some(ti);
                 break;
             }
-            accepted_drafts.push(draft);
+            accepted_count += 1;
             sampler.observe(draft); // detects switch to grammar-constrained sampling
         }
         let new_pending =
             new_pending.unwrap_or_else(|| sampler.active().sample(&self.ctx, k_max as i32));
-        let j = accepted_drafts.len();
 
-        if j < k_max {
-            let keep_up_to = (self.n_past + 1 + j as i32) as u32;
+        if accepted_count < k_max {
+            let keep_up_to = (self.n_past + 1 + accepted_count as i32) as u32;
             let rolled_back = self
                 .ctx
                 .clear_kv_cache_seq(Some(0), Some(keep_up_to), None)?;
@@ -583,26 +589,25 @@ impl<'a> InferenceEngine<'a> {
             let EngineContext::Speculative(spec) = &mut self.ctx else {
                 unreachable!();
             };
-            spec.accept(j as u16)?;
+            spec.accept(accepted_count as u16)?;
         }
 
-        self.n_past += 1 + j as i32;
+        self.n_past += 1 + accepted_count as i32;
         self.pending = Some(new_pending);
         self.mtp_drafts_proposed += k_max as u64;
-        self.mtp_drafts_accepted += j as u64;
+        self.mtp_drafts_accepted += accepted_count as u64;
 
         trace!(
-            j,
+            accepted_count,
             k_max,
             ?pending,
             ?new_pending,
             "MTP: deferred iteration complete"
         );
 
-        let mut emitted = Vec::with_capacity(1 + j);
-        emitted.push(pending);
-        emitted.extend_from_slice(&accepted_drafts);
-        Ok(emitted)
+        output.push(pending);
+        output.extend_from_slice(&drafts[..accepted_count]);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Reuses generated-token and decode-output buffers instead of rebuilding token history on every generation step.
- Moves decoded token strings and tracks accepted MTP drafts by count to remove additional hot-path allocations.
- Benchmark (not in the PR): 

| CPU-only Rust benchmark | `main` before | Branch after | Change |
| --- | ---: | ---: | ---: |
| Decode throughput | 122.42 tok/s | 126.46 tok/s | +3.30% |
| Allocation calls/token | 9.8 | 3.7 | -62.2% |
| Allocated/response | 4.60 MiB | 0.40 MiB | -91.3% |
