### PR TITLE
Hide generated files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.nix linguist-generated

--- a/nobodywho/flutter/nobodywho/.gitattributes
+++ b/nobodywho/flutter/nobodywho/.gitattributes
@@ -1,0 +1,2 @@
+lib/src/rust/** linguist-generated
+test/doctest_generated_test.dart

--- a/nobodywho/flutter/rust/.gitattributes
+++ b/nobodywho/flutter/rust/.gitattributes
@@ -1,0 +1,1 @@
+src/frb_generated.rs linguist-generated

--- a/nobodywho/kotlin/.gitattributes
+++ b/nobodywho/kotlin/.gitattributes
@@ -1,0 +1,1 @@
+common/generated/** linguist-generated

--- a/nobodywho/python/.gitattributes
+++ b/nobodywho/python/.gitattributes
@@ -1,0 +1,1 @@
+nobodywho.pyi linguist-generated

--- a/nobodywho/react-native/.gitattributes
+++ b/nobodywho/react-native/.gitattributes
@@ -1,0 +1,3 @@
+cpp/** linguist-generated
+generated/** linguist-generated
+ios/** linguist-generated

--- a/nobodywho/swift/.gitattributes
+++ b/nobodywho/swift/.gitattributes
@@ -1,0 +1,1 @@
+generated/** linguist-generated


### PR DESCRIPTION
This should make it so that changes to the generated files are hidden by default in the diff view, which makes reviewing easier IMO.

As a side bonus, this should also make the "Languages" tab in the sidebar more descriptive. Currently it's:
<img width="712" height="318" alt="Screenshot 2026-08-19 at 16 04 08" src="https://github.com/user-attachments/assets/0e6467e2-6a83-47ad-93bb-f7792cdd6830" />

Where in reality, it's probably more Rusty.