### PR TITLE
fix/godot-docs missing doc for v9.4.0 / 9.3.0

### DIFF
--- a/docs/godot_versioned_docs/version-9.3.0/install.md
+++ b/docs/godot_versioned_docs/version-9.3.0/install.md
@@ -1,3 +1,7 @@
+---
+slug: /
+---
+
 # Installation
 _How to install NobodyWho and start building._
 

--- a/docs/godot_versioned_docs/version-9.4.0/install.md
+++ b/docs/godot_versioned_docs/version-9.4.0/install.md
@@ -1,3 +1,7 @@
+---
+slug: /
+---
+
 # Installation
 _How to install NobodyWho and start building._
 


### PR DESCRIPTION
## Description
Fix #678

Currently in the godot docs, v9.4.0 / 9.3.0 are Page Not Found
https://docs.nobodywho.ooo/godot/9.4.0/
https://docs.nobodywho.ooo/godot/9.3.0/

## Fixes
Now v9.4.0 / 9.3.0 return the documentation

## Type of change

- [x] Documentation update
