### PR TITLE
fix: Link to existing libc++_shared for android builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -609,6 +609,12 @@ jobs:
         working-directory: ./nobodywho
         env:
           ANDROID_NDK: "${{ steps.setup-ndk.outputs.ndk-path }}"
+          # ort-sys hardcodes `-lc++_shared` on Android, which undoes the
+          # static C++ runtime that llama-cpp-rs's `android-static-stdcxx`
+          # already gives us. Linking it statically too leaves the .so needing
+          # only liblog/libdl/libm/libc, so no companion libc++_shared.so has to
+          # be shipped and consumers need no NDK to build against us.
+          ORT_CXX_STDLIB: "c++_static"
           # aarch64 (arm64-v8a)
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang"
           CARGO_TARGET_AARCH64_LINUX_ANDROID_AR: "${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"

--- a/nobodywho/flutter/nobodywho/android/build.gradle.kts
+++ b/nobodywho/flutter/nobodywho/android/build.gradle.kts
@@ -21,12 +21,6 @@ version = "1.0"
 // Supported ABIs (32-bit not supported due to llama.cpp build issues)
 val targetAbis = listOf("arm64-v8a", "x86_64")
 
-// Map Android ABI to NDK triple (for finding libc++_shared.so)
-val abiToNdkTriple = mapOf(
-    "arm64-v8a" to "aarch64-linux-android",
-    "x86_64" to "x86_64-linux-android"
-)
-
 android {
     namespace = "ooo.nobodywho.nobodywho"
     compileSdk = 36
@@ -111,32 +105,6 @@ val resolveNativeLibraries by tasks.registering {
             return stdout.toString().trim()
         }
 
-        // libnobodywho_flutter.so dynamically needs libc++_shared.so at runtime
-        // (android-static-stdcxx doesn't fully embed it - confirmed via `objdump -p`).
-        fun copyLibcxxShared(abi: String, abiOutputDir: File) {
-            val ndkDir = android.ndkDirectory
-            val ndkTriple = abiToNdkTriple[abi]
-                ?: throw GradleException("Unknown ABI: $abi")
-
-            // Find the prebuilt directory (works on any host platform)
-            val prebuiltDir = file("${ndkDir}/toolchains/llvm/prebuilt")
-                .listFiles()
-                ?.firstOrNull { it.isDirectory }
-                ?: throw GradleException("Could not find NDK prebuilt directory")
-
-            val libcxxShared = file("${prebuiltDir}/sysroot/usr/lib/${ndkTriple}/libc++_shared.so")
-
-            if (libcxxShared.exists()) {
-                logger.lifecycle("[$abi] Copying libc++_shared.so")
-                copy {
-                    from(libcxxShared)
-                    into(abiOutputDir)
-                }
-            } else {
-                throw GradleException("libc++_shared.so not found at: ${libcxxShared.absolutePath}")
-            }
-        }
-
         targetAbis.forEach { abi ->
             val abiOutputDir = jniLibsDir.get().dir(abi).asFile
             abiOutputDir.mkdirs()
@@ -149,8 +117,6 @@ val resolveNativeLibraries by tasks.registering {
                 into(abiOutputDir)
                 rename { "libnobodywho_flutter.so" }
             }
-
-            copyLibcxxShared(abi, abiOutputDir)
 
             // Only x86_64 needs onnxruntime as a separate .so (Microsoft ships
             // no static build for it); arm64 statically embeds it (see objdump -p).


### PR DESCRIPTION
Ort library which we use for `Tts`, `Vac` and some other things requires `libc++_shared` library.
Usually, platforms provide it and the linker resolves it automatically, but on android, youre required to bring it into the build yourself.

What we used to do for flutter is that we have copied the libc++ from android NDK library, but that required the user to install it. Moreover other platforms were left crashing.

This fix tells the linker to reach out for already existing copy, which llama.cpp pulls in - it should fix all the android builds.

Was part of #676  , but im splitting this out. Also, a proper verification of this will come later in the mobile phone CI.