### PR TITLE
fix: commit assistant message before tool call correctly to history

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -58,8 +58,8 @@ pub enum Message {
         content: MessageContent,
     },
     // The optional tool_calls field distinguishes a plain assistant response
-    // from one that includes tool calls. When tool_calls is Some, the content
-    // field is typically empty (required by qwen3 chat templates).
+    // from one that includes tool calls. When tool_calls is Some, content holds
+    // whatever the model said before the first call.
     // https://github.com/QwenLM/Qwen3/blob/e5a1d326/docs/source/framework/function_call.md
     Assistant {
         content: MessageContent,
@@ -1981,9 +1981,13 @@ impl<'a> Chat<'a> {
         });
     }
 
-    pub fn add_tool_calls(&mut self, tool_calls: Vec<ToolCall>) {
+    pub fn add_tool_calls(
+        &mut self,
+        content: impl Into<MessageContent>,
+        tool_calls: Vec<ToolCall>,
+    ) {
         self.messages.push(Message::Assistant {
-            content: "".into(),
+            content: content.into(),
             tool_calls: Some(tool_calls),
         });
     }
@@ -2291,13 +2295,16 @@ impl<'a> Chat<'a> {
         if let Some(tool_format) = self.tool_format.clone() {
             while let Some(tool_calls) = tool_format.extract_tool_calls(&response) {
                 debug!(?tool_calls, "Got tool calls:");
-                self.add_tool_calls(tool_calls.clone());
+
+                // Whatever the model said before the call is part of the turn,
+                // so it goes into the history message alongside the calls.
+                let content = response
+                    .split_once(tool_format.begin_token())
+                    .map_or("", |(content, _)| content);
+                self.add_tool_calls(content, tool_calls.clone());
 
                 if skip_calling_tools {
-                    let content = response
-                        .split_once(tool_format.begin_token())
-                        .map(|(content, _)| content.to_string())
-                        .unwrap_or_default();
+                    let content = content.to_string();
                     self.context.chunks = self.render_as_chunks(&self.messages, true)?;
                     return Ok(AssistantResponse {
                         content,
@@ -3169,6 +3176,26 @@ mod tests {
         println!("{}", result);
         assert!(result.contains("13.37"));
         assert!(result.contains("42.69"));
+
+        // The history splits the response at the begin token: the preamble is
+        // kept as content, the call block itself never is.
+        let begin_token = worker
+            .tool_format
+            .as_ref()
+            .expect("the test model has a tool format")
+            .begin_token();
+        for message in &worker.messages {
+            if let Message::Assistant {
+                content,
+                tool_calls: Some(_),
+            } = message
+            {
+                assert!(
+                    !content.to_string().contains(begin_token),
+                    "raw call block stored as content: {content}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -3203,6 +3230,60 @@ mod tests {
         println!("{}", result);
         assert!(result.contains("13.37"));
         assert!(result.contains("0.15"));
+    }
+
+    /// A tool-calling turn keeps whatever the model wrote before the call, so
+    /// the next turn sees its own reasoning instead of a bare call.
+    #[test]
+    fn tool_call_preamble_is_kept_in_history() {
+        test_utils::init_test_tracing();
+        let model = test_utils::load_test_model();
+        let mut worker = Chat::new_chat_worker(
+            &model,
+            ChatConfig {
+                n_ctx: 1024,
+                tools: vec![test_tool()],
+                ..Default::default()
+            },
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("Failed making worker");
+
+        let preamble = "Let me look up the temperature in Copenhagen.";
+        worker.add_user_message("What is the temperature in Copenhagen?");
+        worker.add_tool_calls(
+            preamble,
+            vec![ToolCall {
+                name: "get_current_temperature".into(),
+                arguments: serde_json::json!({"location": "Copenhagen"}),
+            }],
+        );
+
+        let Some(Message::Assistant {
+            content,
+            tool_calls: Some(_),
+        }) = worker.messages.last()
+        else {
+            panic!("expected an assistant message with tool calls");
+        };
+        assert_eq!(content.to_string(), preamble);
+
+        // Keeping it in the history is only worth anything if the template puts
+        // it back into the prompt next to the call.
+        let rendered = worker
+            .chat_template
+            .render(
+                &worker.with_system_prompt(&worker.messages),
+                &ChatTemplateContext::new(
+                    worker.template_variables.clone(),
+                    Some(worker.tools.clone()),
+                ),
+            )
+            .expect("rendering a history with a tool call");
+        assert!(
+            rendered.contains(preamble),
+            "preamble missing from the rendered prompt: {rendered}"
+        );
     }
 
     #[test]
@@ -3548,10 +3629,13 @@ mod tests {
             // Add a tool call every other message
             // Pattern: User -> Assistant (with tool call) -> Tool response -> Assistant
             if i % 2 == 0 {
-                worker.add_tool_calls(vec![ToolCall {
-                    name: "get_current_temperature".into(),
-                    arguments: serde_json::json!({"location": "Copenhagen"}),
-                }]);
+                worker.add_tool_calls(
+                    "",
+                    vec![ToolCall {
+                        name: "get_current_temperature".into(),
+                        arguments: serde_json::json!({"location": "Copenhagen"}),
+                    }],
+                );
                 worker.add_tool_resp("get_current_temperature".into(), "13.37°C".into());
                 worker.add_assistant_message(format!(
                     "The temperature is 13.37°C and {} * {} = {}.",


### PR DESCRIPTION
bug fix: when the model generated a message with a tool call, we streamed the entire response but didn't commit the pre-tool call content to `self.messages`. Now added.