### PR TITLE
Make `InferenceEngine` return one token at a time

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1641,13 +1641,7 @@ fn process_worker_msg(worker_state: &mut Chat<'_>, msg: ChatMsg) {
             let _ = output_tx.blocking_send(stats);
         }
         ChatMsg::GetMtpAcceptanceRate { output_tx } => {
-            let proposed = worker_state.engine.mtp_drafts_proposed;
-            let rate = if proposed > 0 {
-                Some(worker_state.engine.mtp_drafts_accepted as f32 / proposed as f32)
-            } else {
-                None
-            };
-            let _ = output_tx.blocking_send(rate);
+            let _ = output_tx.blocking_send(worker_state.engine.mtp_acceptance_rate());
         }
         ChatMsg::Tokenize { prompt, output_tx } => {
             let result = worker_state.tokenize(prompt);

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -1636,7 +1636,7 @@ fn process_worker_msg(worker_state: &mut Chat<'_>, msg: ChatMsg) {
         ChatMsg::GetStats { output_tx } => {
             let stats = ChatStats {
                 context_size: worker_state.engine.ctx.n_ctx(),
-                context_used: worker_state.engine.n_past(),
+                context_used: worker_state.engine.actual_context_size() as u32,
             };
             let _ = output_tx.blocking_send(stats);
         }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2777,7 +2777,8 @@ mod tests {
     /// env vars are set to existing files.
     #[test]
     fn test_mtp_gemma4_smoke() -> Result<(), Box<dyn std::error::Error>> {
-        // test_utils::init_test_tracing();
+        test_utils::init_test_tracing();
+
         let (Some(target_path), Some(draft_path)) = (
             test_utils::test_mtp_target_model_path(),
             test_utils::test_mtp_draft_model_path(),
@@ -2822,11 +2823,21 @@ mod tests {
                 sender.send(resp).unwrap();
             }
         };
-
         worker.ask("What is the capital of Denmark?".into(), f)?;
         let resp = receiver.recv()?;
         println!("MTP response: {}", resp);
         assert!(resp.contains("Copenhagen"));
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let f = move |x| {
+            if let llm::WriteOutput::Done(resp) = x {
+                sender.send(resp).unwrap();
+            }
+        };
+        worker.ask("Are you sure?".into(), f)?;
+        let resp = receiver.recv()?;
+        println!("MTP response: {}", resp);
+        assert!(resp.contains("Yes"));
 
         Ok(())
     }

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2089,7 +2089,6 @@ impl<'a> Chat<'a> {
         // 4096 is a very randomly chosen number. how does this affect performance?
         let mut full_response: String = String::with_capacity(4096);
         let mut tokens_written_until_now = Vec::new();
-        let mut new_tokens = Vec::new();
         let mut generated_tokens = 0;
 
         self.sampler.reset();
@@ -2114,73 +2113,51 @@ impl<'a> Chat<'a> {
                 // do not update tokens_in_context as this is done later by ask
             }
 
-            // Sample next token(s), no need to use sampler.accept as sample already accepts the token.
-            // using sampler.accept() will cause the sampler to crash when using grammar sampling.
-            // https://github.com/utilityai/llama-cpp-rs/issues/604
-            let remaining_tokens =
-                max_tokens.map(|max_tokens| max_tokens.saturating_sub(generated_tokens));
-            self.engine.sample_and_decode_next_tokens(
-                &mut self.sampler,
-                &mut new_tokens,
-                remaining_tokens,
-            )?;
+            let new_token = self.engine.next_token(&mut self.sampler)?;
 
-            tokens_written_until_now.extend_from_slice(&new_tokens);
+            tokens_written_until_now.push(new_token);
 
-            let mut should_finish = false;
-            for &new_token in &new_tokens {
-                // Attempt to convert token(s) to bytes
-                let token_bytes = match self
-                    .engine
-                    .ctx
-                    .model
-                    .token_to_piece_bytes(new_token, 64, true, None)
-                {
-                    Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
-                        self.engine.ctx.model.token_to_piece_bytes(
-                            new_token,
-                            (-i).try_into().expect("Error buffer size is positive"),
-                            true,
-                            None,
-                        )
-                    }
-                    x => x,
-                }?;
-
-                // Attempt to convert bytes to utf8 string.
-                let max_len = decoder
-                    .max_utf8_buffer_length(token_bytes.len())
-                    .unwrap_or(32);
-                let mut token_str = String::with_capacity(max_len);
-
-                // this is where the utf-8 decoder handles partial unicode
-                // it'll write whatever printable chars it can into `token_str`
-                // and retain partial codepoints for next decoding attempt
-                let (_result, _bytes_read, _had_errors) =
-                    decoder.decode_to_string(&token_bytes, &mut token_str, false);
-
-                let has_eog = self.engine.ctx.model.is_eog_token(new_token);
-                trace!(?new_token, ?token_str, ?has_eog);
-
-                if has_eog {
-                    should_finish = true;
-                    break;
+            // Attempt to convert token(s) to bytes
+            let token_bytes = match self
+                .engine
+                .ctx
+                .model
+                .token_to_piece_bytes(new_token, 64, true, None)
+            {
+                Err(llama_cpp_2::TokenToStringError::InsufficientBufferSpace(i)) => {
+                    self.engine.ctx.model.token_to_piece_bytes(
+                        new_token,
+                        (-i).try_into().expect("Error buffer size is positive"),
+                        true,
+                        None,
+                    )
                 }
+                x => x,
+            }?;
 
-                full_response.push_str(&token_str);
-                generated_tokens += 1;
-                trace!(?token_str, "Sending out token:");
-                respond(WriteOutput::Token(token_str));
+            // Attempt to convert bytes to utf8 string.
+            let max_len = decoder
+                .max_utf8_buffer_length(token_bytes.len())
+                .unwrap_or(32);
+            let mut token_str = String::with_capacity(max_len);
 
-                if max_tokens.is_some_and(|max_tokens| generated_tokens >= max_tokens) {
-                    should_finish = true;
-                    break;
-                }
-            }
+            // this is where the utf-8 decoder handles partial unicode
+            // it'll write whatever printable chars it can into `token_str`
+            // and retain partial codepoints for next decoding attempt
+            let (_result, _bytes_read, _had_errors) =
+                decoder.decode_to_string(&token_bytes, &mut token_str, false);
 
-            if should_finish {
+            let has_eog = self.engine.ctx.model.is_eog_token(new_token);
+            trace!(?new_token, ?token_str, ?has_eog);
+
+            if has_eog {
                 break;
             }
+
+            full_response.push_str(&token_str);
+            generated_tokens += 1;
+            trace!(?token_str, "Sending out token:");
+            respond(WriteOutput::Token(token_str));
         }
 
         // we're done!

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2102,8 +2102,6 @@ impl<'a> Chat<'a> {
         {
             // Check if the context is full
             if self.engine.is_context_full() {
-                // pending should be preserved during context shift
-                let deferred_pending = self.engine.take_pending();
                 self.context_shift()?;
                 self.sync_context_with_render(inference_lock_token)?;
                 if !tokens_written_until_now.is_empty() {
@@ -2113,7 +2111,6 @@ impl<'a> Chat<'a> {
                     self.engine
                         .read_chunks(generated_chunks, inference_lock_token)?;
                 }
-                self.engine.restore_pending(deferred_pending);
                 // do not update tokens_in_context as this is done later by ask
             }
 
@@ -2514,7 +2511,7 @@ impl<'a> Chat<'a> {
             self.tool_format.as_ref(),
         )?;
 
-        self.engine.reset_context();
+        self.engine.reset_context()?;
         self.sampler.set_tool(tool_sampler);
         self.tools = tools;
         self.messages = Vec::new();

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -40,6 +40,7 @@ use crate::tokenizer::{ChunkId, Prompt, Promptable, TokenizerChunk, TokenizerChu
 use crate::tool_calling::{detect_tool_format, Tool, ToolCall, ToolFormat, ToolFormatError};
 use ahash::AHasher;
 use indexmap::IndexMap;
+use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::mtmd::MtmdBitmap;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
@@ -1807,7 +1808,7 @@ impl ChatSampler {
     }
 
     /// The sampler that should produce the next token.
-    pub(crate) fn active(&mut self) -> &mut LlamaSampler {
+    fn active(&mut self) -> &mut LlamaSampler {
         if self.grammar_activated {
             self.tool
                 .as_mut()
@@ -1817,11 +1818,19 @@ impl ChatSampler {
         }
     }
 
+    pub(crate) fn sample(&mut self, ctx: &LlamaContext<'_>, idx: i32) -> LlamaToken {
+        // No need to use `sampler.accept` as `.sample` already accepts
+        // the token: https://github.com/utilityai/llama-cpp-rs/issues/604
+        let token = self.active().sample(ctx, idx);
+        self.observe(token);
+        token
+    }
+
     /// Feed an emitted token back in so the begin sequence can be tracked, and
     /// switch to the tool sampler once it completes. Must be called on each
     /// emitted token, in order, before its successor is sampled. Returns whether
     /// the switch just happened.
-    pub(crate) fn observe(&mut self, token: LlamaToken) -> bool {
+    fn observe(&mut self, token: LlamaToken) -> bool {
         if self.grammar_activated || self.begin_tokens.is_empty() {
             return false;
         }

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -492,6 +492,9 @@ pub enum SetterError {
 
     #[error("Invalid sampler configuration: {0}")]
     Sampler(#[from] SamplerError),
+
+    #[error("MTP speculative decode call failed: {0}")]
+    MtpSpeculative(#[from] llama_cpp_2::speculative::MtpSpeculativeError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1002,6 +1005,12 @@ pub enum DecodingError {
     #[error("MTP speculative decode call failed: {0}")]
     MtpSpeculative(#[from] llama_cpp_2::speculative::MtpSpeculativeError),
 
+    #[error(transparent)]
+    Rollback(#[from] RollbackError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RollbackError {
     #[error("KV cache rollback failed: {0}")]
     KvCache(#[from] llama_cpp_2::context::kv_cache::KvCacheConversionError),
 
@@ -1211,6 +1220,9 @@ pub enum ContextSyncError {
     #[error("Error shifting context: {0}")]
     #[diagnostic(transparent)]
     Shift(#[from] ShiftError),
+
+    #[error("MTP speculative decode call failed: {0}")]
+    MtpSpeculative(#[from] llama_cpp_2::speculative::MtpSpeculativeError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -115,8 +115,8 @@ pub(crate) struct InferenceEngine<'a> {
     tokenizer: Tokenizer<'a>,
     // Configured limits before llama.cpp's internal rounding.
     batch_capacity: BatchCapacity,
-    big_batch: LlamaBatch<'a>,
-    small_batch: LlamaBatch<'a>,
+    /// Batch that's used when decoding. Stored here to re-use the allocation.
+    batch: LlamaBatch<'static>,
     use_embeddings: bool,
     /// Deferred-decode "pending sample": a token sampled from the
     /// target but not yet decoded into the KV cache
@@ -133,19 +133,20 @@ pub(crate) struct InferenceEngine<'a> {
 impl<'a> InferenceEngine<'a> {
     pub(crate) fn new(
         ctx: EngineContext<'a>,
-        big_batch: LlamaBatch<'a>,
-        small_batch: LlamaBatch<'a>,
         projection_model: Option<&'a ProjectionModel>,
         batch_capacity: BatchCapacity,
         tokenizer: Tokenizer<'a>,
         use_embeddings: bool,
     ) -> Self {
+        // The batch limit is sequence IDs per token; each embedding token
+        // belongs to one sequence.
+        let batch = LlamaBatch::new(ctx.n_ctx() as usize, 1);
+
         Self {
             n_past: 0,
             ctx,
             batch_capacity,
-            big_batch,
-            small_batch,
+            batch,
             projection_model,
             tokenizer,
             use_embeddings,
@@ -200,14 +201,14 @@ impl<'a> InferenceEngine<'a> {
         let mut outputs = Vec::with_capacity(tokenized_inputs.len());
 
         for range in ranges {
-            self.big_batch.clear();
+            self.batch.clear();
             for (sequence_id, tokens) in tokenized_inputs[range.clone()].iter().enumerate() {
-                self.big_batch
+                self.batch
                     .add_sequence(tokens, sequence_id as i32, true)
                     .map_err(ReadError::BatchAdd)?;
             }
 
-            let n_tokens = self.big_batch.n_tokens();
+            let n_tokens = self.batch.n_tokens();
             let n_sequences = range.len();
             let inference_lock_token = acquire_inference_lock();
             self.reset_context();
@@ -219,7 +220,7 @@ impl<'a> InferenceEngine<'a> {
             );
             let decode_guard = decode_span.enter();
             self.ctx
-                .decode(&mut self.big_batch)
+                .decode(&mut self.batch)
                 .map_err(ReadError::Decode)?;
             drop(decode_guard);
 
@@ -318,7 +319,7 @@ impl<'a> InferenceEngine<'a> {
         {
             debug!("Populating batch");
             // make batch
-            self.big_batch.clear();
+            self.batch.clear();
             let seq_ids = &[0];
             for (i, token) in (0..).zip(tokens.iter()) {
                 // For LLM workers only the last token's logits are needed (sampling).
@@ -327,7 +328,7 @@ impl<'a> InferenceEngine<'a> {
                 // logs "embeddings required but some input tokens were not marked as
                 // outputs -> overriding" and silently flips them on for us.
                 let output_logits = self.use_embeddings || i == n_tokens - 1;
-                self.big_batch
+                self.batch
                     .add(*token, self.n_past + i as i32, seq_ids, output_logits)?;
             }
         }
@@ -335,12 +336,12 @@ impl<'a> InferenceEngine<'a> {
         // llm go brr
         let decode_span = debug_span!("read decode", n_tokens = n_tokens);
         let decode_guard = decode_span.enter();
-        self.ctx.decode(&mut self.big_batch)?;
+        self.ctx.decode(&mut self.batch)?;
         drop(decode_guard);
         // brrr
 
         // Keep the MTP draft ctx's hidden state in sync (no-op on solo).
-        self.ctx.mtp_process(&self.big_batch)?;
+        self.ctx.mtp_process(&self.batch)?;
 
         self.n_past += tokens.len() as i32;
         // A new prompt (or context-shift replay) invalidates any deferred
@@ -498,11 +499,11 @@ impl<'a> InferenceEngine<'a> {
         let token = sampler.active().sample(&self.ctx, -1);
         sampler.observe(token);
 
-        self.small_batch.clear();
-        self.small_batch.add(token, self.n_past, &[0], true)?;
+        self.batch.clear();
+        self.batch.add(token, self.n_past, &[0], true)?;
 
         let _span = trace_span!("write decode", n_past = self.n_past).entered();
-        self.ctx.decode(&mut self.small_batch)?;
+        self.ctx.decode(&mut self.batch)?;
 
         self.n_past += 1;
 
@@ -546,16 +547,15 @@ impl<'a> InferenceEngine<'a> {
         drafts.truncate(room.min(output_room));
         let k_max = drafts.len();
 
-        self.big_batch.clear();
-        self.big_batch.add(pending, self.n_past, &[0], true)?;
+        self.batch.clear();
+        self.batch.add(pending, self.n_past, &[0], true)?;
         for (i, &d) in drafts.iter().enumerate() {
-            self.big_batch
-                .add(d, self.n_past + 1 + i as i32, &[0], true)?;
+            self.batch.add(d, self.n_past + 1 + i as i32, &[0], true)?;
         }
         let span = trace_span!("mtp verify decode", n_past = self.n_past, k_max).entered();
-        self.ctx.decode(&mut self.big_batch)?;
+        self.ctx.decode(&mut self.batch)?;
         drop(span);
-        self.ctx.mtp_process(&self.big_batch)?;
+        self.ctx.mtp_process(&self.batch)?;
 
         let mut accepted_count = 0;
         self.pending = None;

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -535,7 +535,6 @@ impl<'a> InferenceEngine<'a> {
             };
             spec.draft(self.n_past, pending, &[])?
         };
-        let accept_owed = !drafts.is_empty();
 
         // Clamp drafts so the verify batch [pending, drafts...] stays
         // within the context window:
@@ -546,56 +545,33 @@ impl<'a> InferenceEngine<'a> {
         drafts.truncate(room.min(output_room));
         let k_max = drafts.len();
 
-        if k_max == 0 {
-            trace!(?pending, "MTP: no draft proposals to verify");
-            self.small_batch.clear();
-            self.small_batch.add(pending, self.n_past, &[0], true)?;
-            self.ctx.decode(&mut self.small_batch)?;
-            self.ctx.mtp_process(&self.small_batch)?;
-            if accept_owed {
-                let EngineContext::Speculative(spec) = &mut self.ctx else {
-                    unreachable!();
-                };
-                spec.accept(0)?;
-            }
-            let new_pending = sampler.active().sample(&self.ctx, -1);
-            self.n_past += 1;
-            self.pending = Some(new_pending);
-            output.push(pending);
-            return Ok(());
-        }
-
         self.big_batch.clear();
         self.big_batch.add(pending, self.n_past, &[0], true)?;
         for (i, &d) in drafts.iter().enumerate() {
             self.big_batch
                 .add(d, self.n_past + 1 + i as i32, &[0], true)?;
         }
-        {
-            let decode_span = trace_span!("mtp verify decode", n_past = self.n_past, k_max);
-            let _decode_guard = decode_span.enter();
-            self.ctx.decode(&mut self.big_batch)?;
-        }
+        let span = trace_span!("mtp verify decode", n_past = self.n_past, k_max).entered();
+        self.ctx.decode(&mut self.big_batch)?;
+        drop(span);
         self.ctx.mtp_process(&self.big_batch)?;
 
         let mut accepted_count = 0;
-        let mut new_pending = None;
+        self.pending = None;
         for (i, &draft) in drafts.iter().enumerate() {
             let ti = sampler.active().sample(&self.ctx, i as i32);
             if self.ctx.model.is_eog_token(ti) {
                 trace!(?ti, "MTP: target sampled EOG during verify, stopping");
-                new_pending = Some(ti);
+                self.pending = Some(ti);
                 break;
             }
             if ti != draft {
-                new_pending = Some(ti);
+                self.pending = Some(ti);
                 break;
             }
             accepted_count += 1;
             sampler.observe(draft); // detects switch to grammar-constrained sampling
         }
-        let new_pending =
-            new_pending.unwrap_or_else(|| sampler.active().sample(&self.ctx, k_max as i32));
 
         if accepted_count < k_max {
             let keep_up_to = (self.n_past + 1 + accepted_count as i32) as u32;
@@ -621,7 +597,6 @@ impl<'a> InferenceEngine<'a> {
         }
 
         self.n_past += 1 + accepted_count as i32;
-        self.pending = Some(new_pending);
         self.mtp_drafts_proposed += k_max as u64;
         self.mtp_drafts_accepted += accepted_count as u64;
 
@@ -629,7 +604,6 @@ impl<'a> InferenceEngine<'a> {
             accepted_count,
             k_max,
             ?pending,
-            ?new_pending,
             "MTP: deferred iteration complete"
         );
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -478,6 +478,20 @@ impl<'a> InferenceEngine<'a> {
         output: &mut Vec<LlamaToken>,
     ) -> Result<(), DecodingError> {
         trace!("Applying sampler (solo)");
+
+        // Somewhat un-intuitively, we actually want to sample first, before
+        // attempting to generate new logits / tokens.
+        //
+        // This done for two reasons:
+        // 1. Right after prefilling, the next token has already been
+        //    generated (along with logits for all other tokens).
+        // 2. Decoding is asynchronous, and sampling here implicitly
+        //    synchronizes with it.
+        //
+        // The second point in particular is important for performance:
+        // ideally, we always want a decoding stage in progress, so that all
+        // the various other work we do (including the work the user does)
+        // isn't going to block inference.
         let new_token = sampler.active().sample(&self.ctx, -1);
         sampler.observe(new_token);
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -465,7 +465,11 @@ impl<'a> InferenceEngine<'a> {
     ) -> Result<(), DecodingError> {
         output.clear();
         match &self.ctx {
-            EngineContext::Solo(_) => self.sample_and_decode_solo(sampler, output),
+            EngineContext::Solo(_) => {
+                let token = self.sample_and_decode_solo(sampler)?;
+                output.push(token);
+                Ok(())
+            }
             EngineContext::Speculative(_) => {
                 self.sample_and_decode_speculative(sampler, output, max_output_tokens)
             }
@@ -475,8 +479,7 @@ impl<'a> InferenceEngine<'a> {
     fn sample_and_decode_solo(
         &mut self,
         sampler: &mut ChatSampler,
-        output: &mut Vec<LlamaToken>,
-    ) -> Result<(), DecodingError> {
+    ) -> Result<LlamaToken, DecodingError> {
         trace!("Applying sampler (solo)");
 
         // Somewhat un-intuitively, we actually want to sample first, before
@@ -492,20 +495,18 @@ impl<'a> InferenceEngine<'a> {
         // ideally, we always want a decoding stage in progress, so that all
         // the various other work we do (including the work the user does)
         // isn't going to block inference.
-        let new_token = sampler.active().sample(&self.ctx, -1);
-        sampler.observe(new_token);
+        let token = sampler.active().sample(&self.ctx, -1);
+        sampler.observe(token);
 
         self.small_batch.clear();
-        self.small_batch.add(new_token, self.n_past, &[0], true)?;
+        self.small_batch.add(token, self.n_past, &[0], true)?;
 
-        let decode_span = trace_span!("write decode", n_past = self.n_past);
-        let decode_guard = decode_span.enter();
+        let _span = trace_span!("write decode", n_past = self.n_past).entered();
         self.ctx.decode(&mut self.small_batch)?;
-        drop(decode_guard);
+
         self.n_past += 1;
 
-        output.push(new_token);
-        Ok(())
+        Ok(token)
     }
 
     fn sample_and_decode_speculative(

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -169,6 +169,9 @@ pub(crate) struct BatchCapacity {
 pub(crate) struct InferenceEngine<'a> {
     pub(crate) ctx: EngineContext<'a>,
     projection_model: Option<&'a ProjectionModel>,
+    /// The token position in the KV cache that we've logically read.
+    ///
+    /// This does not include drafts.
     n_past: i32,
     tokenizer: Tokenizer<'a>,
     // Configured limits before llama.cpp's internal rounding.
@@ -407,7 +410,7 @@ impl<'a> InferenceEngine<'a> {
         // Keep the MTP draft ctx's hidden state in sync.
         if let EngineContext::Speculative(s) = &mut self.ctx {
             s.ctx.process(&self.batch)?;
-            // A new prompt (or context-shift replay) invalidates any drafts
+            // A new prompt (or context-shift replay) invalidates in-progress drafts.
             s.drafts.clear();
             s.accepted = 0;
         }
@@ -429,18 +432,18 @@ impl<'a> InferenceEngine<'a> {
         &mut self,
         index: usize,
     ) -> Result<(usize, i32), KvCacheConversionError> {
-        if self.n_past <= index as i32 {
+        let context_size = self.actual_context_size();
+        if context_size <= index as i32 {
             return Ok((index, 0));
         }
 
-        let before = self.n_past;
         let seq_rm_success = self
             .ctx
             .clear_kv_cache_seq(Some(0), Some(index as u32), None)?;
 
         if seq_rm_success {
             self.n_past = index as i32;
-            Ok((index, before - self.n_past))
+            Ok((index, context_size - self.n_past))
         } else {
             // Partial sequence removal is not supported by this model's memory type
             // (e.g. hybrid models with recurrent components). Fall back to full reset,
@@ -452,7 +455,7 @@ impl<'a> InferenceEngine<'a> {
             );
             self.ctx.clear_kv_cache();
             self.n_past = 0;
-            Ok((0, before))
+            Ok((0, context_size))
         }
     }
 
@@ -465,6 +468,10 @@ impl<'a> InferenceEngine<'a> {
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<TokenizerChunks, ContextSyncError> {
         if let EngineContext::Speculative(spec) = &mut self.ctx {
+            // Clear draft state.
+            //
+            // The parts of the KV cache containing the drafts will be cleared
+            // in `remove_all_tokens_from_index_from_ctx`.
             spec.accept_drafts()?;
             spec.drafts.clear();
             spec.accepted = 0;
@@ -491,18 +498,18 @@ impl<'a> InferenceEngine<'a> {
         Ok(target)
     }
 
-    pub(crate) fn n_past(&self) -> u32 {
-        self.n_past as u32
-    }
-
-    pub(crate) fn is_context_full(&self) -> bool {
+    /// The context size including drafts.
+    pub(crate) fn actual_context_size(&self) -> i32 {
         let in_progress_drafts = if let EngineContext::Speculative(spec) = &self.ctx {
-            (spec.drafts.len() - spec.accepted) as u32
+            (spec.drafts.len() - spec.accepted) as i32
         } else {
             0
         };
+        self.n_past + in_progress_drafts
+    }
 
-        self.n_past as u32 + in_progress_drafts == self.ctx.n_ctx()
+    pub(crate) fn is_context_full(&self) -> bool {
+        self.actual_context_size() == self.ctx.n_ctx() as i32
     }
 
     pub(crate) fn tokenize(

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -497,28 +497,15 @@ impl<'a> InferenceEngine<'a> {
             .load_audio(path)
     }
 
-    // FIXME(madsmtm): Refactor this
-    pub(crate) fn sample_and_decode_next_tokens(
-        &mut self,
-        sampler: &mut ChatSampler,
-        output: &mut Vec<LlamaToken>,
-        _max_output_tokens: Option<usize>,
-    ) -> Result<(), DecodingError> {
-        output.clear();
-        let token = match &self.ctx {
-            EngineContext::Solo(_) => self.sample_and_decode_solo(sampler),
-            EngineContext::Speculative(_) => self.sample_and_decode_speculative(sampler),
-        }?;
-        output.push(token);
-        Ok(())
-    }
-
-    fn sample_and_decode_solo(
+    /// Sample and decode the next token.
+    ///
+    /// This abstracts over the speculative decoder's otherwise multi-token
+    /// design by storing the draft / in-progress tokens internally.
+    pub(crate) fn next_token(
         &mut self,
         sampler: &mut ChatSampler,
     ) -> Result<LlamaToken, DecodingError> {
-        trace!("Applying sampler (solo)");
-
+        let _span = trace_span!("next_token").entered();
         // Somewhat un-intuitively, we actually want to sample first, before
         // attempting to generate new logits / tokens.
         //
@@ -532,26 +519,8 @@ impl<'a> InferenceEngine<'a> {
         // ideally, we always want a decoding stage in progress, so that all
         // the various other work we do (including the work the user does)
         // isn't going to block inference.
-        let token = sampler.active().sample(&self.ctx, -1);
-        sampler.observe(token);
 
-        self.batch.clear();
-        self.batch.add(token, self.n_past, &[0], true)?;
-
-        let _span = trace_span!("write decode", n_past = self.n_past).entered();
-        self.ctx.decode(&mut self.batch)?;
-
-        self.n_past += 1;
-
-        Ok(token)
-    }
-
-    fn sample_and_decode_speculative(
-        &mut self,
-        sampler: &mut ChatSampler,
-    ) -> Result<LlamaToken, DecodingError> {
-        trace!("Applying sampler (MTP speculative, deferred)");
-
+        let span = trace_span!("sample").entered();
         let token = if let Some(draft) = self.draft_state.drafts.get(self.draft_state.accepted) {
             let token = sampler
                 .active()
@@ -569,12 +538,13 @@ impl<'a> InferenceEngine<'a> {
             // Otherwise decode new tokens.
             token
         } else {
-            // We're out of draft tokens, we haven't started, or the state
-            // has been reset previously.
+            // No need to use `sampler.accept` as `.sample` already accepts
+            // the token: https://github.com/utilityai/llama-cpp-rs/issues/604
             let token = sampler.active().sample(&self.ctx, -1);
             sampler.observe(token);
             token
         };
+        drop(span);
 
         // Reset draft state.
         self.accept_drafts()?;
@@ -582,26 +552,27 @@ impl<'a> InferenceEngine<'a> {
         self.draft_state.drafts.clear();
         self.draft_state.accepted = 0;
 
-        let EngineContext::Speculative(spec) = &mut self.ctx else {
-            unreachable!("sample_and_decode_speculative called on solo ctx");
-        };
-
-        // FIXME(madsmtm): Avoid starting a whole new draft if the token is an
-        // EOG token (then we'd rather decode just that token).
-
         // Create new drafts.
-        trace!(n_past = self.n_past, ?token, "starting draft");
-        let mut drafts = spec.draft(self.n_past, token, &[])?;
+        //
+        // FIXME(madsmtm): Maybe avoid starting a whole new draft if the
+        // token is an EOG token (then we'd rather decode just that token).
+        let drafts = if let EngineContext::Speculative(spec) = &mut self.ctx {
+            let _span = trace_span!("draft", n_past = self.n_past, ?token).entered();
+            let mut drafts = spec.draft(self.n_past, token, &[])?;
 
-        // Make sure we later `.accept(...)` the drafts.
-        self.draft_state.needs_accept = !drafts.is_empty();
+            // Make sure we later `.accept(...)` the drafts.
+            self.draft_state.needs_accept = !drafts.is_empty();
 
-        // Clamp drafts so the verify batch [pending, drafts...] stays
-        // within the context window:
-        let room =
-            usize::try_from(spec.target_context().n_ctx() as i32 - self.n_past - 1).unwrap_or(0);
-        drafts.truncate(room);
-        trace!(?drafts);
+            // Clamp drafts so the verify batch [pending, drafts...] stays
+            // within the context window:
+            let room = usize::try_from(self.ctx.n_ctx() as i32 - self.n_past - 1).unwrap_or(0);
+            drafts.truncate(room);
+
+            trace!(?drafts);
+            drafts
+        } else {
+            Vec::new()
+        };
 
         self.batch.clear();
         self.batch.add(token, self.n_past, &[0], true)?;
@@ -609,11 +580,18 @@ impl<'a> InferenceEngine<'a> {
             self.batch.add(d, self.n_past + 1 + i as i32, &[0], true)?;
         }
 
-        let span = trace_span!("mtp verify decode", n_past = self.n_past).entered();
-        spec.target_context_mut().decode(&mut self.batch)?;
+        let span = trace_span!("decode", n_past = self.n_past).entered();
+        self.ctx.decode(&mut self.batch)?;
         drop(span);
 
-        spec.process(&self.batch)?;
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            // Keep MTP state in sync.
+            //
+            // FIXME(madsmtm): This seems to synchronize the context, can we
+            // avoid that somehow?
+            let _span = trace_span!("mtp_process").entered();
+            spec.process(&self.batch)?;
+        }
 
         self.draft_state.drafts = drafts;
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -522,10 +522,7 @@ impl<'a> InferenceEngine<'a> {
 
         let span = trace_span!("sample").entered();
         let token = if let Some(draft) = self.draft_state.drafts.get(self.draft_state.accepted) {
-            let token = sampler
-                .active()
-                .sample(&self.ctx, self.draft_state.accepted as _);
-            sampler.observe(token);
+            let token = sampler.sample(&self.ctx, self.draft_state.accepted as _);
 
             // Fast path: If the token matches what the draft model predicted,
             // return the token.
@@ -538,11 +535,7 @@ impl<'a> InferenceEngine<'a> {
             // Otherwise decode new tokens.
             token
         } else {
-            // No need to use `sampler.accept` as `.sample` already accepts
-            // the token: https://github.com/utilityai/llama-cpp-rs/issues/604
-            let token = sampler.active().sample(&self.ctx, -1);
-            sampler.observe(token);
-            token
+            sampler.sample(&self.ctx, -1)
         };
         drop(span);
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -52,6 +52,76 @@ where
     (wrapped_respond, resp_receiver)
 }
 
+/// MTP state.
+#[derive(Debug)]
+pub(crate) struct SpeculativeEngine<'a> {
+    ctx: MtpSpeculative<'a>,
+    /// The in-progress drafts.
+    drafts: Vec<LlamaToken>,
+    /// The number of accepted drafts.
+    accepted: usize,
+    /// Whether we still need to tell the MTP state which tokens are accepted.
+    needs_accept: bool,
+    /// Statistics.
+    total_proposed: u64,
+    total_accepted: u64,
+}
+
+impl<'a> SpeculativeEngine<'a> {
+    pub(crate) fn new(ctx: MtpSpeculative<'a>) -> Self {
+        Self {
+            ctx,
+            drafts: Vec::new(),
+            accepted: 0,
+            needs_accept: false,
+            total_proposed: 0,
+            total_accepted: 0,
+        }
+    }
+
+    /// Update MTP state to accept in-progress drafts.
+    ///
+    /// This should only happen once per draft state.
+    fn accept_drafts(&mut self) -> Result<(), MtpSpeculativeError> {
+        if self.needs_accept {
+            let (accepted, declined) = self.drafts.split_at(self.accepted);
+            trace!(?accepted, ?declined, "accepting draft");
+
+            self.ctx.accept(self.accepted as u16)?;
+
+            self.needs_accept = false;
+        }
+
+        self.total_proposed += self.drafts.len() as u64;
+        self.total_accepted += self.accepted as u64;
+
+        Ok(())
+    }
+
+    fn roll_back_declined_drafts(&mut self, keep_up_to: u32) -> Result<(), RollbackError> {
+        let declined = self.drafts.len() - self.accepted;
+        if 0 < declined {
+            // Remove declined drafts from the KV cache.
+            let rolled_back = self.ctx.target_context_mut().clear_kv_cache_seq(
+                Some(0),
+                Some(keep_up_to),
+                None,
+            )?;
+            if !rolled_back {
+                // Recurrent / hybrid-recurrent memory types reject partial
+                // removal (Ok(false)). Unlike `remove_all_tokens_from_index_from_ctx`
+                // we cannot fall back to a full reset here — that would drop the
+                // prompt mid-generation. Leaving the rejected drafts' KV in place
+                // would silently corrupt subsequent decodes, so fail loudly. MTP
+                // targets attention models, where partial removal is supported.
+                return Err(RollbackError::MtpPartialRollbackUnsupported);
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// The low-level inference state for a single llama.cpp context.
 ///
 /// Holds everything needed to read tokens/media into the KV cache and sample new tokens,
@@ -67,7 +137,7 @@ where
 #[derive(Debug)]
 pub(crate) enum EngineContext<'a> {
     Solo(LlamaContext<'a>),
-    Speculative(MtpSpeculative<'a>),
+    Speculative(SpeculativeEngine<'a>),
 }
 
 impl<'a> std::ops::Deref for EngineContext<'a> {
@@ -75,7 +145,7 @@ impl<'a> std::ops::Deref for EngineContext<'a> {
     fn deref(&self) -> &LlamaContext<'a> {
         match self {
             Self::Solo(c) => c,
-            Self::Speculative(s) => s.target_context(),
+            Self::Speculative(s) => s.ctx.target_context(),
         }
     }
 }
@@ -84,7 +154,7 @@ impl<'a> std::ops::DerefMut for EngineContext<'a> {
     fn deref_mut(&mut self) -> &mut LlamaContext<'a> {
         match self {
             Self::Solo(c) => c,
-            Self::Speculative(s) => s.target_context_mut(),
+            Self::Speculative(s) => s.ctx.target_context_mut(),
         }
     }
 }
@@ -93,16 +163,6 @@ impl<'a> std::ops::DerefMut for EngineContext<'a> {
 pub(crate) struct BatchCapacity {
     pub(crate) tokens: usize,
     pub(crate) sequences: usize,
-}
-
-/// The state of an in-progress draft.
-#[derive(Debug)]
-struct DraftState {
-    drafts: Vec<LlamaToken>,
-    /// The number of accepted drafts.
-    accepted: usize,
-    /// Whether we still need to tell the MTP state which tokens are accepted.
-    needs_accept: bool,
 }
 
 #[derive(Debug)]
@@ -116,9 +176,6 @@ pub(crate) struct InferenceEngine<'a> {
     /// Batch that's used when decoding. Stored here to re-use the allocation.
     batch: LlamaBatch<'static>,
     use_embeddings: bool,
-    draft_state: DraftState,
-    pub(crate) mtp_drafts_proposed: u64,
-    pub(crate) mtp_drafts_accepted: u64,
 }
 
 impl<'a> InferenceEngine<'a> {
@@ -141,29 +198,39 @@ impl<'a> InferenceEngine<'a> {
             projection_model,
             tokenizer,
             use_embeddings,
-            draft_state: DraftState {
-                drafts: Vec::new(),
-                accepted: 0,
-                needs_accept: false,
-            },
-            mtp_drafts_proposed: 0,
-            mtp_drafts_accepted: 0,
         }
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn reset_context(&mut self) -> Result<(), MtpSpeculativeError> {
-        self.accept_drafts()?;
-        self.draft_state.drafts.clear();
-        self.draft_state.accepted = 0;
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            spec.accept_drafts()?;
+            spec.drafts.clear();
+            spec.accepted = 0;
+        }
         self.ctx.clear_kv_cache();
         self.n_past = 0;
         Ok(())
     }
 
     pub(crate) fn reset_mtp_stats(&mut self) {
-        self.mtp_drafts_proposed = 0;
-        self.mtp_drafts_accepted = 0;
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            spec.total_proposed = 0;
+            spec.total_accepted = 0;
+        }
+    }
+
+    pub(crate) fn mtp_acceptance_rate(&self) -> Option<f32> {
+        if let EngineContext::Speculative(spec) = &self.ctx {
+            let proposed = spec.total_proposed;
+            if proposed > 0 {
+                Some(spec.total_accepted as f32 / proposed as f32)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 
     pub(crate) fn read_strings_batched<T, E>(
@@ -338,14 +405,14 @@ impl<'a> InferenceEngine<'a> {
         // brrr
 
         // Keep the MTP draft ctx's hidden state in sync.
-        if let EngineContext::Speculative(spec) = &mut self.ctx {
-            spec.process(&self.batch)?;
+        if let EngineContext::Speculative(s) = &mut self.ctx {
+            s.ctx.process(&self.batch)?;
+            // A new prompt (or context-shift replay) invalidates any drafts
+            s.drafts.clear();
+            s.accepted = 0;
         }
 
         self.n_past += tokens.len() as i32;
-        // A new prompt (or context-shift replay) invalidates any drafts
-        self.draft_state.drafts.clear();
-        self.draft_state.accepted = 0;
 
         debug!("Completed read tokens operation, n_past: {}", self.n_past);
 
@@ -389,50 +456,6 @@ impl<'a> InferenceEngine<'a> {
         }
     }
 
-    /// Update MTP state to accept in-progress drafts.
-    ///
-    /// This should only happen once per draft state.
-    fn accept_drafts(&mut self) -> Result<(), MtpSpeculativeError> {
-        if self.draft_state.needs_accept {
-            let (accepted, declined) = self.draft_state.drafts.split_at(self.draft_state.accepted);
-            trace!(?accepted, ?declined, "accepting draft");
-
-            let EngineContext::Speculative(spec) = &mut self.ctx else {
-                unreachable!("only context should not have drafts");
-            };
-            spec.accept(self.draft_state.accepted as u16)?;
-
-            self.draft_state.needs_accept = false;
-        }
-
-        self.mtp_drafts_proposed += self.draft_state.drafts.len() as u64;
-        self.mtp_drafts_accepted += self.draft_state.accepted as u64;
-
-        Ok(())
-    }
-
-    fn roll_back_declined_drafts(&mut self) -> Result<(), RollbackError> {
-        let declined = self.draft_state.drafts.len() - self.draft_state.accepted;
-        if 0 < declined {
-            // Remove declined drafts from the KV cache.
-            let keep_up_to = self.n_past as u32;
-            let rolled_back = self
-                .ctx
-                .clear_kv_cache_seq(Some(0), Some(keep_up_to), None)?;
-            if !rolled_back {
-                // Recurrent / hybrid-recurrent memory types reject partial
-                // removal (Ok(false)). Unlike `remove_all_tokens_from_index_from_ctx`
-                // we cannot fall back to a full reset here — that would drop the
-                // prompt mid-generation. Leaving the rejected drafts' KV in place
-                // would silently corrupt subsequent decodes, so fail loudly. MTP
-                // targets attention models, where partial removal is supported.
-                return Err(RollbackError::MtpPartialRollbackUnsupported);
-            }
-        }
-
-        Ok(())
-    }
-
     /// Diff `target` chunks against `prev` and load only the new tail into the KV cache.
     /// Returns the new KV-cache mirror; the caller is responsible for storing it.
     pub(crate) fn sync_context(
@@ -441,9 +464,11 @@ impl<'a> InferenceEngine<'a> {
         prev: &TokenizerChunks,
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<TokenizerChunks, ContextSyncError> {
-        self.accept_drafts()?;
-        self.draft_state.drafts.clear();
-        self.draft_state.accepted = 0;
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            spec.accept_drafts()?;
+            spec.drafts.clear();
+            spec.accepted = 0;
+        }
 
         let prefix_index = find_chunks_prefix_difference(prev, &target);
 
@@ -471,7 +496,12 @@ impl<'a> InferenceEngine<'a> {
     }
 
     pub(crate) fn is_context_full(&self) -> bool {
-        let in_progress_drafts = (self.draft_state.drafts.len() - self.draft_state.accepted) as u32;
+        let in_progress_drafts = if let EngineContext::Speculative(spec) = &self.ctx {
+            (spec.drafts.len() - spec.accepted) as u32
+        } else {
+            0
+        };
+
         self.n_past as u32 + in_progress_drafts == self.ctx.n_ctx()
     }
 
@@ -521,29 +551,35 @@ impl<'a> InferenceEngine<'a> {
         // isn't going to block inference.
 
         let span = trace_span!("sample").entered();
-        let token = if let Some(draft) = self.draft_state.drafts.get(self.draft_state.accepted) {
-            let token = sampler.sample(&self.ctx, self.draft_state.accepted as _);
+        let token = if let EngineContext::Speculative(spec) = &mut self.ctx {
+            if let Some(draft) = spec.drafts.get(spec.accepted) {
+                let token = sampler.sample(spec.ctx.target_context_mut(), spec.accepted as _);
 
-            // Fast path: If the token matches what the draft model predicted,
-            // return the token.
-            if token == *draft {
-                self.draft_state.accepted += 1;
-                self.n_past += 1;
-                return Ok(token);
+                // Fast path: If the token matches what the draft model predicted,
+                // return the token.
+                if token == *draft {
+                    spec.accepted += 1;
+                    self.n_past += 1;
+                    return Ok(token);
+                }
+
+                // Otherwise decode new tokens.
+                token
+            } else {
+                sampler.sample(&self.ctx, -1)
             }
-
-            // Otherwise decode new tokens.
-            token
         } else {
             sampler.sample(&self.ctx, -1)
         };
         drop(span);
 
         // Reset draft state.
-        self.accept_drafts()?;
-        self.roll_back_declined_drafts()?;
-        self.draft_state.drafts.clear();
-        self.draft_state.accepted = 0;
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            spec.accept_drafts()?;
+            spec.roll_back_declined_drafts(self.n_past as u32)?;
+            spec.drafts.clear();
+            spec.accepted = 0;
+        }
 
         // Create new drafts.
         //
@@ -551,10 +587,10 @@ impl<'a> InferenceEngine<'a> {
         // token is an EOG token (then we'd rather decode just that token).
         let drafts = if let EngineContext::Speculative(spec) = &mut self.ctx {
             let _span = trace_span!("draft", n_past = self.n_past, ?token).entered();
-            let mut drafts = spec.draft(self.n_past, token, &[])?;
+            let mut drafts = spec.ctx.draft(self.n_past, token, &[])?;
 
             // Make sure we later `.accept(...)` the drafts.
-            self.draft_state.needs_accept = !drafts.is_empty();
+            spec.needs_accept = !drafts.is_empty();
 
             // Clamp drafts so the verify batch [pending, drafts...] stays
             // within the context window:
@@ -583,10 +619,10 @@ impl<'a> InferenceEngine<'a> {
             // FIXME(madsmtm): This seems to synchronize the context, can we
             // avoid that somehow?
             let _span = trace_span!("mtp_process").entered();
-            spec.process(&self.batch)?;
-        }
+            spec.ctx.process(&self.batch)?;
 
-        self.draft_state.drafts = drafts;
+            spec.drafts = drafts;
+        }
 
         self.n_past += 1;
 

--- a/nobodywho/core/src/inference.rs
+++ b/nobodywho/core/src/inference.rs
@@ -1,7 +1,7 @@
 //! Generic inference pipeline, independent of chat history.
 
 use crate::chat::ChatSampler;
-use crate::errors::{ContextSyncError, DecodingError, MultimodalError, ReadError};
+use crate::errors::{ContextSyncError, DecodingError, MultimodalError, ReadError, RollbackError};
 use crate::llm::{GlobalInferenceLockToken, WriteOutput, GLOBAL_INFERENCE_LOCK};
 use crate::tokenizer::{
     find_chunks_prefix_difference, ProjectionModel, Tokenizer, TokenizerChunk, TokenizerChunks,
@@ -11,7 +11,7 @@ use llama_cpp_2::context::LlamaContext;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::mtmd::MtmdBitmap;
 use llama_cpp_2::mtmd::MtmdInputChunks;
-use llama_cpp_2::speculative::MtpSpeculative;
+use llama_cpp_2::speculative::{MtpSpeculative, MtpSpeculativeError};
 use llama_cpp_2::token::LlamaToken;
 use std::ops::Range;
 use std::path::Path;
@@ -89,22 +89,20 @@ impl<'a> std::ops::DerefMut for EngineContext<'a> {
     }
 }
 
-impl<'a> EngineContext<'a> {
-    fn mtp_process(
-        &mut self,
-        batch: &LlamaBatch<'a>,
-    ) -> Result<(), llama_cpp_2::speculative::MtpSpeculativeError> {
-        if let Self::Speculative(spec) = self {
-            spec.process(batch)?;
-        }
-        Ok(())
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct BatchCapacity {
     pub(crate) tokens: usize,
     pub(crate) sequences: usize,
+}
+
+/// The state of an in-progress draft.
+#[derive(Debug)]
+struct DraftState {
+    drafts: Vec<LlamaToken>,
+    /// The number of accepted drafts.
+    accepted: usize,
+    /// Whether we still need to tell the MTP state which tokens are accepted.
+    needs_accept: bool,
 }
 
 #[derive(Debug)]
@@ -118,14 +116,7 @@ pub(crate) struct InferenceEngine<'a> {
     /// Batch that's used when decoding. Stored here to re-use the allocation.
     batch: LlamaBatch<'static>,
     use_embeddings: bool,
-    /// Deferred-decode "pending sample": a token sampled from the
-    /// target but not yet decoded into the KV cache
-    /// Invariants:
-    /// - `None` after `read_text_tokens` and `reset_context`.
-    /// - `Some(t)` between speculative iterations, where `t` is the
-    ///   target's sample for the next-to-emit position and is *not* in
-    ///   the KV cache.
-    pending: Option<LlamaToken>,
+    draft_state: DraftState,
     pub(crate) mtp_drafts_proposed: u64,
     pub(crate) mtp_drafts_accepted: u64,
 }
@@ -150,18 +141,24 @@ impl<'a> InferenceEngine<'a> {
             projection_model,
             tokenizer,
             use_embeddings,
-            pending: None,
+            draft_state: DraftState {
+                drafts: Vec::new(),
+                accepted: 0,
+                needs_accept: false,
+            },
             mtp_drafts_proposed: 0,
             mtp_drafts_accepted: 0,
         }
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    pub(crate) fn reset_context(&mut self) -> &mut Self {
+    pub(crate) fn reset_context(&mut self) -> Result<(), MtpSpeculativeError> {
+        self.accept_drafts()?;
+        self.draft_state.drafts.clear();
+        self.draft_state.accepted = 0;
         self.ctx.clear_kv_cache();
         self.n_past = 0;
-        self.pending = None;
-        self
+        Ok(())
     }
 
     pub(crate) fn reset_mtp_stats(&mut self) {
@@ -211,7 +208,7 @@ impl<'a> InferenceEngine<'a> {
             let n_tokens = self.batch.n_tokens();
             let n_sequences = range.len();
             let inference_lock_token = acquire_inference_lock();
-            self.reset_context();
+            self.reset_context().expect("failed resetting context");
 
             let decode_span = debug_span!(
                 "read embedding batch",
@@ -340,13 +337,15 @@ impl<'a> InferenceEngine<'a> {
         drop(decode_guard);
         // brrr
 
-        // Keep the MTP draft ctx's hidden state in sync (no-op on solo).
-        self.ctx.mtp_process(&self.batch)?;
+        // Keep the MTP draft ctx's hidden state in sync.
+        if let EngineContext::Speculative(spec) = &mut self.ctx {
+            spec.process(&self.batch)?;
+        }
 
         self.n_past += tokens.len() as i32;
-        // A new prompt (or context-shift replay) invalidates any deferred
-        // pending sample from a previous generation.
-        self.pending = None;
+        // A new prompt (or context-shift replay) invalidates any drafts
+        self.draft_state.drafts.clear();
+        self.draft_state.accepted = 0;
 
         debug!("Completed read tokens operation, n_past: {}", self.n_past);
 
@@ -359,7 +358,7 @@ impl<'a> InferenceEngine<'a> {
     /// Returns `(effective_prefix, trimmed)` where:
     /// - `effective_prefix` is the number of tokens still valid in the KV cache
     /// - `trimmed` is how many positions were evicted.
-    pub(crate) fn remove_all_tokens_from_index_from_ctx(
+    fn remove_all_tokens_from_index_from_ctx(
         &mut self,
         index: usize,
     ) -> Result<(usize, i32), KvCacheConversionError> {
@@ -384,9 +383,54 @@ impl<'a> InferenceEngine<'a> {
                 n_past = self.n_past,
                 "Partial KV cache removal not supported, falling back to full context reset"
             );
-            self.reset_context();
+            self.ctx.clear_kv_cache();
+            self.n_past = 0;
             Ok((0, before))
         }
+    }
+
+    /// Update MTP state to accept in-progress drafts.
+    ///
+    /// This should only happen once per draft state.
+    fn accept_drafts(&mut self) -> Result<(), MtpSpeculativeError> {
+        if self.draft_state.needs_accept {
+            let (accepted, declined) = self.draft_state.drafts.split_at(self.draft_state.accepted);
+            trace!(?accepted, ?declined, "accepting draft");
+
+            let EngineContext::Speculative(spec) = &mut self.ctx else {
+                unreachable!("only context should not have drafts");
+            };
+            spec.accept(self.draft_state.accepted as u16)?;
+
+            self.draft_state.needs_accept = false;
+        }
+
+        self.mtp_drafts_proposed += self.draft_state.drafts.len() as u64;
+        self.mtp_drafts_accepted += self.draft_state.accepted as u64;
+
+        Ok(())
+    }
+
+    fn roll_back_declined_drafts(&mut self) -> Result<(), RollbackError> {
+        let declined = self.draft_state.drafts.len() - self.draft_state.accepted;
+        if 0 < declined {
+            // Remove declined drafts from the KV cache.
+            let keep_up_to = self.n_past as u32;
+            let rolled_back = self
+                .ctx
+                .clear_kv_cache_seq(Some(0), Some(keep_up_to), None)?;
+            if !rolled_back {
+                // Recurrent / hybrid-recurrent memory types reject partial
+                // removal (Ok(false)). Unlike `remove_all_tokens_from_index_from_ctx`
+                // we cannot fall back to a full reset here — that would drop the
+                // prompt mid-generation. Leaving the rejected drafts' KV in place
+                // would silently corrupt subsequent decodes, so fail loudly. MTP
+                // targets attention models, where partial removal is supported.
+                return Err(RollbackError::MtpPartialRollbackUnsupported);
+            }
+        }
+
+        Ok(())
     }
 
     /// Diff `target` chunks against `prev` and load only the new tail into the KV cache.
@@ -397,6 +441,10 @@ impl<'a> InferenceEngine<'a> {
         prev: &TokenizerChunks,
         inference_lock_token: &MutexGuard<'_, GlobalInferenceLockToken>,
     ) -> Result<TokenizerChunks, ContextSyncError> {
+        self.accept_drafts()?;
+        self.draft_state.drafts.clear();
+        self.draft_state.accepted = 0;
+
         let prefix_index = find_chunks_prefix_difference(prev, &target);
 
         debug_assert!(!target.is_empty());
@@ -422,18 +470,9 @@ impl<'a> InferenceEngine<'a> {
         self.n_past as u32
     }
 
-    /// Detach the deferred MTP `pending` token so a context-shift KV replay
-    /// can run without desyncing the stateful sampler.
-    pub(crate) fn take_pending(&mut self) -> Option<LlamaToken> {
-        self.pending.take()
-    }
-
-    pub(crate) fn restore_pending(&mut self, pending: Option<LlamaToken>) {
-        self.pending = pending;
-    }
-
     pub(crate) fn is_context_full(&self) -> bool {
-        self.n_past as u32 == self.ctx.n_ctx()
+        let in_progress_drafts = (self.draft_state.drafts.len() - self.draft_state.accepted) as u32;
+        self.n_past as u32 + in_progress_drafts == self.ctx.n_ctx()
     }
 
     pub(crate) fn tokenize(
@@ -458,23 +497,20 @@ impl<'a> InferenceEngine<'a> {
             .load_audio(path)
     }
 
+    // FIXME(madsmtm): Refactor this
     pub(crate) fn sample_and_decode_next_tokens(
         &mut self,
         sampler: &mut ChatSampler,
         output: &mut Vec<LlamaToken>,
-        max_output_tokens: Option<usize>,
+        _max_output_tokens: Option<usize>,
     ) -> Result<(), DecodingError> {
         output.clear();
-        match &self.ctx {
-            EngineContext::Solo(_) => {
-                let token = self.sample_and_decode_solo(sampler)?;
-                output.push(token);
-                Ok(())
-            }
-            EngineContext::Speculative(_) => {
-                self.sample_and_decode_speculative(sampler, output, max_output_tokens)
-            }
-        }
+        let token = match &self.ctx {
+            EngineContext::Solo(_) => self.sample_and_decode_solo(sampler),
+            EngineContext::Speculative(_) => self.sample_and_decode_speculative(sampler),
+        }?;
+        output.push(token);
+        Ok(())
     }
 
     fn sample_and_decode_solo(
@@ -513,104 +549,77 @@ impl<'a> InferenceEngine<'a> {
     fn sample_and_decode_speculative(
         &mut self,
         sampler: &mut ChatSampler,
-        output: &mut Vec<LlamaToken>,
-        max_output_tokens: Option<usize>,
-    ) -> Result<(), DecodingError> {
+    ) -> Result<LlamaToken, DecodingError> {
         trace!("Applying sampler (MTP speculative, deferred)");
-        let pending = match self.pending {
-            Some(p) => p,
-            None => sampler.active().sample(&self.ctx, -1),
+
+        let token = if let Some(draft) = self.draft_state.drafts.get(self.draft_state.accepted) {
+            let token = sampler
+                .active()
+                .sample(&self.ctx, self.draft_state.accepted as _);
+            sampler.observe(token);
+
+            // Fast path: If the token matches what the draft model predicted,
+            // return the token.
+            if token == *draft {
+                self.draft_state.accepted += 1;
+                self.n_past += 1;
+                return Ok(token);
+            }
+
+            // Otherwise decode new tokens.
+            token
+        } else {
+            // We're out of draft tokens, we haven't started, or the state
+            // has been reset previously.
+            let token = sampler.active().sample(&self.ctx, -1);
+            sampler.observe(token);
+            token
         };
 
-        if self.ctx.model.is_eog_token(pending) {
-            trace!(?pending, "MTP: pending is EOG, short-circuiting");
-            self.pending = None;
-            output.push(pending);
-            return Ok(());
-        }
+        // Reset draft state.
+        self.accept_drafts()?;
+        self.roll_back_declined_drafts()?;
+        self.draft_state.drafts.clear();
+        self.draft_state.accepted = 0;
 
-        sampler.observe(pending);
-
-        let mut drafts = {
-            let EngineContext::Speculative(spec) = &mut self.ctx else {
-                unreachable!("sample_and_decode_speculative called on solo ctx");
-            };
-            spec.draft(self.n_past, pending, &[])?
+        let EngineContext::Speculative(spec) = &mut self.ctx else {
+            unreachable!("sample_and_decode_speculative called on solo ctx");
         };
+
+        // FIXME(madsmtm): Avoid starting a whole new draft if the token is an
+        // EOG token (then we'd rather decode just that token).
+
+        // Create new drafts.
+        trace!(n_past = self.n_past, ?token, "starting draft");
+        let mut drafts = spec.draft(self.n_past, token, &[])?;
+
+        // Make sure we later `.accept(...)` the drafts.
+        self.draft_state.needs_accept = !drafts.is_empty();
 
         // Clamp drafts so the verify batch [pending, drafts...] stays
         // within the context window:
-        let room = usize::try_from(self.ctx.n_ctx() as i32 - self.n_past - 1).unwrap_or(0);
-        let output_room = max_output_tokens
-            .map(|max_output_tokens| max_output_tokens.saturating_sub(1))
-            .unwrap_or(usize::MAX);
-        drafts.truncate(room.min(output_room));
-        let k_max = drafts.len();
+        let room =
+            usize::try_from(spec.target_context().n_ctx() as i32 - self.n_past - 1).unwrap_or(0);
+        drafts.truncate(room);
+        trace!(?drafts);
 
         self.batch.clear();
-        self.batch.add(pending, self.n_past, &[0], true)?;
+        self.batch.add(token, self.n_past, &[0], true)?;
         for (i, &d) in drafts.iter().enumerate() {
             self.batch.add(d, self.n_past + 1 + i as i32, &[0], true)?;
         }
-        let span = trace_span!("mtp verify decode", n_past = self.n_past, k_max).entered();
-        self.ctx.decode(&mut self.batch)?;
+
+        let span = trace_span!("mtp verify decode", n_past = self.n_past).entered();
+        spec.target_context_mut().decode(&mut self.batch)?;
         drop(span);
-        self.ctx.mtp_process(&self.batch)?;
 
-        let mut accepted_count = 0;
-        self.pending = None;
-        for (i, &draft) in drafts.iter().enumerate() {
-            let ti = sampler.active().sample(&self.ctx, i as i32);
-            if self.ctx.model.is_eog_token(ti) {
-                trace!(?ti, "MTP: target sampled EOG during verify, stopping");
-                self.pending = Some(ti);
-                break;
-            }
-            if ti != draft {
-                self.pending = Some(ti);
-                break;
-            }
-            accepted_count += 1;
-            sampler.observe(draft); // detects switch to grammar-constrained sampling
-        }
+        spec.process(&self.batch)?;
 
-        if accepted_count < k_max {
-            let keep_up_to = (self.n_past + 1 + accepted_count as i32) as u32;
-            let rolled_back = self
-                .ctx
-                .clear_kv_cache_seq(Some(0), Some(keep_up_to), None)?;
-            if !rolled_back {
-                // Recurrent / hybrid-recurrent memory types reject partial
-                // removal (Ok(false)). Unlike `remove_all_tokens_from_index_from_ctx`
-                // we cannot fall back to a full reset here — that would drop the
-                // prompt mid-generation. Leaving the rejected drafts' KV in place
-                // would silently corrupt subsequent decodes, so fail loudly. MTP
-                // targets attention models, where partial removal is supported.
-                return Err(DecodingError::MtpPartialRollbackUnsupported);
-            }
-        }
+        self.draft_state.drafts = drafts;
 
-        {
-            let EngineContext::Speculative(spec) = &mut self.ctx else {
-                unreachable!();
-            };
-            spec.accept(accepted_count as u16)?;
-        }
+        self.n_past += 1;
 
-        self.n_past += 1 + accepted_count as i32;
-        self.mtp_drafts_proposed += k_max as u64;
-        self.mtp_drafts_accepted += accepted_count as u64;
-
-        trace!(
-            accepted_count,
-            k_max,
-            ?pending,
-            "MTP: deferred iteration complete"
-        );
-
-        output.push(pending);
-        output.extend_from_slice(&drafts[..accepted_count]);
-        Ok(())
+        Ok(token)
     }
 }
 

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -11,7 +11,6 @@ use crate::tokenizer::{ProjectionModel, Tokenizer};
 use lazy_static::lazy_static;
 use llama_cpp_2::context::params::{LlamaContextParams, LlamaContextType, LlamaPoolingType};
 use llama_cpp_2::llama_backend::LlamaBackend;
-use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::AddBos;
 use llama_cpp_2::model::LlamaModel;
@@ -382,10 +381,6 @@ where
             .new_context(&LLAMA_BACKEND, ctx_params)?;
         let n_batch = planned_n_ctx as usize;
 
-        // The batch limit is sequence IDs per token; each embedding token belongs to one sequence.
-        let big_batch = LlamaBatch::new(ctx.n_ctx() as usize, 1);
-        let small_batch = LlamaBatch::new(1, 1);
-
         let engine_ctx = if let Some(mtp_config) = mtp {
             match &model.draft_model {
                 Some(draft_model) => {
@@ -427,8 +422,6 @@ where
 
         let engine = InferenceEngine::new(
             engine_ctx,
-            big_batch,
-            small_batch,
             projection_model,
             BatchCapacity {
                 tokens: n_batch,

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -4,7 +4,7 @@ use crate::errors::{InitWorkerError, LoadModelError};
 use crate::huggingface::{download_gguf, parse_model_path};
 #[cfg(test)]
 use crate::inference::acquire_inference_lock;
-use crate::inference::{BatchCapacity, EngineContext, InferenceEngine};
+use crate::inference::{BatchCapacity, EngineContext, InferenceEngine, SpeculativeEngine};
 use crate::memory;
 use crate::model_selection;
 use crate::tokenizer::{ProjectionModel, Tokenizer};
@@ -405,7 +405,7 @@ where
                         p_min: mtp_config.p_min,
                     };
                     let spec = MtpSpeculative::new(ctx, draft_ctx, spec_params)?;
-                    EngineContext::Speculative(spec)
+                    EngineContext::Speculative(SpeculativeEngine::new(spec))
                 }
                 None => {
                     return Err(InitWorkerError::MtpDraftModelNotLoaded);


### PR DESCRIPTION
Refactor `InferenceEngine` to store the draft data internally, such that it can return one token at a time. Ideally, it should be opaque to the caller that `InferenceEngine::next_token` can choose to generate multiple tokens when using speculative decoding / MTP.

This makes it easier for `Chat` to consume, since it doesn't need to worry about context overflow etc. inside the inference engine.

This should also make it possible in the future to refactor `Chat` to work on a more pull-based model, where the caller "pulls" tokens instead of the `Chat` running in a background thread and eagerly pushing them onto a queue.