### PR TITLE
fix: rejected inputs no longer kill the encoder worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 ### Fixed
 
 - A chat setter the worker rejects no longer kills the chat. Passing an invalid sampler config, or tools to a model with no tool-call template, ended the worker thread: the setter reported only "worker terminated", the real reason went to the log, and every later call on that chat — including `ask()` — failed the same way. The reason now reaches the caller and the chat keeps working, with the rejected value not applied. `set_chat_history` was fixed this way in the chat-completion change above; this covers `set_sampler_config`, `set_tools` and `reset_chat` too. Available for all bindings.
+- An input the encoder or cross-encoder rejects no longer kills it. Encoding or ranking text longer than the context window ended the worker thread, so the call reported only that the worker never responded, and every later `encode()` or `rank()` on that instance failed the same way. The reason — including the "input is too large for the context window" hint naming the token count and `n_ctx` — now reaches the caller, and the encoder stays usable for the next input. Available for all bindings.
 
 ## [Python v2.0.0, Flutter v3.0.0, Godot v10.0.0, Kotlin v3.0.0, React Native v3.0.0, Swift v3.0.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ### Fixed
 
-- A chat setter the worker rejects no longer kills the chat. Passing an invalid sampler config, or tools to a model with no tool-call template, ended the worker thread: the setter reported only "worker terminated", the real reason went to the log, and every later call on that chat — including `ask()` — failed the same way. The reason now reaches the caller and the chat keeps working, with the rejected value not applied. `set_chat_history` was fixed this way in the chat-completion change above; this covers `set_sampler_config`, `set_tools` and `reset_chat` too. Available for all bindings.
-- An input the encoder or cross-encoder rejects no longer kills it. Encoding or ranking text longer than the context window ended the worker thread, so the call reported only that the worker never responded, and every later `encode()` or `rank()` on that instance failed the same way. The reason — including the "input is too large for the context window" hint naming the token count and `n_ctx` — now reaches the caller, and the encoder stays usable for the next input. Available for all bindings.
+- A rejected chat setter no longer kills the chat. `set_sampler_config`, `set_tools` and `reset_chat` used to end the worker, so the reason was only logged and every later call — including `ask()` — failed with "worker terminated". The error now reaches the caller and the chat keeps working. Available for all bindings.
+- A rejected encoder or cross-encoder input no longer kills the worker. Text longer than the context window used to end it, so every later `encode()` or `rank()` failed too. The error now reaches the caller and the worker stays usable. Available for all bindings.
 
 ## [Python v2.0.0, Flutter v3.0.0, Godot v10.0.0, Kotlin v3.0.0, React Native v3.0.0, Swift v3.0.0] - 2026-08-20
 

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -55,9 +55,7 @@ impl CrossEncoderAsync {
             };
 
             while let Ok(msg) = msg_rx.recv() {
-                if let Err(e) = process_worker_msg(&mut worker_state, msg) {
-                    return error!(error=%e, "Cross-encoder worker crashed");
-                }
+                process_worker_msg(&mut worker_state, msg);
             }
         });
 
@@ -77,7 +75,7 @@ impl CrossEncoderAsync {
         scores_rx
             .recv()
             .await
-            .ok_or(CrossEncoderWorkerError::NoResponse)
+            .ok_or(CrossEncoderWorkerError::NoResponse)?
     }
 
     pub async fn rank_and_sort(
@@ -104,22 +102,22 @@ impl CrossEncoderAsync {
 }
 
 enum CrossEncoderMsg {
-    Rank(String, Vec<String>, tokio::sync::mpsc::Sender<Vec<f32>>),
+    Rank(
+        String,
+        Vec<String>,
+        tokio::sync::mpsc::Sender<Result<Vec<f32>, CrossEncoderWorkerError>>,
+    ),
 }
 
-fn process_worker_msg(
-    worker_state: &mut Worker<'_, CrossEncoderWorker>,
-    msg: CrossEncoderMsg,
-) -> Result<(), CrossEncoderWorkerError> {
+/// Handle one message, reporting success or failure on its reply channel.
+fn process_worker_msg(worker_state: &mut Worker<'_, CrossEncoderWorker>, msg: CrossEncoderMsg) {
     match msg {
         CrossEncoderMsg::Rank(query, documents, respond) => {
-            let scores = worker_state.rank(query, documents)?;
+            let scores = worker_state.rank(query, documents);
 
             let _ = respond.blocking_send(scores);
         }
     }
-
-    Ok(())
 }
 
 struct CrossEncoderWorker {}
@@ -367,5 +365,30 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_oversized_input_keeps_crossencoder_alive() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_crossencoder_model();
+        let crossencoder = CrossEncoder::new(model, 64);
+
+        let err = crossencoder
+            .rank("query".to_string(), vec!["word ".repeat(500)])
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CrossEncoderWorkerError::Read(crate::errors::ReadError::InputExceedsContext { .. })
+            ),
+            "the read error should reach the caller, got {err:?}"
+        );
+
+        crossencoder
+            .rank(
+                "What is the capital of France?".to_string(),
+                vec!["Paris is the capital of France.".to_string()],
+            )
+            .expect("worker still answers");
     }
 }

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -70,8 +70,11 @@ impl CrossEncoderAsync {
         documents: Vec<String>,
     ) -> Result<Vec<f32>, CrossEncoderWorkerError> {
         let (scores_tx, mut scores_rx) = tokio::sync::mpsc::channel(1);
-        self.guard
-            .send(CrossEncoderMsg::Rank(query, documents, scores_tx));
+        self.guard.send(CrossEncoderMsg::Rank {
+            query,
+            documents,
+            output_tx: scores_tx,
+        });
         scores_rx
             .recv()
             .await
@@ -102,20 +105,24 @@ impl CrossEncoderAsync {
 }
 
 enum CrossEncoderMsg {
-    Rank(
-        String,
-        Vec<String>,
-        tokio::sync::mpsc::Sender<Result<Vec<f32>, CrossEncoderWorkerError>>,
-    ),
+    Rank {
+        query: String,
+        documents: Vec<String>,
+        output_tx: tokio::sync::mpsc::Sender<Result<Vec<f32>, CrossEncoderWorkerError>>,
+    },
 }
 
 /// Handle one message, reporting success or failure on its reply channel.
 fn process_worker_msg(worker_state: &mut Worker<'_, CrossEncoderWorker>, msg: CrossEncoderMsg) {
     match msg {
-        CrossEncoderMsg::Rank(query, documents, respond) => {
+        CrossEncoderMsg::Rank {
+            query,
+            documents,
+            output_tx,
+        } => {
             let scores = worker_state.rank(query, documents);
 
-            let _ = respond.blocking_send(scores);
+            let _ = output_tx.blocking_send(scores);
         }
     }
 }

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -45,9 +45,7 @@ impl EncoderAsync {
             };
 
             while let Ok(msg) = msg_rx.recv() {
-                if let Err(e) = process_worker_msg(&mut worker_state, msg) {
-                    return error!(error=%e, "Encoder Worker crashed");
-                }
+                process_worker_msg(&mut worker_state, msg);
             }
         });
 
@@ -72,18 +70,19 @@ impl EncoderAsync {
             .send(EncoderMsg::EncodeBatch(texts, embedding_tx));
         embedding_rx.recv().await.ok_or(EncoderWorkerError::Encode(
             "Could not encode the texts. Worker never responded.".into(),
-        ))
+        ))?
     }
 }
 
 enum EncoderMsg {
-    EncodeBatch(Vec<String>, tokio::sync::mpsc::Sender<Vec<Vec<f32>>>),
+    EncodeBatch(
+        Vec<String>,
+        tokio::sync::mpsc::Sender<Result<Vec<Vec<f32>>, EncoderWorkerError>>,
+    ),
 }
 
-fn process_worker_msg(
-    worker_state: &mut Worker<'_, EncoderWorker>,
-    msg: EncoderMsg,
-) -> Result<(), EncoderWorkerError> {
+/// Handle one message, reporting success or failure on its reply channel.
+fn process_worker_msg(worker_state: &mut Worker<'_, EncoderWorker>, msg: EncoderMsg) {
     match msg {
         EncoderMsg::EncodeBatch(texts, respond) => {
             let pooling = worker_state.extra.pooling;
@@ -100,12 +99,10 @@ fn process_worker_msg(
                 .map_err(|error| match error {
                     BatchedReadError::Read(error) => EncoderWorkerError::Read(error),
                     BatchedReadError::Output(error) => EncoderWorkerError::Embeddings(error),
-                })?;
+                });
             let _ = respond.blocking_send(embeddings);
         }
     }
-
-    Ok(())
 }
 
 struct EncoderWorker {
@@ -295,5 +292,25 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_oversized_input_keeps_encoder_alive() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_embeddings_model();
+        let encoder = Encoder::new(model, 64);
+
+        let err = encoder.encode("word ".repeat(500)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                EncoderWorkerError::Read(crate::errors::ReadError::InputExceedsContext { .. })
+            ),
+            "the read error should reach the caller, got {err:?}"
+        );
+
+        encoder
+            .encode("Copenhagen is the capital of Denmark.".to_string())
+            .expect("worker still answers");
     }
 }

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -66,8 +66,10 @@ impl EncoderAsync {
         texts: Vec<String>,
     ) -> Result<Vec<Vec<f32>>, EncoderWorkerError> {
         let (embedding_tx, mut embedding_rx) = tokio::sync::mpsc::channel(1);
-        self.guard
-            .send(EncoderMsg::EncodeBatch(texts, embedding_tx));
+        self.guard.send(EncoderMsg::EncodeBatch {
+            texts,
+            output_tx: embedding_tx,
+        });
         embedding_rx.recv().await.ok_or(EncoderWorkerError::Encode(
             "Could not encode the texts. Worker never responded.".into(),
         ))?
@@ -75,16 +77,16 @@ impl EncoderAsync {
 }
 
 enum EncoderMsg {
-    EncodeBatch(
-        Vec<String>,
-        tokio::sync::mpsc::Sender<Result<Vec<Vec<f32>>, EncoderWorkerError>>,
-    ),
+    EncodeBatch {
+        texts: Vec<String>,
+        output_tx: tokio::sync::mpsc::Sender<Result<Vec<Vec<f32>>, EncoderWorkerError>>,
+    },
 }
 
 /// Handle one message, reporting success or failure on its reply channel.
 fn process_worker_msg(worker_state: &mut Worker<'_, EncoderWorker>, msg: EncoderMsg) {
     match msg {
-        EncoderMsg::EncodeBatch(texts, respond) => {
+        EncoderMsg::EncodeBatch { texts, output_tx } => {
             let pooling = worker_state.extra.pooling;
             let embeddings = worker_state
                 .engine
@@ -100,7 +102,7 @@ fn process_worker_msg(worker_state: &mut Worker<'_, EncoderWorker>, msg: Encoder
                     BatchedReadError::Read(error) => EncoderWorkerError::Read(error),
                     BatchedReadError::Output(error) => EncoderWorkerError::Embeddings(error),
                 });
-            let _ = respond.blocking_send(embeddings);
+            let _ = output_tx.blocking_send(embeddings);
         }
     }
 }


### PR DESCRIPTION
   Encoding or ranking text longer than the context window propagated the
   error out of `process_worker_msg`, which ended the worker thread before it
   could answer on the caller's reply channel. The caller therefore saw only
   the "worker never responded" fallback, and the dead thread made every
   later `encode()` / `rank()` on that instance fail the same way.

   Both workers now carry the Result on the message's own reply channel, so
   the read error reaches its caller and the worker stays alive. Same shape
   as the chat setter fix in #701. `EncoderMsg` and `CrossEncoderMsg` are
   private and the public signatures already returned these error types, so
   no binding changes.