### PR TITLE
fix: Expose coroutines API for Kotlin

### DIFF
--- a/nobodywho/kotlin/common/build.gradle.kts
+++ b/nobodywho/kotlin/common/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
-    // Provides the `api` configuration — needed so types we expose publicly
-    // (notably kotlinx.coroutines Flow) reach consumers' compile classpath.
-    `java-library`
+    `java-library` // provides the `api` configuration
     id("maven-publish")
     signing
 }
@@ -31,10 +29,7 @@ sourceSets {
 dependencies {
     // JNA is required by UniFFI-generated Kotlin bindings
     implementation("net.java.dev.jna:jna:5.14.0")
-    // Coroutines for suspend functions and Flow. `api`, not `implementation`:
-    // Flow appears in public return types (e.g. Chat.ask(...).asFlow()), so it
-    // must land on consumers' compile classpath — otherwise they cannot call
-    // our API without declaring coroutines themselves.
+    // Coroutines for suspend functions and Flow. `api`: exposed by TokenStream.asFlow.
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
     // Reflection for Tool function introspection
     implementation(kotlin("reflect"))

--- a/nobodywho/kotlin/common/build.gradle.kts
+++ b/nobodywho/kotlin/common/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    // Provides the `api` configuration — needed so types we expose publicly
+    // (notably kotlinx.coroutines Flow) reach consumers' compile classpath.
+    `java-library`
     id("maven-publish")
     signing
 }
@@ -28,8 +31,11 @@ sourceSets {
 dependencies {
     // JNA is required by UniFFI-generated Kotlin bindings
     implementation("net.java.dev.jna:jna:5.14.0")
-    // Coroutines for suspend functions and Flow
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    // Coroutines for suspend functions and Flow. `api`, not `implementation`:
+    // Flow appears in public return types (e.g. Chat.ask(...).asFlow()), so it
+    // must land on consumers' compile classpath — otherwise they cannot call
+    // our API without declaring coroutines themselves.
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
     // Reflection for Tool function introspection
     implementation(kotlin("reflect"))
     // JSON library


### PR DESCRIPTION
Kotlin distinguishes between two types of deps: api and implementation.
When you include something, you have to specify which type it is.

If a dep is "implementation" its types are not included for the users of *your* library, which is what happened here.
The change is then to move it to "api", so that the users of nobodywho can actually use the underlying types, such as the streams (named flows in this case).

Was part of #676 , but im splitting this out.