### PR TITLE
Pin llama-cpp-rs to restore Apple builds

### DIFF
--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -2653,8 +2653,8 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.154"
-source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#bed81ad4ab1a6c904b11d425608e50f976d8ea62"
+version = "0.1.153"
+source = "git+https://github.com/utilityai/llama-cpp-rs?rev=b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc#b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2668,8 +2668,8 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.154"
-source = "git+https://github.com/utilityai/llama-cpp-rs?branch=main#bed81ad4ab1a6c904b11d425608e50f976d8ea62"
+version = "0.1.153"
+source = "git+https://github.com/utilityai/llama-cpp-rs?rev=b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc#b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -5998,7 +5998,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/nobodywho/Cargo.nix
+++ b/nobodywho/Cargo.nix
@@ -8277,13 +8277,13 @@ rec {
       };
       "llama-cpp-2" = rec {
         crateName = "llama-cpp-2";
-        version = "0.1.154";
+        version = "0.1.153";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/utilityai/llama-cpp-rs";
-          rev = "bed81ad4ab1a6c904b11d425608e50f976d8ea62";
-          sha256 = "0f72fhx42cl6amkifn1cvw6arwc672334xr1lhm0k6yd88rk83vw";
+          rev = "b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc";
+          sha256 = "1z1s58pxf4nk6c3306xzp7w0gbvw1m6rl5c44cfqgzmplyjysr7q";
         };
         libName = "llama_cpp_2";
         dependencies = [
@@ -8360,14 +8360,14 @@ rec {
       };
       "llama-cpp-sys-2" = rec {
         crateName = "llama-cpp-sys-2";
-        version = "0.1.154";
+        version = "0.1.153";
         edition = "2021";
         links = "llama";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/utilityai/llama-cpp-rs";
-          rev = "bed81ad4ab1a6c904b11d425608e50f976d8ea62";
-          sha256 = "0f72fhx42cl6amkifn1cvw6arwc672334xr1lhm0k6yd88rk83vw";
+          rev = "b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc";
+          sha256 = "1z1s58pxf4nk6c3306xzp7w0gbvw1m6rl5c44cfqgzmplyjysr7q";
         };
         libName = "llama_cpp_sys_2";
         buildDependencies = [
@@ -19225,7 +19225,7 @@ rec {
         dependencies = [
           {
             name = "windows-sys";
-            packageId = "windows-sys 0.48.0";
+            packageId = "windows-sys 0.52.0";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" "Win32_System_Console" "Win32_System_SystemInformation" ];
           }
@@ -19672,7 +19672,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_SystemInformation" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Networking" "Win32_Networking_WinSock" "Win32_Security" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_IO" "Win32_System_Pipes" "Win32_System_Threading" "Win32_System_WindowsProgramming" "default" ];
       };
       "windows-sys 0.52.0" = rec {
         crateName = "windows-sys";
@@ -19920,7 +19920,7 @@ rec {
           "Win32_Web" = [ "Win32" ];
           "Win32_Web_InternetExplorer" = [ "Win32_Web" ];
         };
-        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_System" "Win32_System_Threading" "default" ];
+        resolvedDefaultFeatures = [ "Win32" "Win32_Foundation" "Win32_Storage" "Win32_Storage_FileSystem" "Win32_System" "Win32_System_Console" "Win32_System_SystemInformation" "Win32_System_Threading" "default" ];
       };
       "windows-sys 0.61.2" = rec {
         crateName = "windows-sys";

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4.39"
 gbnf = { path = "../grammar/gbnf" }
 llguidance = "1.7.5"
 
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc", default-features = false, features = [
     "openmp",
     "mtmd",
     "llguidance",
@@ -71,7 +71,7 @@ libc = "0.2"
 # search path, which then resolves `-lgomp` to the non-PIC `libgomp.a` and
 # breaks linking the cdylib ("relocation R_X86_64_TPOFF32 against hidden symbol
 # `gomp_tls_data`"). Desktop keeps the dynamic libstdc++ it has always used.
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc", default-features = false, features = [
     "android-static-stdcxx",
 ] }
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-rustls", "copy-dylibs", "api-20"] }
@@ -101,7 +101,7 @@ features = [
 # Apple platforms use Metal, which is auto-enabled by llama-cpp-rs for all Apple targets
 # (except watchOS which has no Metal support — handled in llama-cpp-rs build.rs).
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "visionos"), not(target_os = "watchos"), not(target_os = "android"), any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
-llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", branch = "main", default-features = false, features = [
+llama-cpp-2 = { git = "https://github.com/utilityai/llama-cpp-rs", rev = "b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc", default-features = false, features = [
     "openmp",
     "vulkan",
     "mtmd",

--- a/nobodywho/crate-hashes.json
+++ b/nobodywho/crate-hashes.json
@@ -7,6 +7,6 @@
   "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#ruff_text_size@0.0.0": "03a816gz8nk7zadnwlcx21bmgb2wx6n2wpj4a10jcnlbjvhh4m4x",
   "git+https://github.com/everruns/bashkit?tag=v0.1.10#0.1.10": "0i0m81sqcmkynrdi45q112p6brcna9ws7wy1ac3wkh6mjl5k9swg",
   "git+https://github.com/pydantic/monty?tag=v0.0.7#0.0.7": "0k7a1pqyph7062msz39p6v2s1ylpyjn37wbscwmi09m3xkj109pa",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-2@0.1.154": "0f72fhx42cl6amkifn1cvw6arwc672334xr1lhm0k6yd88rk83vw",
-  "git+https://github.com/utilityai/llama-cpp-rs?branch=main#llama-cpp-sys-2@0.1.154": "0f72fhx42cl6amkifn1cvw6arwc672334xr1lhm0k6yd88rk83vw"
+  "git+https://github.com/utilityai/llama-cpp-rs?rev=b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc#llama-cpp-2@0.1.153": "1z1s58pxf4nk6c3306xzp7w0gbvw1m6rl5c44cfqgzmplyjysr7q",
+  "git+https://github.com/utilityai/llama-cpp-rs?rev=b48ce80b4f2c6c0f76227be27f8cba8624f4c0dc#llama-cpp-sys-2@0.1.153": "1z1s58pxf4nk6c3306xzp7w0gbvw1m6rl5c44cfqgzmplyjysr7q"
 }


### PR DESCRIPTION
- Pin the upstream dependency to utilityai/llama-cpp-rs@b48ce80, which includes the change adopted by #663 without the later llama.cpp update that builds unsupported subprocess code on watchOS and visionOS.
- Regenerate Cargo and Nix dependency metadata.
- Verified host compilation and test compilation, plus nightly `llama-cpp-sys-2` builds for `aarch64-apple-watchos` and `aarch64-apple-visionos`.