### PR TITLE
chore: AI review model change for Kimi K3

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AI_REVIEW_PROVIDER: opencode-go
-  AI_REVIEW_MODEL: deepseek-v4-pro
+  AI_REVIEW_MODEL: kimi-k3
   AI_REVIEW_THINKING: high
 
 jobs:


### PR DESCRIPTION
Deepseek that we have been using for AI reviews is now scoped only to china as they are making some changes with the hosting. We will thus pivot to Kimi K3 or GLM 5.3 