### PR TITLE
chore: Document android INTERNET permission

### DIFF
--- a/docs/docs-flutter/downloading-models.md
+++ b/docs/docs-flutter/downloading-models.md
@@ -18,6 +18,16 @@ The `modelPath` argument to `Chat.fromPath`, `downloadModel`, and friends accept
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
+## Android permissions
+
+Loading a model from `hf://` or `https://` needs network access. Add the internet permission to `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+Things to note: Flutter's generated debug and profile manifests already include this permission for the development tooling, so downloads can succeed while you are debugging and then fail in a release build. Declaring it in the main manifest covers every build mode. Apps that only load models from local paths need no network permission.
+
 ## Tracking download progress
 
 When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.

--- a/docs/docs-flutter/downloading-models.md
+++ b/docs/docs-flutter/downloading-models.md
@@ -4,7 +4,7 @@ description: How NobodyWho downloads, caches, and inspects GGUF models in Flutte
 sidebar_position: 1
 ---
 
-NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to access gated/private models, how to observe a download in progress, and how to inspect what's already in the local cache.
 
 ## Supported model path formats
 
@@ -27,19 +27,6 @@ Loading a model from `hf://` or `https://` needs network access. Add the interne
 ```
 
 Things to note: Flutter's generated debug and profile manifests already include this permission for the development tooling, so downloads can succeed while you are debugging and then fail in a release build. Declaring it in the main manifest covers every build mode. Apps that only load models from local paths need no network permission.
-
-## Tracking download progress
-
-When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
-
-```dart
-final chat = await nobodywho.Chat.fromPath(
-  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-  onDownloadProgress: (downloaded, total) {
-    print('$downloaded / $total bytes');
-  },
-);
-```
 
 ## Downloading a gated model
 
@@ -67,6 +54,19 @@ final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
 ```
 
 You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Tracking download progress
+
+When loading a remote model, pass an `onDownloadProgress` callback to observe the download. It receives `(downloadedBytes, totalBytes)`, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```dart
+final chat = await nobodywho.Chat.fromPath(
+  modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+  onDownloadProgress: (downloaded, total) {
+    print('$downloaded / $total bytes');
+  },
+);
+```
 
 ## Inspecting the model cache
 

--- a/docs/docs-godot/downloading-models.md
+++ b/docs/docs-godot/downloading-models.md
@@ -19,6 +19,12 @@ The `model_path` field on `NobodyWhoModel` (and `projection_model_path` for visi
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
 
+## Android permissions
+
+Loading a model from `hf://` or `https://` needs network access. In the Android export preset, enable the **Internet** permission under **Permissions** before exporting.
+
+Exports that only load models from local paths need no network permission.
+
 ## Showing download progress
 
 `NobodyWhoModel` emits a `download_progress(downloaded, total)` signal while a remote model is downloading, throttled to roughly 10 Hz with a guaranteed final emit on completion. Connect it if you'd like to drive a progress bar:

--- a/docs/docs-godot/downloading-models.md
+++ b/docs/docs-godot/downloading-models.md
@@ -19,13 +19,7 @@ The `model_path` field on `NobodyWhoModel` (and `projection_model_path` for visi
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs. Downloads happen on a background thread — the Godot main loop stays responsive while a multi-GB model is fetched.
 
-## Android permissions
-
-Loading a model from `hf://` or `https://` needs network access. In the Android export preset, enable the **Internet** permission under **Permissions** before exporting.
-
-Exports that only load models from local paths need no network permission.
-
-## Showing download progress
+## Tracking download progress
 
 `NobodyWhoModel` emits a `download_progress(downloaded, total)` signal while a remote model is downloading, throttled to roughly 10 Hz with a guaranteed final emit on completion. Connect it if you'd like to drive a progress bar:
 
@@ -76,3 +70,10 @@ Each entry is a `Dictionary` with two keys:
 - `"size"` — size in bytes
 
 The array is empty if nothing has been downloaded yet. On error the function returns `null` and logs a Godot error to the console.
+
+## Android permissions
+
+Loading a model from `hf://` or `https://` needs network access. In the Android export preset, enable the **Internet** permission under **Permissions** before exporting.
+
+Exports that only load models from local paths need no network permission.
+

--- a/docs/docs-kotlin/downloading-models.md
+++ b/docs/docs-kotlin/downloading-models.md
@@ -1,12 +1,26 @@
 ---
-title: Downloading Models
-description: How to download and manage GGUF models
+title: Downloading models
+description: How NobodyWho downloads, caches, and inspects GGUF models in Kotlin
 sidebar_position: 6
 ---
 
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to access gated/private models, how to observe a download in progress, and how to inspect what's already in the local cache.
+
+## Supported model path formats
+
+The `modelPath` argument to `Model.load`, `Chat.fromPath`, and `Model.download` accepts:
+
+| Form | Example | Notes |
+| ---- | ------- | ----- |
+| HuggingFace reference | `hf:owner/repo/file.gguf` | Downloaded and cached on first use |
+| HTTPS URL | `https://example.com/model.gguf` | Downloaded and cached on first use |
+| Local path | `./model.gguf` | Used as-is |
+
+The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
+
 ## Android permissions
 
-Loading a model from `hf://` or `https://` needs network access, so add the internet permission to your app's `AndroidManifest.xml`:
+Android requires explicit approval, adding the internet permission to your app's `AndroidManifest.xml`:
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET" />
@@ -14,7 +28,7 @@ Loading a model from `hf://` or `https://` needs network access, so add the inte
 
 NobodyWho does not declare this permission for you, so apps that only load models from local paths keep working without requesting any network access.
 
-## Downloading gated models
+## Downloading a gated model
 
 Some HuggingFace models are either private or gated by a license that you need to accept. For both scenarios, you need to be authorized to download the model weights.
 
@@ -52,7 +66,7 @@ val model = Model.load(
 }
 ```
 
-## Listing cached models
+## Inspecting the model cache
 
 `getCachedModels()` returns every `.gguf` model in NobodyWho's cache directory, paired with its size in bytes. This is the same cache used by `Model.download` and by `Chat.fromPath`'s `hf://` paths.
 

--- a/docs/docs-kotlin/downloading-models.md
+++ b/docs/docs-kotlin/downloading-models.md
@@ -4,6 +4,16 @@ description: How to download and manage GGUF models
 sidebar_position: 6
 ---
 
+## Android permissions
+
+Loading a model from `hf://` or `https://` needs network access, so add the internet permission to your app's `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+NobodyWho does not declare this permission for you, so apps that only load models from local paths keep working without requesting any network access.
+
 ## Downloading gated models
 
 Some HuggingFace models are either private or gated by a license that you need to accept. For both scenarios, you need to be authorized to download the model weights.

--- a/docs/docs-react-native/downloading-models.md
+++ b/docs/docs-react-native/downloading-models.md
@@ -18,6 +18,16 @@ The `modelPath` option to `Chat.fromPath` and `downloadModel` accepts:
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
+## Android permissions
+
+Loading a model from `hf://` or `https://` needs network access. The React Native app template already declares the internet permission in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+If your project has removed it, add it back. Apps that only load models from local paths need no network permission.
+
 ## Tracking download progress
 
 When loading a remote model, pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.

--- a/docs/docs-react-native/downloading-models.md
+++ b/docs/docs-react-native/downloading-models.md
@@ -4,7 +4,7 @@ description: How NobodyWho downloads, caches, and inspects GGUF models in React 
 sidebar_position: 1
 ---
 
-NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to observe a download in progress, how to access gated/private models, and how to inspect what's already in the local cache.
+NobodyWho can either load a model from a path on disk or download it for you on first use, caching it for subsequent runs. This page covers the available model path formats, how to access gated/private models, how to observe a download in progress, and how to inspect what's already in the local cache.
 
 ## Supported model path formats
 
@@ -27,19 +27,6 @@ Loading a model from `hf://` or `https://` needs network access. The React Nativ
 ```
 
 If your project has removed it, add it back. Apps that only load models from local paths need no network permission.
-
-## Tracking download progress
-
-When loading a remote model, pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
-
-```typescript
-const chat = await Chat.fromPath({
-  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
-  onDownloadProgress: (downloaded, total) => {
-    console.log(`${downloaded} / ${total} bytes`);
-  },
-});
-```
 
 ## Downloading a gated model
 
@@ -67,6 +54,19 @@ const chat = await Chat.fromPath({ modelPath });
 ```
 
 You can generate a HuggingFace token in [your account settings](https://huggingface.co/settings/tokens).
+
+## Tracking download progress
+
+When loading a remote model, pass an `onDownloadProgress` option to observe the download. It receives `(downloaded, total)` byte counts, is throttled to roughly 10 Hz with a guaranteed final emit on completion, and is not called for cached or local files.
+
+```typescript
+const chat = await Chat.fromPath({
+  modelPath: "huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf",
+  onDownloadProgress: (downloaded, total) => {
+    console.log(`${downloaded} / ${total} bytes`);
+  },
+});
+```
 
 ## Inspecting the model cache
 

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -168,7 +168,7 @@ void main() {
       );
     });
 
-    test('downloading-models.md:25', () async {
+    test('downloading-models.md:35', () async {
       final chat = await nobodywho.Chat.fromPath(
         modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
         onDownloadProgress: (downloaded, total) {
@@ -177,13 +177,13 @@ void main() {
       );
     });
 
-    test('downloading-models.md:40', () async {
+    test('downloading-models.md:50', () async {
       final chat = await nobodywho.Chat.fromPath(
         modelPath: './model.gguf',
       );
     });
 
-    test('downloading-models.md:48', () async {
+    test('downloading-models.md:58', () async {
       final modelPath = await nobodywho.downloadModel(
         modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
         headers: {'Authorization': 'Bearer your_hf_token'},
@@ -192,7 +192,7 @@ void main() {
       final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
     });
 
-    test('downloading-models.md:65', () async {
+    test('downloading-models.md:75', () async {
       final models = nobodywho.getCachedModels();
       for (final (path, size) in models) {
         print('$path: ${size ~/ BigInt.from(1024 * 1024)} MiB');

--- a/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
+++ b/nobodywho/flutter/nobodywho/test/doctest_generated_test.dart
@@ -168,28 +168,28 @@ void main() {
       );
     });
 
-    test('downloading-models.md:35', () async {
-      final chat = await nobodywho.Chat.fromPath(
-        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
-        onDownloadProgress: (downloaded, total) {
-          print('$downloaded / $total bytes');
-        },
-      );
-    });
-
-    test('downloading-models.md:50', () async {
+    test('downloading-models.md:37', () async {
       final chat = await nobodywho.Chat.fromPath(
         modelPath: './model.gguf',
       );
     });
 
-    test('downloading-models.md:58', () async {
+    test('downloading-models.md:45', () async {
       final modelPath = await nobodywho.downloadModel(
         modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
         headers: {'Authorization': 'Bearer your_hf_token'},
       );
       
       final chat = await nobodywho.Chat.fromPath(modelPath: modelPath);
+    });
+
+    test('downloading-models.md:62', () async {
+      final chat = await nobodywho.Chat.fromPath(
+        modelPath: 'huggingface:NobodyWho/Qwen_Qwen3-0.6B-GGUF/Qwen_Qwen3-0.6B-Q4_K_M.gguf',
+        onDownloadProgress: (downloaded, total) {
+          print('$downloaded / $total bytes');
+        },
+      );
     });
 
     test('downloading-models.md:75', () async {


### PR DESCRIPTION
If you want to access internet, android requires an explicit permission in its manifest.

You can add that in nobodywho, but its little bit weird, as we want to be offline first and technically this model downloading should be opt-in. To document it seems therefore like the more reasonable choice.

Also, synced some inconsistencies between the RN/Flutter/Kotlin docs.

Was part of #676  , but im splitting this out.
