### PR TITLE
fix: replace chunks_exact with as_chunks in kokoro

### DIFF
--- a/nobodywho/core/src/text_to_speech/kokoro.rs
+++ b/nobodywho/core/src/text_to_speech/kokoro.rs
@@ -546,12 +546,15 @@ impl KokoroVoice {
 
     fn decode_style_rows(view: &safetensors::tensor::TensorView<'_>) -> Vec<[f32; STYLE_DIM]> {
         view.data()
-            .chunks_exact(4)
-            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(f32::from_le_bytes)
             .collect::<Vec<f32>>()
-            .chunks_exact(STYLE_DIM)
-            .map(|row| row.try_into().expect("STYLE_DIM-sized chunk"))
-            .collect()
+            .as_chunks::<STYLE_DIM>()
+            .0
+            .to_vec()
     }
 }
 

--- a/nobodywho/core/src/text_to_speech/pocket.rs
+++ b/nobodywho/core/src/text_to_speech/pocket.rs
@@ -606,8 +606,11 @@ fn copy_bytes_f32(
     source_shape: &[usize],
 ) {
     let source: Vec<f32> = source
-        .chunks_exact(4)
-        .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("f32 chunks")))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(f32::from_le_bytes)
         .collect();
     copy_tensor_values(target, target_shape, &source, source_shape);
 }
@@ -619,8 +622,11 @@ fn copy_bytes_i64(
     source_shape: &[usize],
 ) {
     let source: Vec<i64> = source
-        .chunks_exact(8)
-        .map(|bytes| i64::from_le_bytes(bytes.try_into().expect("i64 chunks")))
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .copied()
+        .map(i64::from_le_bytes)
         .collect();
     copy_tensor_values(target, target_shape, &source, source_shape);
 }


### PR DESCRIPTION
clippy 1.98.0 promotes `chunks_exact_to_as_chunks` to warn-by-default, which fails the `-D warnings` lint job on every new run (the swift release tag run failed on this today).