### PR TITLE
chore: Change AI review for GLM 5.3

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AI_REVIEW_PROVIDER: opencode-go
-  AI_REVIEW_MODEL: kimi-k3
+  AI_REVIEW_MODEL: glm-5.3
   AI_REVIEW_THINKING: high
 
 jobs:


### PR DESCRIPTION
Kimi runs for 30 mins and is quite expensive. Changing for GLM 5.3 if possible. 