### PR TITLE
Improve logging on Android and iOS (and WASM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 - **Android:** the C++ runtime is now linked statically, so no companion `libc++_shared.so` has to be shipped and no NDK is needed to build against the library. Affects all Android artifacts.
 - **Flutter:** Android builds now package the libc and onnxruntime `.so` files they depend on.
 - **Swift:** visionOS and watchOS builds fixed.
+- **Flutter:** Logs are now visible in `flutter run` and `adb logcat` on Android.
+- **Flutter/React Native/Swift:** Logs are now visible in Xcode on iOS.
 
 ## [Python v1.7.0, Flutter v2.5.0, Godot v9.6.0, Kotlin v2.2.0, React Native v2.5.0, Swift v2.3.0] - 2026-07-30
 

--- a/nobodywho/Cargo.lock
+++ b/nobodywho/Cargo.lock
@@ -65,23 +65,12 @@ checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
-dependencies = [
- "android_log-sys",
- "env_filter",
- "log",
-]
-
-[[package]]
-name = "android_logger"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -934,6 +923,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "delegate-attr"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1205,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter 2.0.0",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,7 +1430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0884853aae8a6517b5b58cf36f55da487f2fe110e1686938eb29b6640aae4a5"
 dependencies = [
  "allo-isolate",
- "android_logger 0.15.1",
+ "android_logger",
  "anyhow",
  "build-target",
  "bytemuck",
@@ -2431,6 +2474,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lzma-rust2"
@@ -2750,15 +2829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9047e0a37a596d4e15411a1ffbdabe71c328908cb90a721cb9bf8dcf3434e6d2"
 dependencies = [
  "unicode-id",
-]
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -3021,11 +3091,13 @@ name = "nobodywho"
 version = "2.4.0"
 dependencies = [
  "ahash",
+ "android_logger",
  "bashkit",
  "chrono",
  "dirs",
  "emojis",
  "encoding_rs",
+ "env_logger",
  "espeak-ng",
  "futures",
  "gbnf",
@@ -3036,6 +3108,7 @@ dependencies = [
  "libc",
  "llama-cpp-2",
  "llguidance",
+ "log",
  "mel_spec",
  "miette",
  "minijinja",
@@ -3045,6 +3118,7 @@ dependencies = [
  "ndarray 0.17.2",
  "nom 8.0.0",
  "ort",
+ "oslog",
  "rand 0.9.5",
  "rand_distr",
  "regex",
@@ -3081,7 +3155,6 @@ dependencies = [
  "regex",
  "serde_json",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3121,15 +3194,11 @@ dependencies = [
 name = "nobodywho-uniffi"
 version = "0.4.0"
 dependencies = [
- "android_logger 0.14.1",
- "log",
  "nobodywho",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
  "uniffi",
 ]
 
@@ -5471,14 +5540,10 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/nobodywho/core/Cargo.toml
+++ b/nobodywho/core/Cargo.toml
@@ -31,8 +31,10 @@ tokio = { version = "1.43.0", features = [
     "macros",
 ] }
 tokio-stream = "0.1.17"
+# Make `tracing` emit `log` events when no subscriber is installed.
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = "0.3.19"
+log = "0.4.34"
 regex = "1.11.1"
 serde_json = "1.0.140"
 nom = "8.0.0"
@@ -60,10 +62,14 @@ unicode-normalization = "0.1"
 emojis = "0.9.0"
 unicode-segmentation = "1.13.3"
 
+[target.'cfg(target_vendor = "apple")'.dependencies]
+oslog = "0.2.0"
+
 [target.'cfg(any(target_os = "android", target_vendor = "apple"))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.15.1"
 # Statically link the C++ stdlib (libc++) on Android so the produced shared
 # library is self-contained. This is Android-only on purpose: on Linux, the
 # `static-stdcxx` feature makes llama-cpp-rs's build.rs add the compiler's
@@ -94,6 +100,9 @@ windows-sys = { version = "0.61", features = ["Win32_System_SystemInformation"] 
 # to x86_64 or enable ort's `lax-feature-matching`).
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["cuda"] }
+
+[target.'cfg(not(any(target_os = "android", all(target_vendor = "apple", not(target_os = "macos")), target_family = "wasm")))'.dependencies]
+env_logger = "0.11.11"
 
 [dependencies.espeak-ng]
 version = "0.1.2"

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -7,6 +7,7 @@ mod host_memory;
 pub mod huggingface;
 pub mod inference;
 pub mod llm;
+pub mod log;
 pub mod memory;
 mod model_selection;
 pub mod onnx;
@@ -34,10 +35,6 @@ pub fn render_miette(err: &dyn miette::Diagnostic) -> String {
         out = err.to_string();
     }
     out
-}
-
-pub fn send_llamacpp_logs_to_tracing() {
-    llama_cpp_2::send_logs_to_tracing(llama_cpp_2::LogOptions::default().with_logs_enabled(true));
 }
 
 #[cfg(test)]

--- a/nobodywho/core/src/log.rs
+++ b/nobodywho/core/src/log.rs
@@ -1,0 +1,62 @@
+pub use log::LevelFilter;
+
+/// Configure a sensible global [logger][`log`] for the current target.
+///
+/// This also captures [`tracing`] events as long as either:
+/// - No tracing subscriber is registered.
+/// - The `tracing/log-always` feature is enabled.
+///
+/// NOTE: Ideally, we'd probably want to make this use `tracing` instead, and
+/// set up a `tracing_log::LogTracer` for catching `log` events. But for now,
+/// this will suffice.
+///
+/// This should be safe to call in a constructor.
+///
+/// # Panics
+///
+/// Panics if called more than once.
+pub fn init(level: LevelFilter) {
+    send_llamacpp_logs_to_tracing();
+
+    // Android logs to `adb logcat`.
+    #[cfg(target_os = "android")]
+    {
+        let config = android_logger::Config::default()
+            .with_max_level(level)
+            .with_tag("nobodywho");
+        android_logger::init_once(config)
+    }
+
+    // iOS/tvOS/watchOS/visionOS logs to oslog (/usr/bin/log)
+    #[cfg(all(target_vendor = "apple", not(target_os = "macos")))]
+    {
+        oslog::OsLogger::new("nobodywho")
+            .level_filter(level)
+            .init()
+            .expect("log initialization must only happen once")
+    }
+
+    // Web platforms log to the console.
+    #[cfg(target_family = "wasm")]
+    {
+        console_log::init_with_level(level).expect("log initialization must only happen once")
+    }
+
+    // All other platforms log to stderr.
+    #[cfg(not(any(
+        target_os = "android",
+        all(target_vendor = "apple", not(target_os = "macos")),
+        target_family = "wasm"
+    )))]
+    {
+        env_logger::Builder::new()
+            .filter_level(level)
+            .parse_default_env()
+            .init()
+    }
+}
+
+/// Forward `llama.cpp` logs into tracing.
+pub fn send_llamacpp_logs_to_tracing() {
+    llama_cpp_2::send_logs_to_tracing(llama_cpp_2::LogOptions::default().with_logs_enabled(true));
+}

--- a/nobodywho/flutter/rust/Cargo.toml
+++ b/nobodywho/flutter/rust/Cargo.toml
@@ -12,7 +12,6 @@ flutter_rust_bridge = "=2.12.0"
 regex = "1.11.2"
 serde_json = "1.0.145"
 futures = "0.3.31"
-tracing-subscriber = "0.3.20"
 tracing = "0.1.41"
 nom = "8.0.0"
 

--- a/nobodywho/flutter/rust/src/lib.rs
+++ b/nobodywho/flutter/rust/src/lib.rs
@@ -1,7 +1,7 @@
 use flutter_rust_bridge::DartFnFuture;
 use nobodywho::chat::Asset;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 // ^ in general I've only done fully-qualified imports, but these things need to be imported to
 // satisfy some frb macros
 
@@ -1679,24 +1679,20 @@ impl SamplerPresets {
 
 #[flutter_rust_bridge::frb(init)]
 pub fn init_app() {
-    // send llamacpp logs into tracing
-    nobodywho::send_llamacpp_logs_to_tracing();
+    static INIT: Once = Once::new();
 
-    // send logs to the appropriate places for android, ios and wasm
-    flutter_rust_bridge::setup_default_user_utils();
+    // Only initialize once.
+    // This allows hot restart/reload to work.
+    INIT.call_once(|| {
+        let level = if cfg!(debug_assertions) {
+            nobodywho::log::LevelFilter::Debug
+        } else {
+            nobodywho::log::LevelFilter::Info
+        };
+        nobodywho::log::init(level);
 
-    let log_level = if cfg!(debug_assertions) {
-        tracing::Level::DEBUG
-    } else {
-        tracing::Level::INFO
-    };
-
-    tracing_subscriber::fmt()
-        .with_max_level(log_level)
-        .with_timer(tracing_subscriber::fmt::time::uptime())
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-        .try_init()
-        .ok();
+        flutter_rust_bridge::setup_backtrace();
+    });
 }
 
 #[cfg(test)]

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -3522,7 +3522,7 @@ pub mod nobodywhopython {
 
         // STEP 3: Route llamacpp logs to tracing dispatcher
         // Flow: llamacpp -> tracing -> LogForwardingLayer -> log crate -> pyo3_log -> Python
-        nobodywho::send_llamacpp_logs_to_tracing();
+        nobodywho::log::send_llamacpp_logs_to_tracing();
 
         // STEP 4: Enable log forwarding and register shutdown hook.
         // The atexit handler disables forwarding before Py_FinalizeEx so that

--- a/nobodywho/uniffi/Cargo.toml
+++ b/nobodywho/uniffi/Cargo.toml
@@ -14,10 +14,6 @@ serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.43.0", features = ["sync"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-tracing-log = "0.2"
-android_logger = "0.14"
-log = "0.4"
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/nobodywho/uniffi/src/lib.rs
+++ b/nobodywho/uniffi/src/lib.rs
@@ -1,29 +1,23 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
+
+use tracing::{debug, error, info};
 
 uniffi::setup_scaffolding!("nobodywho");
 
-/// Initialize logging so tracing output goes to Android logcat.
-#[cfg(target_os = "android")]
 fn init_logging() {
-    use std::sync::Once;
     static INIT: Once = Once::new();
+
     INIT.call_once(|| {
-        // Set up android_logger so log crate macros go to logcat
-        android_logger::init_once(
-            android_logger::Config::default()
-                .with_max_level(log::LevelFilter::Debug)
-                .with_tag("nobodywho"),
-        );
-        // Bridge tracing → log crate → android_logger → logcat
-        tracing_log::LogTracer::init().ok();
-        log::info!("NobodyWho logging initialized");
+        let level = if cfg!(debug_assertions) {
+            nobodywho::log::LevelFilter::Debug
+        } else {
+            nobodywho::log::LevelFilter::Info
+        };
+        nobodywho::log::init(level);
     });
 }
-
-#[cfg(not(target_os = "android"))]
-fn init_logging() {}
 
 // ---------- Error type ----------
 // UniFFI 0.30 requires a proper error type instead of bare String.
@@ -209,12 +203,9 @@ pub async fn load_model(
     on_download_progress: Option<Box<dyn RustDownloadProgressCallback>>,
 ) -> Result<Arc<RustModel>, NobodyWhoError> {
     init_logging();
-    log::info!(
+    info!(
         "load_model called: path={}, gpu={}, mmproj={:?}, draft={:?}",
-        model_path,
-        use_gpu,
-        projection_model_path,
-        draft_model_path,
+        model_path, use_gpu, projection_model_path, draft_model_path,
     );
 
     let progress = on_download_progress.map(wrap_progress);
@@ -228,11 +219,11 @@ pub async fn load_model(
     .await
     .map_err(|e| {
         let msg = nobodywho::render_miette(&e);
-        log::error!("{}", msg);
+        error!("{}", msg);
         NobodyWhoError::Error { message: msg }
     })?;
 
-    log::info!("load_model SUCCESS for {}", model_path);
+    info!("load_model SUCCESS for {}", model_path);
     Ok(Arc::new(RustModel {
         inner: Arc::new(model),
     }))
@@ -373,7 +364,7 @@ impl RustChat {
 
     /// Send a message and get a token stream for the response.
     pub fn ask(&self, message: String) -> Arc<RustTokenStream> {
-        log::info!("RustChat::ask called with message: {}", message);
+        info!("RustChat::ask called with message: {}", message);
         Arc::new(RustTokenStream {
             inner: tokio::sync::Mutex::new(self.inner.ask(message)),
         })
@@ -766,7 +757,7 @@ impl RustTokenStream {
     /// Get the next token. Returns None when generation is complete, or an error if generation failed.
     pub async fn next_token(&self) -> Result<Option<String>, NobodyWhoError> {
         let result = self.inner.lock().await.next_token().await;
-        log::debug!("next_token: {:?}", result);
+        debug!("next_token: {:?}", result);
         result.map_err(|e| NobodyWhoError::Error {
             message: nobodywho::render_miette(&e),
         })


### PR DESCRIPTION
Provide a common entry-point where loggers are initialized, and use platform-specific crates such as `android_logger` and `oslog` (and `console_log` for future WASM support) to initialize the logger.

The Python and Godot bindings do not use this, they integrate with the language's own logging framework instead.

Fixes https://github.com/nobodywho-ooo/nobodywho/issues/440. Replaces https://github.com/nobodywho-ooo/nobodywho/pull/517.

## How Has This Been Tested?

Tested in `flutter-start-example` on both iOS and Android, and in `NobodyWho-Chat` on iOS.
