### PR TITLE
Handle Python download interruptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,5 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for detailed setup instructions.
 ## Documentation
 Documentation is built with Docusaurus and lives in the `docs/` folder. It is deployed to docs.nobodywho.ooo via Cloudflare Pages (see `.github/workflows/docs.yml`).
 
+For user-facing changes, add a concise entry under `Unreleased` in [`CHANGELOG.md`](CHANGELOG.md). Use the appropriate Keep a Changelog section and name the affected bindings when the change is not universal.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ### Fixed
 
+- **Python:** Pressing Ctrl+C during a synchronous GGUF model download now cancels the download, raises `KeyboardInterrupt`, and removes the incomplete temporary file.
 - A rejected chat setter no longer kills the chat. `set_sampler_config`, `set_tools` and `reset_chat` used to end the worker, so the reason was only logged and every later call — including `ask()` — failed with "worker terminated". The error now reaches the caller and the chat keeps working. Available for all bindings.
 - A rejected encoder or cross-encoder input no longer kills the worker. Text longer than the context window used to end it, so every later `encode()` or `rank()` failed too. The error now reaches the caller and the worker stays usable. Available for all bindings.
 - **React Native:** Logs are now visible in Xcode on iOS.

--- a/nobodywho/core/src/errors.rs
+++ b/nobodywho/core/src/errors.rs
@@ -111,6 +111,9 @@ pub enum LoadModelError {
     ModelChannelError,
     #[error("Failed parsing model path: {0}")]
     FailedParsingModelPath(#[from] nom::Err<nom::error::Error<String>>),
+    #[error("Model download cancelled")]
+    #[diagnostic(code(nobodywho::download_cancelled))]
+    DownloadCancelled,
     #[error("Failed to download model: authentication required")]
     #[diagnostic(
         code(nobodywho::download_unauthorized),

--- a/nobodywho/core/src/huggingface.rs
+++ b/nobodywho/core/src/huggingface.rs
@@ -29,6 +29,18 @@ use tracing::{info, warn};
 /// synchronization (hence the `Sync` bound).
 pub type DownloadProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
 
+/// Callback checked between download chunks. Returning `true` stops the download.
+pub type DownloadCancellationCallback = Arc<dyn Fn() -> bool + Send + Sync>;
+
+fn check_download_cancellation(
+    cancellation: Option<&DownloadCancellationCallback>,
+) -> Result<(), LoadModelError> {
+    if cancellation.is_some_and(|is_cancelled| is_cancelled()) {
+        return Err(LoadModelError::DownloadCancelled);
+    }
+    Ok(())
+}
+
 /// Default terminal progress bar shown when the user doesn't pass their own callback,
 /// labeled with the last path segment of `path` — e.g. `"hf://owner/repo/model.gguf"`
 /// shows as `"model.gguf"`.
@@ -184,8 +196,10 @@ impl ModelCache {
         target_path: &Path,
         progress: &DownloadProgressCallback,
         headers: &[(String, String)],
+        cancellation: Option<&DownloadCancellationCallback>,
     ) -> Result<(), LoadModelError> {
         Self::validate_no_traversal(target_path)?;
+        check_download_cancellation(cancellation)?;
 
         if target_path.exists() {
             info!("Using cached file: {}", target_path.display());
@@ -206,6 +220,7 @@ impl ModelCache {
             &tmp_path,
             content_length,
             progress,
+            cancellation,
         )?;
 
         tmp_file
@@ -307,12 +322,14 @@ impl ModelCache {
         tmp_path: &Path,
         content_length: u64,
         progress: &DownloadProgressCallback,
+        cancellation: Option<&DownloadCancellationCallback>,
     ) -> Result<(), LoadModelError> {
         let mut downloaded: u64 = 0;
         let mut last_logged_pct: u64 = 0;
         let mut buf = vec![0u8; 256 * 1024];
 
         loop {
+            check_download_cancellation(cancellation)?;
             let n = reader
                 .read(&mut buf)
                 .map_err(|source| LoadModelError::ReadDownload {
@@ -330,6 +347,7 @@ impl ModelCache {
             downloaded += n as u64;
 
             progress(downloaded, content_length);
+            check_download_cancellation(cancellation)?;
 
             if let Some(pct) = (downloaded * 100).checked_div(content_length) {
                 if pct >= last_logged_pct + 5 {
@@ -421,6 +439,7 @@ impl ModelCache {
         source: &GgufSource,
         progress: &DownloadProgressCallback,
         headers: &[(String, String)],
+        cancellation: Option<&DownloadCancellationCallback>,
     ) -> Result<PathBuf, LoadModelError> {
         let (url, target) = match source {
             GgufSource::HuggingFace { repo, filename } => (
@@ -435,7 +454,7 @@ impl ModelCache {
             }
         };
 
-        self.fetch_to_path(&url, &target, progress, headers)?;
+        self.fetch_to_path(&url, &target, progress, headers, cancellation)?;
         Ok(target)
     }
 
@@ -524,7 +543,9 @@ pub(crate) fn download_gguf(
     parsed_path: ParsedModelPath,
     progress: &DownloadProgressCallback,
     headers: &[(String, String)],
+    cancellation: Option<&DownloadCancellationCallback>,
 ) -> Result<PathBuf, LoadModelError> {
+    check_download_cancellation(cancellation)?;
     let cache = ModelCache::open()?;
     let fs_model_path = match parsed_path {
         ParsedModelPath::HuggingFaceUrl(owner, repo, filename) => {
@@ -532,11 +553,11 @@ pub(crate) fn download_gguf(
                 repo: HfRepo::main(owner, repo),
                 filename,
             };
-            cache.download_file(&source, progress, headers)?
+            cache.download_file(&source, progress, headers, cancellation)?
         }
         ParsedModelPath::FilesystemPath(path) => path,
         ParsedModelPath::HttpUrl(url) => {
-            cache.download_file(&GgufSource::Url(url), progress, headers)?
+            cache.download_file(&GgufSource::Url(url), progress, headers, cancellation)?
         }
     };
 
@@ -754,7 +775,7 @@ impl ModelCache {
                 named(downloaded, total);
                 progress(downloaded, total);
             });
-            self.fetch_to_path(&url, &target, &file_progress, headers)
+            self.fetch_to_path(&url, &target, &file_progress, headers, None)
                 .map_err(|source| HuggingFaceError::DownloadEntry {
                     path: path.clone(),
                     source: Box::new(source),
@@ -852,6 +873,54 @@ pub(crate) fn download_onnx(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn cancelled_download_removes_partial_file() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let body = vec![0; 512 * 1024];
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(&body);
+        });
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("model.gguf");
+        let cache = ModelCache {
+            root: directory.path().to_path_buf(),
+        };
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let progress_cancelled = Arc::clone(&cancelled);
+        let progress: DownloadProgressCallback = Arc::new(move |_, _| {
+            progress_cancelled.store(true, Ordering::Relaxed);
+        });
+        let cancellation: DownloadCancellationCallback =
+            Arc::new(move || cancelled.load(Ordering::Relaxed));
+
+        let result = cache.fetch_to_path(
+            &format!("http://{address}/model.gguf"),
+            &target,
+            &progress,
+            &[],
+            Some(&cancellation),
+        );
+
+        assert!(matches!(result, Err(LoadModelError::DownloadCancelled)));
+        assert!(!target.exists());
+        assert!(std::fs::read_dir(directory.path())
+            .unwrap()
+            .all(|entry| !entry.unwrap().path().to_string_lossy().ends_with(".part")));
+        server.join().unwrap();
+    }
 
     #[test]
     fn parses_hf_scheme() {

--- a/nobodywho/core/src/llm.rs
+++ b/nobodywho/core/src/llm.rs
@@ -25,7 +25,7 @@ use tracing::{debug, error, info, info_span, warn};
 // `nobodywho::llm::*`. The implementations now live in `crate::huggingface`.
 pub use crate::huggingface::{
     default_progress_callback, get_cached_models, throttled_progress_callback,
-    DownloadProgressCallback,
+    DownloadCancellationCallback, DownloadProgressCallback,
 };
 
 #[derive(Debug)]
@@ -122,6 +122,25 @@ pub fn get_model(
     draft_model_path: Option<&str>,
     progress: Option<DownloadProgressCallback>,
 ) -> Result<Model, LoadModelError> {
+    get_model_cancellable(
+        model_path,
+        use_gpu_if_available,
+        mmproj_path,
+        draft_model_path,
+        progress,
+        None,
+    )
+}
+
+#[tracing::instrument(level = "info", skip(progress, cancellation))]
+pub fn get_model_cancellable(
+    model_path: &str,
+    use_gpu_if_available: bool,
+    mmproj_path: Option<&str>,
+    draft_model_path: Option<&str>,
+    progress: Option<DownloadProgressCallback>,
+    cancellation: Option<DownloadCancellationCallback>,
+) -> Result<Model, LoadModelError> {
     if model_path == "auto" && mmproj_path.is_some() {
         return Err(LoadModelError::InvalidModel(
             "Automatic model selection does not support projection models; pass an explicit multimodal model path"
@@ -134,13 +153,23 @@ pub fn get_model(
     let model_progress = progress
         .clone()
         .unwrap_or_else(|| default_progress_callback(model_path));
-    let real_model_path = download_gguf(parse_model_path(model_path)?, &model_progress, &[])?;
+    let real_model_path = download_gguf(
+        parse_model_path(model_path)?,
+        &model_progress,
+        &[],
+        cancellation.as_ref(),
+    )?;
     let real_mmproj_path = match mmproj_path {
         Some(p) => {
             let mmproj_progress = progress
                 .clone()
                 .unwrap_or_else(|| default_progress_callback(p));
-            Some(download_gguf(parse_model_path(p)?, &mmproj_progress, &[])?)
+            Some(download_gguf(
+                parse_model_path(p)?,
+                &mmproj_progress,
+                &[],
+                cancellation.as_ref(),
+            )?)
         }
         None => None,
     };
@@ -149,7 +178,12 @@ pub fn get_model(
             let draft_progress = progress
                 .clone()
                 .unwrap_or_else(|| default_progress_callback(p));
-            Some(download_gguf(parse_model_path(p)?, &draft_progress, &[])?)
+            Some(download_gguf(
+                parse_model_path(p)?,
+                &draft_progress,
+                &[],
+                cancellation.as_ref(),
+            )?)
         }
         None => None,
     };
@@ -268,8 +302,22 @@ pub fn download_model(
     headers: Vec<(String, String)>,
     progress: Option<DownloadProgressCallback>,
 ) -> Result<std::path::PathBuf, LoadModelError> {
+    download_model_cancellable(model_path, headers, progress, None)
+}
+
+pub fn download_model_cancellable(
+    model_path: &str,
+    headers: Vec<(String, String)>,
+    progress: Option<DownloadProgressCallback>,
+    cancellation: Option<DownloadCancellationCallback>,
+) -> Result<std::path::PathBuf, LoadModelError> {
     let progress = progress.unwrap_or_else(|| default_progress_callback(model_path));
-    download_gguf(parse_model_path(model_path)?, &progress, &headers)
+    download_gguf(
+        parse_model_path(model_path)?,
+        &progress,
+        &headers,
+        cancellation.as_ref(),
+    )
 }
 
 fn read_add_bos_metadata(model: &LlamaModel) -> Result<AddBos, InitWorkerError> {

--- a/nobodywho/python/src/lib.rs
+++ b/nobodywho/python/src/lib.rs
@@ -1,7 +1,8 @@
+use pyo3::exceptions::PyKeyboardInterrupt;
 use pyo3::prelude::*;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use nobodywho::render_miette;
@@ -41,22 +42,91 @@ pub struct Model {
     model: Arc<nobodywho::llm::Model>,
 }
 
-/// Wrap a Python `on_download_progress` argument into a core `DownloadProgressCallback`.
-///
-/// - `Some(py_callable)` → wraps it so the Python function is invoked on each chunk
-///   with `(downloaded_bytes, total_bytes)`. Exceptions are printed and swallowed.
-/// - `None` → returns `None`; core installs its own default terminal progress bar.
-///
-/// Returns `TypeError` if `py_callback` is not callable, so a non-callable argument
-/// fails fast at construction rather than per-chunk during download.
+struct PythonDownloadContext {
+    cancelled: Arc<AtomicBool>,
+    signal_error: Arc<Mutex<Option<PyErr>>>,
+}
+
+impl PythonDownloadContext {
+    fn new() -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            signal_error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn cancellation_callback(&self) -> nobodywho::llm::DownloadCancellationCallback {
+        let cancelled = Arc::clone(&self.cancelled);
+        let signal_error = Arc::clone(&self.signal_error);
+        Arc::new(move || {
+            if cancelled.load(Ordering::Relaxed) {
+                return true;
+            }
+            Python::attach(|py| match py.check_signals() {
+                Ok(()) => false,
+                Err(error) => {
+                    *signal_error.lock().expect("signal error mutex poisoned") = Some(error);
+                    cancelled.store(true, Ordering::Relaxed);
+                    true
+                }
+            })
+        })
+    }
+
+    fn finish<T>(&self, result: Result<T, nobodywho::errors::LoadModelError>) -> PyResult<T> {
+        if let Some(error) = self
+            .signal_error
+            .lock()
+            .expect("signal error mutex poisoned")
+            .take()
+        {
+            return Err(error);
+        }
+        Python::attach(|py| py.check_signals())?;
+        result.map_err(err)
+    }
+
+    fn resolve_progress(
+        &self,
+        py_callback: Option<Py<PyAny>>,
+    ) -> PyResult<Option<nobodywho::llm::DownloadProgressCallback>> {
+        let Some(callback) = py_callback else {
+            return Ok(None);
+        };
+        Python::attach(|py| {
+            if !callback.bind(py).is_callable() {
+                return Err(pyo3::exceptions::PyTypeError::new_err(
+                    "on_download_progress must be callable, taking (downloaded_bytes, total_bytes)",
+                ));
+            }
+            Ok(())
+        })?;
+
+        let cancelled = Arc::clone(&self.cancelled);
+        let signal_error = Arc::clone(&self.signal_error);
+        Ok(Some(Arc::new(move |downloaded: u64, total: u64| {
+            Python::attach(|py| {
+                if let Err(error) = callback.call1(py, (downloaded, total)) {
+                    if error.is_instance_of::<PyKeyboardInterrupt>(py) {
+                        *signal_error.lock().expect("signal error mutex poisoned") = Some(error);
+                        cancelled.store(true, Ordering::Relaxed);
+                    } else {
+                        error.print(py);
+                    }
+                }
+            });
+        }) as nobodywho::llm::DownloadProgressCallback))
+    }
+}
+
 fn resolve_on_download_progress(
     py_callback: Option<Py<PyAny>>,
 ) -> PyResult<Option<nobodywho::llm::DownloadProgressCallback>> {
-    let Some(cb) = py_callback else {
+    let Some(callback) = py_callback else {
         return Ok(None);
     };
     Python::attach(|py| {
-        if !cb.bind(py).is_callable() {
+        if !callback.bind(py).is_callable() {
             return Err(pyo3::exceptions::PyTypeError::new_err(
                 "on_download_progress must be callable, taking (downloaded_bytes, total_bytes)",
             ));
@@ -65,8 +135,8 @@ fn resolve_on_download_progress(
     })?;
     Ok(Some(Arc::new(move |downloaded: u64, total: u64| {
         Python::attach(|py| {
-            if let Err(e) = cb.call1(py, (downloaded, total)) {
-                e.print(py);
+            if let Err(error) = callback.call1(py, (downloaded, total)) {
+                error.print(py);
             }
         });
     }) as nobodywho::llm::DownloadProgressCallback))
@@ -125,20 +195,19 @@ impl Model {
                 })
             })
             .transpose()?;
-        let progress = resolve_on_download_progress(on_download_progress)?;
-        let model_result = nobodywho::llm::get_model(
+        let download = PythonDownloadContext::new();
+        let progress = download.resolve_progress(on_download_progress)?;
+        let model = download.finish(nobodywho::llm::get_model_cancellable(
             path_str,
             use_gpu_if_available,
             mmproj_str,
             draft_str,
             progress,
-        );
-        match model_result {
-            Ok(model) => Ok(Self {
-                model: Arc::new(model),
-            }),
-            Err(e) => Err(err(e)),
-        }
+            Some(download.cancellation_callback()),
+        ))?;
+        Ok(Self {
+            model: Arc::new(model),
+        })
     }
 
     /// Asynchronously load a model from a GGUF file.
@@ -243,8 +312,16 @@ impl<'py> ModelOrPath<'py> {
                         path.display()
                     ))
                 })?;
-                nobodywho::llm::get_model(path_str, true, None, None, None)
-                    .map_err(err)
+                let download = PythonDownloadContext::new();
+                download
+                    .finish(nobodywho::llm::get_model_cancellable(
+                        path_str,
+                        true,
+                        None,
+                        None,
+                        None,
+                        Some(download.cancellation_callback()),
+                    ))
                     .map(Arc::new)
             }
         }
@@ -2284,8 +2361,14 @@ fn download_model(
         ))
     })?;
     let headers_vec: Vec<(String, String)> = headers.unwrap_or_default().into_iter().collect();
-    let progress = resolve_on_download_progress(on_download_progress)?;
-    nobodywho::llm::download_model(path_str, headers_vec, progress).map_err(err)
+    let download = PythonDownloadContext::new();
+    let progress = download.resolve_progress(on_download_progress)?;
+    download.finish(nobodywho::llm::download_model_cancellable(
+        path_str,
+        headers_vec,
+        progress,
+        Some(download.cancellation_callback()),
+    ))
 }
 
 /// `SamplerConfig` contains the configuration for a token sampler. The mechanism by which

--- a/nobodywho/python/tests/test_model_downloading.py
+++ b/nobodywho/python/tests/test_model_downloading.py
@@ -1,7 +1,15 @@
 """Tests for model downloading via the hf:// prefix."""
 
-import pytest
+import http.server
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
 import nobodywho
+import pytest
 
 # The model used for all download tests.
 # This translates to: https://huggingface.co/NobodyWho/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf
@@ -101,6 +109,67 @@ def test_hf_invalid_format_gives_parse_error():
     """
     with pytest.raises(RuntimeError, match="Failed parsing model path"):
         nobodywho.Model(HF_INVALID_ID)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX SIGINT semantics")
+def test_ctrl_c_cancels_download_and_removes_partial_file(tmp_path):
+    download_started = threading.Event()
+
+    class SlowDownloadHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(16 * 1024 * 1024))
+            self.end_headers()
+            for _ in range(256):
+                try:
+                    self.wfile.write(bytes(64 * 1024))
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+                download_started.set()
+                time.sleep(0.01)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SlowDownloadHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    url = f"http://127.0.0.1:{server.server_port}/model.gguf"
+    script = """
+import sys
+from nobodywho import download_model
+
+try:
+    download_model(sys.argv[1])
+except KeyboardInterrupt:
+    raise SystemExit(42)
+except BaseException as error:
+    print(repr(error), file=sys.stderr)
+    raise SystemExit(1)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, url],
+        env={**os.environ, "XDG_CACHE_HOME": str(tmp_path)},
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        assert download_started.wait(timeout=5)
+        process.send_signal(signal.SIGINT)
+        _, stderr = process.communicate(timeout=5)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+    assert process.returncode == 42, stderr
+    assert not list(tmp_path.rglob("*.part"))
+    assert not list(tmp_path.rglob("*.gguf"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Cancel synchronous Python GGUF downloads when Ctrl+C is pressed and preserve `KeyboardInterrupt`.
- Remove incomplete temporary files and cover `Model`, `download_model`, and model-path consumers.
- Add local HTTP regression tests for cancellation and cleanup.
- Add the Python changelog entry and changelog guidance for agents.
- Checks: Rust formatting and compile checks, plus Ruff formatting and linting.