### PR TITLE
:wrench: Install npm deps in `regen-uniffi` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,5 +52,9 @@ regen-uniffi:
     cd nobodywho && cargo build -p nobodywho-uniffi --locked
     cd nobodywho && target/debug/uniffi-bindgen generate --library target/debug/libnobodywho_uniffi.{{LIB_EXT}} --language swift --out-dir swift/generated
     cd nobodywho && target/debug/uniffi-bindgen generate --library target/debug/libnobodywho_uniffi.{{LIB_EXT}} --language kotlin --out-dir kotlin/common/generated
+    # npm's hidden lockfile mirrors the installed tree; if it predates
+    # package-lock.json the install is missing or stale. Without this,
+    # npx below silently fetches an unpinned uniffi-bindgen-react-native.
+    cd nobodywho/react-native && { [ node_modules/.package-lock.json -nt package-lock.json ] || npm ci; }
     cd nobodywho && npx --prefix react-native uniffi-bindgen-react-native generate jsi bindings --library --ts-dir react-native/generated/ts --cpp-dir react-native/generated/cpp $(pwd)/target/debug/libnobodywho_uniffi.{{LIB_EXT}}
     git diff --exit-code nobodywho/swift/generated/ nobodywho/kotlin/common/generated/ nobodywho/react-native/generated/ || (echo "Uniffi bindings are out of date — commit them before pushing" && exit 1)


### PR DESCRIPTION
Adds a line to the `regen-uniffi` Justfile recipe that installs npm dependencies iff the `node_modules` dir is stale or non-existant.

Without this, npx will install a non-pinned version of uniffi which will generate different bindings. This is of course bad in itself, but it will also make the recipe fail spuriously.
