### PR TITLE
docs/expo-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@
 
 ## Platforms
 
-We support Kotlin, Swift, Python, Flutter, React Native and Godot.
+We support Kotlin, Swift, Python, Flutter, React Native, Expo and Godot.
 
 | Platform | Installation | Documentation |
 |----------|-------------|---------------|
 | **Kotlin** | [Maven Central](#kotlin) | [docs.nobodywho.ooo/kotlin](https://docs.nobodywho.ooo/kotlin/) |
 | **Swift** | [SPM](#swift) | [docs.nobodywho.ooo/swift](https://docs.nobodywho.ooo/swift/) |
-| **React Native** | [npm](#react-native) | [docs.nobodywho.ooo/react-native](https://docs.nobodywho.ooo/react-native/) |
+| **React Native / Expo** | [npm](#react-native) | [docs.nobodywho.ooo/react-native](https://docs.nobodywho.ooo/react-native/) |
 | **Flutter** | [pub.dev](#flutter) | [docs.nobodywho.ooo/flutter](https://docs.nobodywho.ooo/flutter/) |
 | **Python** | [pypi](#python) | [docs.nobodywho.ooo/python](https://docs.nobodywho.ooo/python/) |
 | **Godot** | [AssetLib](#godot) | [docs.nobodywho.ooo/godot](https://docs.nobodywho.ooo/godot/) |
@@ -105,7 +105,7 @@ https://github.com/nobodywho-ooo/nobodywho-swift.git
 
 ---
 
-### React Native
+### React Native / Expo
 
 ```typescript
 import { Chat } from "react-native-nobodywho";
@@ -120,11 +120,15 @@ console.log(msg); // The capital of Denmark is Copenhagen.
 
 Install via npm:
 
-```
+```bash
+# React Native
 npm install react-native-nobodywho
+
+# Expo
+npx expo install react-native-nobodywho
 ```
 
-[React Native documentation](https://docs.nobodywho.ooo/react-native/) - [npm](https://www.npmjs.com/package/react-native-nobodywho) - [starter example app](https://github.com/nobodywho-ooo/react-native-starter-example)
+[RN / Expo documentation](https://docs.nobodywho.ooo/react-native/) - [npm](https://www.npmjs.com/package/react-native-nobodywho) - [RN starter example app](https://github.com/nobodywho-ooo/react-native-starter-example) - [Expo starter example app](https://github.com/nobodywho-ooo/expo-starter-example)
 
 ---
 

--- a/docs/docs-react-native/downloading-models.md
+++ b/docs/docs-react-native/downloading-models.md
@@ -1,6 +1,6 @@
 ---
 title: Downloading models
-description: How NobodyWho downloads, caches, and inspects GGUF models in React Native
+description: How NobodyWho downloads, caches, and inspects GGUF models in React Native & Expo
 sidebar_position: 1
 ---
 
@@ -18,7 +18,7 @@ The `modelPath` option to `Chat.fromPath` and `downloadModel` accepts:
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
-## Android permissions
+## Android permissions (React Native only)
 
 Loading a model from `hf://` or `https://` needs network access. The React Native app template already declares the internet permission in `android/app/src/main/AndroidManifest.xml`:
 

--- a/docs/docs-react-native/index.md
+++ b/docs/docs-react-native/index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: How to setup NobodyWho in React Native
+description: How to setup NobodyWho in React Native / Expo
 sidebar_position: 0
 ---
 
@@ -8,10 +8,44 @@ sidebar_position: 0
 
 First, install `react-native-nobodywho`.
 ```bash
+# React Native
 npm install react-native-nobodywho
+# Expo
+npx expo install react-native-nobodywho
 ```
 
+### React Native
+
 No additional initialization step is required — the native module is loaded automatically when you first import from the package.
+
+### Expo
+
+NobodyWho ships native code, so it does **not** run in [Expo Go](https://docs.expo.dev/get-started/set-up-your-environment/). You need a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+
+#### • Continuous Native Generation (CNG) projects
+
+In a managed project, `ios/` and `android/` are not committed. For the **first build**, run the command for the platform you are targeting (`run:ios` and `run:android` are alternatives — pick your target). It runs prebuild automatically since the native folders don't exist yet, installs pods, and builds NobodyWho in:
+
+```bash
+npx expo run:ios
+# or
+npx expo run:android
+```
+
+After you **upgrade** NobodyWho (or any other native dependency), the native folders already exist, so `run:*` would build against stale native code. Regenerate them from scratch, then rebuild:
+
+```bash
+npx expo prebuild --clean   # regenerate ios/ and android/ from scratch
+npx expo run:ios            # then rebuild (or run:android)
+```
+
+#### • Bare projects
+
+Here `ios/` and `android/` are committed. Autolinking registers the module on your next native build — just rebuild with `expo run:*` (or your existing native build). Do not run `prebuild --clean` here unless you intend to regenerate the native folders, since it overwrites manual native edits.
+
+You can also build with [EAS Build](https://docs.expo.dev/build/introduction/) instead of building locally. No config plugin is required.
+
+## Pick a model
 
 Now you are ready to pick a model. NobodyWho can download GGUF models directly from Hugging Face — just pass a `huggingface:` path. See [model selection](/docs/model-selection) for recommendations.
 

--- a/docs/docs-react-native/speech-to-text.md
+++ b/docs/docs-react-native/speech-to-text.md
@@ -1,6 +1,6 @@
 ---
 title: Speech to Text
-description: Transcribe spoken audio to text with NobodyWho in React Native.
+description: Transcribe spoken audio to text with NobodyWho in React Native & Expo.
 sidebar_position: 5
 ---
 

--- a/docs/docs-react-native/text-to-speech.md
+++ b/docs/docs-react-native/text-to-speech.md
@@ -1,6 +1,6 @@
 ---
 title: Text to Speech
-description: Generate WAV audio from text with NobodyWho in React Native.
+description: Generate WAV audio from text with NobodyWho in React Native & Expo.
 sidebar_position: 6
 ---
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,7 @@ enable real-time streaming of tokens, create embeddings, or synthesize speech, N
 
 All of this is enabled by [Llama.cpp](https://github.com/ggml-org/llama.cpp), while having nice, simple API.
 
-No need to mess around with docker containers, GPU servers, API keys, etc. We make it easy to run local models in Kotlin, Swift, Python, React Native, Flutter and Godot!
+No need to mess around with docker containers, GPU servers, API keys, etc. We make it easy to run local models in Kotlin, Swift, Python, Flutter, React Native, Expo and Godot!
 
 ## Code documentation
 
@@ -25,7 +25,7 @@ If you already know the basics of LLMs, jump to the docs for your favorite langu
   <Link to="/python/" className="button button--secondary button--sm">Python</Link>
   <Link to="/kotlin/" className="button button--secondary button--sm">Kotlin</Link>
   <Link to="/swift/" className="button button--secondary button--sm">Swift</Link>
-  <Link to="/react-native/" className="button button--secondary button--sm">React Native</Link>
+  <Link to="/react-native/" className="button button--secondary button--sm">React Native/Expo</Link>
   <Link to="/flutter/" className="button button--secondary button--sm">Flutter</Link>
   <Link to="/godot/" className="button button--secondary button--sm">Godot</Link>
 </div>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -31,7 +31,7 @@ const config: Config = {
   clientModules: ['./src/github-stars.js'],
 
   title: 'NobodyWho',
-  tagline: 'Local-first LLM inference for Kotlin, Swift, Python, Godot, Flutter, and React Native',
+  tagline: 'Local-first LLM inference for Kotlin, Swift, Python, Flutter, React Native, Expo and Godot',
   favicon: 'img/favicon.ico',
 
   url: 'https://docs.nobodywho.ooo',
@@ -188,7 +188,7 @@ const config: Config = {
         {to: '/kotlin/', label: 'Kotlin', position: 'left', activeBaseRegex: '/kotlin/'},
         {to: '/python/', label: 'Python', position: 'left', activeBaseRegex: '/python/'},
         {to: '/swift/', label: 'Swift', position: 'left', activeBaseRegex: '/swift/'},
-        {to: '/react-native/', label: 'React Native', position: 'left', activeBaseRegex: '/react-native/'},
+        {to: '/react-native/', label: 'RN/Expo', position: 'left', activeBaseRegex: '/react-native/'},
         {to: '/flutter/', label: 'Flutter', position: 'left', activeBaseRegex: '/flutter/'},
         {to: '/godot/', label: 'Godot', position: 'left', activeBaseRegex: '/godot/'},
         // Right side

--- a/docs/plugins/llms-txt/index.js
+++ b/docs/plugins/llms-txt/index.js
@@ -4,7 +4,7 @@ const matter = require('gray-matter');
 
 const SITE_URL = 'https://docs.nobodywho.ooo';
 const DESCRIPTION =
-  'NobodyWho runs LLMs locally in Kotlin, Swift, Python, Godot, Flutter, and React Native. It uses llama.cpp and supports streaming chat, tool calling, embeddings, RAG, offline inference, and GPU acceleration.';
+  'NobodyWho runs LLMs locally in Kotlin, Swift, Python, Flutter, React Native, Expo and Godot. It uses llama.cpp and supports streaming chat, tool calling, embeddings, RAG, speech to text, text to speech, voice activity detection, offline inference, and GPU acceleration.';
 
 // Map of documentation sources to section names and route prefixes
 const SECTIONS = [
@@ -12,7 +12,7 @@ const SECTIONS = [
   {id: 'kotlin', label: 'Kotlin', routeBase: '/kotlin'},
   {id: 'python', label: 'Python', routeBase: '/python'},
   {id: 'swift', label: 'Swift', routeBase: '/swift'},
-  {id: 'react-native', label: 'React Native', routeBase: '/react-native'},
+  {id: 'react-native', label: 'React Native/Expo', routeBase: '/react-native'},
   {id: 'flutter', label: 'Flutter', routeBase: '/flutter'},
   {id: 'godot', label: 'Godot', routeBase: '/godot'},
 ];

--- a/docs/react-native_versioned_docs/version-3.0.0/downloading-models.md
+++ b/docs/react-native_versioned_docs/version-3.0.0/downloading-models.md
@@ -1,6 +1,6 @@
 ---
 title: Downloading models
-description: How NobodyWho downloads, caches, and inspects GGUF models in React Native
+description: How NobodyWho downloads, caches, and inspects GGUF models in React Native & Expo
 sidebar_position: 1
 ---
 
@@ -18,7 +18,7 @@ The `modelPath` option to `Chat.fromPath` and `downloadModel` accepts:
 
 The HuggingFace prefix is case-insensitive and the `//` is optional — `hf:`, `hf://`, `huggingface:`, and `huggingface://` all mean the same thing. Remote models are downloaded to the platform cache directory on first load and re-used on subsequent runs.
 
-## Android permissions
+## Android permissions (React Native only)
 
 Loading a model from `hf://` or `https://` needs network access. The React Native app template already declares the internet permission in `android/app/src/main/AndroidManifest.xml`:
 

--- a/docs/react-native_versioned_docs/version-3.0.0/index.md
+++ b/docs/react-native_versioned_docs/version-3.0.0/index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: How to setup NobodyWho in React Native
+description: How to setup NobodyWho in React Native / Expo
 sidebar_position: 0
 ---
 
@@ -8,10 +8,44 @@ sidebar_position: 0
 
 First, install `react-native-nobodywho`.
 ```bash
+# React Native
 npm install react-native-nobodywho
+# Expo
+npx expo install react-native-nobodywho
 ```
 
+### React Native
+
 No additional initialization step is required — the native module is loaded automatically when you first import from the package.
+
+### Expo
+
+NobodyWho ships native code, so it does **not** run in [Expo Go](https://docs.expo.dev/get-started/set-up-your-environment/). You need a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+
+#### • Continuous Native Generation (CNG) projects
+
+In a managed project, `ios/` and `android/` are not committed. For the **first build**, run the command for the platform you are targeting (`run:ios` and `run:android` are alternatives — pick your target). It runs prebuild automatically since the native folders don't exist yet, installs pods, and builds NobodyWho in:
+
+```bash
+npx expo run:ios
+# or
+npx expo run:android
+```
+
+After you **upgrade** NobodyWho (or any other native dependency), the native folders already exist, so `run:*` would build against stale native code. Regenerate them from scratch, then rebuild:
+
+```bash
+npx expo prebuild --clean   # regenerate ios/ and android/ from scratch
+npx expo run:ios            # then rebuild (or run:android)
+```
+
+#### • Bare projects
+
+Here `ios/` and `android/` are committed. Autolinking registers the module on your next native build — just rebuild with `expo run:*` (or your existing native build). Do not run `prebuild --clean` here unless you intend to regenerate the native folders, since it overwrites manual native edits.
+
+You can also build with [EAS Build](https://docs.expo.dev/build/introduction/) instead of building locally. No config plugin is required.
+
+## Pick a model
 
 Now you are ready to pick a model. NobodyWho can download GGUF models directly from Hugging Face — just pass a `huggingface:` path. See [model selection](/docs/model-selection) for recommendations.
 

--- a/docs/react-native_versioned_docs/version-3.0.0/speech-to-text.md
+++ b/docs/react-native_versioned_docs/version-3.0.0/speech-to-text.md
@@ -1,6 +1,6 @@
 ---
 title: Speech to Text
-description: Transcribe spoken audio to text with NobodyWho in React Native.
+description: Transcribe spoken audio to text with NobodyWho in React Native & Expo.
 sidebar_position: 5
 ---
 

--- a/docs/react-native_versioned_docs/version-3.0.0/text-to-speech.md
+++ b/docs/react-native_versioned_docs/version-3.0.0/text-to-speech.md
@@ -1,6 +1,6 @@
 ---
 title: Text to Speech
-description: Generate WAV audio from text with NobodyWho in React Native.
+description: Generate WAV audio from text with NobodyWho in React Native & Expo.
 sidebar_position: 6
 ---
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -26,6 +26,12 @@ const sdks = [
     link: '/react-native/',
   },
   {
+    name: 'Expo',
+    description: 'Drop-in module for Expo on Android and iOS.',
+    install: 'npx expo install react-native-nobodywho',
+    link: '/react-native/',
+  },
+  {
     name: 'Flutter',
     description: 'Cross-platform plugin for Flutter on mobile and desktop.',
     install: 'flutter pub add nobodywho',

--- a/nobodywho/flutter/nobodywho/README.md
+++ b/nobodywho/flutter/nobodywho/README.md
@@ -2,7 +2,7 @@
 
 NobodyWho is a Flutter library for running large language models locally and offline on iOS, Android, macOS, Linux, and Windows.
 
-Free to use in commercial projects under the EUPL-1.2 license — no API key required. Support text, vision, embeddings, RAG & function calling.
+Free to use in commercial projects under the EUPL-1.2 license — no API key required. Support text, vision, hearing, speech-to-text, text-to-speech, voice activity detection, embeddings, RAG & function calling.
 
 - [Documentation](https://docs.nobodywho.ooo) — Flutter & other frameworks documentation
 - [Discord](https://discord.gg/qhaMc2qCYB) — Get help, share ideas, and connect with other developers
@@ -249,3 +249,75 @@ final response = await chat.askWithPrompt(nobodywho.Prompt([
 You can pass multiple images and audio parts and interleave text between them. If the model performs poorly, try reordering the text and image parts — this can make a noticeable difference. If images consume too much context, increase `contextSize` or preprocess images with compression.
 
 See the [Vision & Hearing documentation](https://docs.nobodywho.ooo/flutter/vision/) for model recommendations and advanced tips.
+
+---
+
+## Speech to Text
+
+Transcribe spoken audio into text using Whisper models in ONNX format:
+
+```dart
+import 'package:nobodywho/nobodywho.dart' as nobodywho;
+
+// ... after NobodyWho.init().
+final stt = await nobodywho.SpeechToText.load(source: 'hf://onnx-community/whisper-base');
+
+final text = await stt.transcribeFile('recording.mp3').completed();
+print(text);
+```
+
+You can also transcribe raw PCM buffers with `transcribePcm`, and stream the transcription token by token.
+
+See the [Speech to Text documentation](https://docs.nobodywho.ooo/flutter/speech-to-text/) for more.
+
+---
+
+## Text to Speech
+
+Generate natural-sounding speech from text, ready to save as a WAV file or play back in your app:
+
+```dart
+import 'dart:io';
+import 'package:nobodywho/nobodywho.dart' as nobodywho;
+
+// ... after NobodyWho.init().
+final tts = await nobodywho.TextToSpeech.load(
+  source: 'hf://NobodyWho/Kokoro-82M', // Hugging Face repo or local folder.
+  voice: 'bf_emma', // Voice to use from the model.
+  language: 'en-gb', // Language code for the input text.
+);
+
+final wav = await tts.synthesize(text: 'Hello from NobodyWho!');
+await File('out.wav').writeAsBytes(wav);
+```
+
+NobodyWho supports the Kokoro, Pocket TTS, and Supertonic speech synthesis architectures.
+
+See the [Text to Speech documentation](https://docs.nobodywho.ooo/flutter/text-to-speech/) for more.
+
+---
+
+## Voice Activity Detection
+
+Detect speech automatically in an audio stream, so you know when to stop listening to the microphone and start transcribing:
+
+```dart
+import 'package:nobodywho/nobodywho.dart' as nobodywho;
+
+// ... after NobodyWho.init().
+final vad = await nobodywho.VoiceActivityDetection.load(
+  sampleRate: 16000,
+  source: 'hf://onnx-community/silero-vad',
+);
+
+while (true) {
+  final chunk = readMic();
+  if (vad.push(chunk) == nobodywho.VoiceActivityDetectionEvent.speechEnded) break;
+}
+
+final speech = vad.finish(); // buffered speech, ready to pass to SpeechToText
+```
+
+You can also segment speech out of an existing recording with `segment()`.
+
+See the [Voice Activity Detection documentation](https://docs.nobodywho.ooo/flutter/voice-activity-detection/) for more.

--- a/nobodywho/flutter/nobodywho/pubspec.yaml
+++ b/nobodywho/flutter/nobodywho/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nobodywho
-description: "On-device AI for mobile & desktop — text, vision, embeddings, RAG & function calling. Run GGUF models with Metal/Vulkan acceleration. Free for commercial use."
+description: "On-device AI for mobile & desktop: text, vision, embeddings, RAG, tool calling, STT, TTS & VAD. Run GGUF models with Metal/Vulkan acceleration. Free for commercial use."
 version: 3.0.0
 repository: https://github.com/nobodywho-ooo/nobodywho
 issue_tracker: https://github.com/nobodywho-ooo/nobodywho/issues
@@ -9,8 +9,8 @@ homepage: https://docs.nobodywho.ooo/
 topics:
   - ai
   - llm
-  - genai
-  - inference
+  - stt
+  - tts
   - local-ai
 
 environment:

--- a/nobodywho/python/PYPI_DESCRIPTION.md
+++ b/nobodywho/python/PYPI_DESCRIPTION.md
@@ -9,6 +9,10 @@ NobodyWho is a lightweight, open-source inference engine that makes it simple to
 - **Run locally, offline, for free** - No API keys or cloud services required
 - **Fast, simple tool calling** - Just pass normal Python functions
 - **Reliable tool execution** - Automatically derives grammar from function signatures
+- **Speech-to-text** - Transcribe spoken audio into text with Whisper models
+- **Text-to-speech** - Generate natural-sounding speech from text
+- **Voice activity detection** - Detect speech in an audio stream to know when to start and stop listening
+- **Vision & embeddings** - Multimodal image input, plus embeddings and reranking for semantic search and RAG
 - **Infinite conversations** - Conversation-aware preemptive context shifting prevents mid-conversation crashes
 - **GPU accelerated** - Vulkan-powered inference for maximum performance
 - **Thousands of compatible models** - Works with any LLM in GGUF format

--- a/nobodywho/react-native/README.md
+++ b/nobodywho/react-native/README.md
@@ -1,22 +1,55 @@
-# NobodyWho React Native
+# NobodyWho React Native / Expo
 
-NobodyWho is a React Native library for running large language models locally and offline on iOS and Android.
+NobodyWho is a React Native / Expo library for running large language models locally and offline on iOS and Android.
 
-Free to use in commercial projects under the EUPL-1.2 license — no API key required. Supports text, vision, embeddings, RAG & function calling.
+Free to use in commercial projects under the EUPL-1.2 license — no API key required. Supports text, vision, hearing, speech-to-text, text-to-speech, voice activity detection, embeddings, RAG & function calling.
 
 - [Documentation](https://docs.nobodywho.ooo) — React Native & other frameworks documentation
-- [Starter example app](https://github.com/nobodywho-ooo/react-native-starter-example) — Test this library in 5 minutes
+- [RN starter example app](https://github.com/nobodywho-ooo/react-native-starter-example) / [Expo starter example app](https://github.com/nobodywho-ooo/expo-starter-example) — Test this library in 5 minutes
 - [Discord](https://discord.gg/qhaMc2qCYB) — Get help, share ideas, and connect with other developers
 - [GitHub Issues](https://github.com/nobodywho-ooo/nobodywho/issues) — Report bugs
 - [GitHub Discussions](https://github.com/nobodywho-ooo/nobodywho/discussions) — Ask questions and request features
 
-## Quick Start
+## How do I get started?
 
-Install the library:
-
-```
+First, install `react-native-nobodywho`.
+```bash
+# React Native
 npm install react-native-nobodywho
+# Expo
+npx expo install react-native-nobodywho
 ```
+
+### React Native
+
+No additional initialization step is required — the native module is loaded automatically when you first import from the package.
+
+### Expo
+
+NobodyWho ships native code, so it does **not** run in [Expo Go](https://docs.expo.dev/get-started/set-up-your-environment/). You need a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+
+#### • Continuous Native Generation (CNG) projects
+
+In a managed project, `ios/` and `android/` are not committed. For the **first build**, run the command for the platform you are targeting (`run:ios` and `run:android` are alternatives — pick your target). It runs prebuild automatically since the native folders don't exist yet, installs pods, and builds NobodyWho in:
+
+```bash
+npx expo run:ios
+# or
+npx expo run:android
+```
+
+After you **upgrade** NobodyWho (or any other native dependency), the native folders already exist, so `run:*` would build against stale native code. Regenerate them from scratch, then rebuild:
+
+```bash
+npx expo prebuild --clean   # regenerate ios/ and android/ from scratch
+npx expo run:ios            # then rebuild (or run:android)
+```
+
+#### • Bare projects
+
+Here `ios/` and `android/` are committed. Autolinking registers the module on your next native build — just rebuild with `expo run:*` (or your existing native build). Do not run `prebuild --clean` here unless you intend to regenerate the native folders, since it overwrites manual native edits.
+
+You can also build with [EAS Build](https://docs.expo.dev/build/introduction/) instead of building locally. No config plugin is required.
 
 ## Supported Model Format
 
@@ -152,3 +185,76 @@ const response = await chat
 You can pass multiple images/audio files and interleave text between them. If the model performs poorly, try reordering the text, audio and image parts — this can make a noticeable difference. If images consume too much context, increase `contextSize` or preprocess images with compression.
 
 See the [Vision & Hearing documentation](https://docs.nobodywho.ooo/react-native/vision/) for model recommendations and advanced tips.
+
+---
+
+## Speech to Text
+
+Transcribe spoken audio into text using Whisper models in ONNX format:
+
+```typescript
+import { SpeechToText } from "react-native-nobodywho";
+
+const stt = await SpeechToText.load({
+  source: "hf://onnx-community/whisper-base",
+});
+
+const text = await stt.transcribeFile("recording.mp3").completed();
+console.log(text);
+```
+
+You can also transcribe raw PCM buffers with `transcribePcm`, and stream the transcription token by token.
+
+See the [Speech to Text documentation](https://docs.nobodywho.ooo/react-native/speech-to-text/) for more.
+
+---
+
+## Text to Speech
+
+Generate natural-sounding speech from text, ready to save as a WAV file or play back in your app:
+
+```typescript
+import { TextToSpeech } from "react-native-nobodywho";
+
+const tts = await TextToSpeech.load({
+  source: "hf://NobodyWho/Kokoro-82M", // Hugging Face repo or local folder.
+  voice: "bf_emma", // Voice to use from the model.
+  language: "en-gb", // Language code for the input text.
+});
+
+const wav = await tts.synthesize("Hello from NobodyWho!");
+// wav is a Uint8Array containing WAV bytes.
+```
+
+NobodyWho supports the Kokoro, Pocket TTS, and Supertonic speech synthesis architectures.
+
+See the [Text to Speech documentation](https://docs.nobodywho.ooo/react-native/text-to-speech/) for more.
+
+---
+
+## Voice Activity Detection
+
+Detect speech automatically in an audio stream, so you know when to stop listening to the microphone and start transcribing:
+
+```typescript
+import {
+  VoiceActivityDetection,
+  VoiceActivityDetectionEvent,
+} from "react-native-nobodywho";
+
+const vad = await VoiceActivityDetection.load({
+  sampleRate: 16000,
+  source: "hf://onnx-community/silero-vad",
+});
+
+while (true) {
+  const chunk = readMic();
+  if (vad.push(chunk) === VoiceActivityDetectionEvent.SpeechEnded) break;
+}
+
+const speech = vad.finish(); // buffered speech, ready to pass to SpeechToText
+```
+
+You can also segment speech out of an existing recording with `segment()`.
+
+See the [Voice Activity Detection documentation](https://docs.nobodywho.ooo/react-native/voice-activity-detection/) for more.

--- a/nobodywho/react-native/package.json
+++ b/nobodywho/react-native/package.json
@@ -1,21 +1,25 @@
 {
   "name": "react-native-nobodywho",
   "version": "3.0.0",
-  "description": "Run LLMs locally with offline inference — React Native bindings",
+  "description": "Run LLMs locally and offline with React Native & Expo - Tool calling, RAG, Speech-to-Text, Text-to-Speech, and VAD",
   "main": "src/wrapper.ts",
   "types": "src/wrapper.ts",
   "exports": {
     ".": "./src/wrapper.ts"
   },
   "license": "EUPL-1.2",
-  "homepage": "https://nobodywho.ooo",
+  "homepage": "https://www.nobodywho.ai",
   "bugs": "https://github.com/nobodywho-ooo/nobodywho/issues",
   "keywords": [
     "react-native",
+    "expo",
     "ai",
     "llm",
     "local-ai",
     "inference",
+    "stt",
+    "tts",
+    "vad",
     "gguf",
     "on-device",
     "offline"

--- a/nobodywho/swift/README.md
+++ b/nobodywho/swift/README.md
@@ -180,6 +180,55 @@ let chat = try await Chat.fromPath(
 // SamplerPresets.constrainWithGrammar("...")        — constrain to a Lark or GBNF grammar
 ```
 
+### Speech to Text
+
+Transcribe spoken audio into text using Whisper models in ONNX format:
+
+```swift
+let stt = try await SpeechToText.load(source: "hf://onnx-community/whisper-base")
+
+let text = try await stt.transcribeFile(path: "recording.mp3").completed()
+```
+
+You can also transcribe raw PCM buffers with `transcribePcm`, and stream the transcription token by token.
+
+### Text to Speech
+
+Generate natural-sounding speech from text, ready to save as a WAV file or play back in your app:
+
+```swift
+let tts = try await TextToSpeech.load(
+    source: "hf://NobodyWho/Kokoro-82M",
+    voice: "bf_emma",
+    language: "en-gb"
+)
+
+let wav = try await tts.synthesize("Hello from NobodyWho!")
+try wav.write(to: URL(fileURLWithPath: "out.wav"))
+```
+
+NobodyWho supports the Kokoro, Pocket TTS, and Supertonic speech synthesis architectures.
+
+### Voice Activity Detection
+
+Detect speech automatically in an audio stream, so you know when to stop listening to the microphone and start transcribing:
+
+```swift
+let vad = try await VoiceActivityDetection.load(sampleRate: 16000, source: "hf://onnx-community/silero-vad")
+let stt = try await SpeechToText.load(source: "hf://onnx-community/whisper-base")
+
+while let chunk = readMic() {
+    if try vad.push(chunk: chunk) == .speechEnded {
+        break
+    }
+}
+
+let speech = vad.finish()
+let transcription = try await stt.transcribePcm(samples: speech, sampleRate: 16000).completed()
+```
+
+You can also segment speech out of an existing recording with `segment`.
+
 ## Documentation
 
 Full documentation is available at [docs.nobodywho.ooo](https://docs.nobodywho.ooo).


### PR DESCRIPTION
## Description

Improve docs for expo support: 
- add expo in doc home page, navbar menu
- `Getting started` for expo in the docs with specific documentation
- mention Expo with React Native in readme
- add expo in llm.txt

Also improve nobodywho presence on npm/pub.dev/SPI/pypi (list all the features that were not presented + code snippets)

## Type of change

- [x] Documentation update