### PR TITLE
Simplify model loading in tests

### DIFF
--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2777,34 +2777,15 @@ mod tests {
     /// env vars are set to existing files.
     #[test]
     fn test_mtp_gemma4_smoke() -> Result<(), Box<dyn std::error::Error>> {
-        // test_utils::init_test_tracing();
-        let (Some(target_path), Some(draft_path)) = (
-            test_utils::test_mtp_target_model_path(),
-            test_utils::test_mtp_draft_model_path(),
-        ) else {
+        test_utils::init_test_tracing();
+
+        let Some(model) = test_utils::load_mtp_models() else {
             eprintln!(
                 "skipping test_mtp_gemma4_smoke: \
                  set TEST_MTP_TARGET_MODEL and TEST_MTP_DRAFT_MODEL to enable"
             );
             return Ok(());
         };
-        if !std::path::Path::new(&target_path).exists()
-            || !std::path::Path::new(&draft_path).exists()
-        {
-            eprintln!(
-                "skipping test_mtp_gemma4_smoke: file missing at {} or {}",
-                target_path, draft_path
-            );
-            return Ok(());
-        }
-
-        let model = Arc::new(crate::llm::get_model(
-            &target_path,
-            true,
-            None,
-            Some(&draft_path),
-            None,
-        )?);
 
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -4333,10 +4314,8 @@ mod tests {
     #[test]
     fn test_set_chat_history_reloads_media() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
-        let (Ok(vision_path), Ok(mmproj_path)) = (
-            std::env::var("TEST_VISION_MODEL"),
-            std::env::var("TEST_MMPROJ_MODEL"),
-        ) else {
+
+        let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_set_chat_history_reloads_media: \
                  set TEST_VISION_MODEL and TEST_MMPROJ_MODEL to enable"
@@ -4344,13 +4323,6 @@ mod tests {
             return Ok(());
         };
 
-        let model = Arc::new(llm::get_model(
-            &vision_path,
-            true,
-            Some(&mmproj_path),
-            None,
-            None,
-        )?);
         let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
@@ -4386,10 +4358,8 @@ mod tests {
     #[test]
     fn test_complete_with_content_parts_from_json() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
-        let (Ok(vision_path), Ok(mmproj_path)) = (
-            std::env::var("TEST_VISION_MODEL"),
-            std::env::var("TEST_MMPROJ_MODEL"),
-        ) else {
+
+        let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_complete_with_content_parts_from_json: \
                  set TEST_VISION_MODEL and TEST_MMPROJ_MODEL to enable"
@@ -4397,13 +4367,6 @@ mod tests {
             return Ok(());
         };
 
-        let model = Arc::new(llm::get_model(
-            &vision_path,
-            true,
-            Some(&mmproj_path),
-            None,
-            None,
-        )?);
         let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
@@ -4469,10 +4432,8 @@ mod tests {
     #[test]
     fn test_complete_reloads_media_from_part_paths() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
-        let (Ok(vision_path), Ok(mmproj_path)) = (
-            std::env::var("TEST_VISION_MODEL"),
-            std::env::var("TEST_MMPROJ_MODEL"),
-        ) else {
+
+        let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_complete_reloads_media_from_part_paths: \
                  set TEST_VISION_MODEL and TEST_MMPROJ_MODEL to enable"
@@ -4480,13 +4441,6 @@ mod tests {
             return Ok(());
         };
 
-        let model = Arc::new(llm::get_model(
-            &vision_path,
-            true,
-            Some(&mmproj_path),
-            None,
-            None,
-        )?);
         let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {
@@ -4574,10 +4528,8 @@ mod tests {
     #[test]
     fn test_reload_media_covers_every_non_system_role() -> Result<(), Box<dyn std::error::Error>> {
         test_utils::init_test_tracing();
-        let (Ok(vision_path), Ok(mmproj_path)) = (
-            std::env::var("TEST_VISION_MODEL"),
-            std::env::var("TEST_MMPROJ_MODEL"),
-        ) else {
+
+        let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_reload_media_covers_every_non_system_role: \
                  set TEST_VISION_MODEL and TEST_MMPROJ_MODEL to enable"
@@ -4585,13 +4537,6 @@ mod tests {
             return Ok(());
         };
 
-        let model = Arc::new(llm::get_model(
-            &vision_path,
-            true,
-            Some(&mmproj_path),
-            None,
-            None,
-        )?);
         let mut worker = Chat::new_chat_worker(
             &model,
             ChatConfig {

--- a/nobodywho/core/src/chat.rs
+++ b/nobodywho/core/src/chat.rs
@@ -2736,7 +2736,6 @@ mod tests {
 
     #[test]
     fn test_chat_worker() -> Result<(), Box<dyn std::error::Error>> {
-        // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         let mut worker = Chat::new_chat_worker(
@@ -2777,8 +2776,6 @@ mod tests {
     /// env vars are set to existing files.
     #[test]
     fn test_mtp_gemma4_smoke() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
-
         let Some(model) = test_utils::load_mtp_models() else {
             eprintln!(
                 "skipping test_mtp_gemma4_smoke: \
@@ -2814,7 +2811,6 @@ mod tests {
 
     #[test]
     fn test_reset_chat() -> Result<(), Box<dyn std::error::Error>> {
-        // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -2856,7 +2852,6 @@ mod tests {
 
     #[test]
     fn test_stop_mid_write() -> Result<(), Box<dyn std::error::Error>> {
-        // test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -2968,7 +2963,6 @@ mod tests {
     #[test]
     #[ignore = "manual perf benchmark — run with `cargo test bench_pre_built_sampler_amortization -- --ignored --nocapture`"]
     fn bench_pre_built_sampler_amortization() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let setup_start = std::time::Instant::now();
         let mut worker = Chat::new_chat_worker(
@@ -3028,7 +3022,6 @@ mod tests {
     #[test]
     #[ignore = "manual perf benchmark — run with `cargo test bench_tool_grammar_rebuild -- --ignored --nocapture`"]
     fn bench_tool_grammar_rebuild() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         let setup_start = std::time::Instant::now();
@@ -3065,7 +3058,6 @@ mod tests {
     /// drive a real tool call, so exercise one on each side of the change.
     #[test]
     fn tool_calling_survives_a_sampler_config_change() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -3110,7 +3102,6 @@ mod tests {
 
     #[test]
     fn test_tool_chat() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -3147,7 +3138,6 @@ mod tests {
 
     #[test]
     fn test_multi_tool_call() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let mut worker = Chat::new_chat_worker(
             &model,
@@ -3221,7 +3211,6 @@ mod tests {
 
     #[test]
     fn test_context_shift() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         // Use a very small context size to force shifting
@@ -3498,7 +3487,6 @@ mod tests {
 
     #[test]
     fn test_context_shift_with_tool_calls() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         // Use a very small context size to force shifting
@@ -3606,7 +3594,6 @@ mod tests {
 
     #[test]
     fn test_context_shift_on_say() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         let n_messages = 14;
@@ -3684,7 +3671,6 @@ mod tests {
 
     #[test]
     fn test_context_while_writing() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         let n_messages = 19;
@@ -3761,7 +3747,6 @@ mod tests {
 
     #[test]
     fn test_chat_worker_multiple_contexts() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         // Create two separate chat handles that will run in parallel
@@ -3810,7 +3795,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_enable_thinking() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .build_async()
@@ -3844,7 +3828,6 @@ mod tests {
 
     #[test]
     fn test_greedy_sampler_produces_deterministic_output() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
 
         let chat = ChatBuilder::new(model)
@@ -3871,7 +3854,6 @@ mod tests {
 
     #[test]
     fn test_reset_chat_with_no_system_prompt() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)
@@ -3900,7 +3882,6 @@ mod tests {
     /// The supplied messages become the history, and the reply is appended to them.
     #[test]
     fn test_complete_replaces_history() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)
@@ -3940,7 +3921,6 @@ mod tests {
     /// leave out is kept — so a later `complete` need not repeat them.
     #[test]
     fn test_complete_options_stick() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)
@@ -3987,7 +3967,6 @@ mod tests {
     /// without one keeps the prompt the chat already had.
     #[test]
     fn test_complete_replaces_system_prompt() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)
@@ -4034,7 +4013,6 @@ mod tests {
 
     #[test]
     fn test_ask_after_complete_continues_completion() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)
@@ -4074,7 +4052,6 @@ mod tests {
 
     #[test]
     fn test_complete_with_tools() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(4096)
@@ -4105,7 +4082,6 @@ mod tests {
     /// that cannot produce a grammar leaves the sampler config alone too.
     #[test]
     fn apply_options_is_atomic_on_failure() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(512)
@@ -4313,8 +4289,6 @@ mod tests {
     /// to be re-registered from the part paths.
     #[test]
     fn test_set_chat_history_reloads_media() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
-
         let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_set_chat_history_reloads_media: \
@@ -4357,8 +4331,6 @@ mod tests {
     /// of parts, with an image interleaved between two runs of text.
     #[test]
     fn test_complete_with_content_parts_from_json() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
-
         let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_complete_with_content_parts_from_json: \
@@ -4431,8 +4403,6 @@ mod tests {
     /// mean nothing to this worker.
     #[test]
     fn test_complete_reloads_media_from_part_paths() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
-
         let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_complete_reloads_media_from_part_paths: \
@@ -4527,8 +4497,6 @@ mod tests {
     /// An unregistered part would flatten to a marker with no bitmap behind it.
     #[test]
     fn test_reload_media_covers_every_non_system_role() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
-
         let Some(model) = test_utils::load_mtmd_models() else {
             eprintln!(
                 "skipping test_reload_media_covers_every_non_system_role: \
@@ -4603,7 +4571,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_complete_async() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_test_model();
         let chat = ChatBuilder::new(model)
             .with_context_size(2048)

--- a/nobodywho/core/src/crossencoder.rs
+++ b/nobodywho/core/src/crossencoder.rs
@@ -204,7 +204,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_crossencoder_async() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
         let handle: CrossEncoderAsync = CrossEncoderAsync::new(model, 4096);
 
@@ -246,7 +245,6 @@ mod tests {
     #[test]
     fn test_crossencoder_batch_matches_individual_scores() -> Result<(), Box<dyn std::error::Error>>
     {
-        test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
         let encoder = CrossEncoder::new(model, 48);
         let query = "What is the capital of France?".to_string();
@@ -337,7 +335,6 @@ mod tests {
 
     #[test]
     fn test_crossencoder_sync() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
         let encoder = CrossEncoder::new(model, 4096);
 
@@ -376,7 +373,6 @@ mod tests {
 
     #[test]
     fn test_oversized_input_keeps_crossencoder_alive() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_crossencoder_model();
         let crossencoder = CrossEncoder::new(model, 64);
 

--- a/nobodywho/core/src/encoder.rs
+++ b/nobodywho/core/src/encoder.rs
@@ -163,7 +163,6 @@ mod tests {
     use crate::test_utils;
     #[test]
     fn test_encoder_sync() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
         let encoder = Encoder::new(model, 1024);
 
@@ -204,7 +203,6 @@ mod tests {
 
     #[test]
     fn test_encoder_worker_direct() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
 
         let mut worker = Worker::new_encoder_worker(&model, 1024)?;
@@ -250,7 +248,6 @@ mod tests {
     #[test]
     fn test_encoder_batch_matches_individual_embeddings() -> Result<(), Box<dyn std::error::Error>>
     {
-        test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
         let encoder = Encoder::new(model, 20);
         let texts = vec![
@@ -278,7 +275,6 @@ mod tests {
 
     #[test]
     fn test_deterministic_encoder() -> Result<(), Box<dyn std::error::Error>> {
-        test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
         let encoder = Encoder::new(model, 1024);
 
@@ -298,7 +294,6 @@ mod tests {
 
     #[test]
     fn test_oversized_input_keeps_encoder_alive() {
-        test_utils::init_test_tracing();
         let model = test_utils::load_embeddings_model();
         let encoder = Encoder::new(model, 64);
 

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -45,7 +45,7 @@ pub fn send_llamacpp_logs_to_tracing() {
 }
 
 #[cfg(test)]
-pub mod test_utils {
+pub(crate) mod test_utils {
     use crate::llm::{get_model, Model};
     use crate::send_llamacpp_logs_to_tracing;
     use std::sync::{Arc, Once};
@@ -53,7 +53,7 @@ pub mod test_utils {
     static INIT: Once = Once::new();
 
     /// Initialize tracing for tests
-    pub fn init_test_tracing() {
+    pub(crate) fn init_test_tracing() {
         INIT.call_once(|| {
             send_llamacpp_logs_to_tracing();
 
@@ -66,55 +66,19 @@ pub mod test_utils {
         });
     }
 
-    /// Get path to test model from TEST_MODEL env var or default to "model.gguf"
-    pub fn test_model_path() -> String {
-        std::env::var("TEST_MODEL").unwrap_or_else(|_| "model.gguf".to_string())
-    }
-
-    /// Get path to test embeddings model from TEST_EMBEDDINGS_MODEL env var
-    pub fn test_embeddings_model_path() -> String {
-        std::env::var("TEST_EMBEDDINGS_MODEL").unwrap_or_else(|_| "embeddings.gguf".to_string())
-    }
-
-    /// Get path to test crossencoder model from TEST_CROSSENCODER_MODEL env var
-    pub fn test_crossencoder_model_path() -> String {
-        std::env::var("TEST_CROSSENCODER_MODEL").unwrap_or_else(|_| "crossencoder.gguf".to_string())
-    }
-
-    /// Get path to test multimodal projector from TEST_MMPROJ env var
-    pub fn test_mmproj_path() -> String {
-        std::env::var("TEST_MMPROJ").unwrap_or_else(|_| "mmproj.gguf".to_string())
-    }
-
-    /// Get path to test vision model from TEST_VISION_MODEL env var
-    pub fn test_vision_model_path() -> String {
-        std::env::var("TEST_VISION_MODEL").unwrap_or_else(|_| "vision-model.gguf".to_string())
-    }
-
-    /// Get path to MTP target model from TEST_MTP_TARGET_MODEL env var
-    pub fn test_mtp_target_model_path() -> Option<String> {
-        std::env::var("TEST_MTP_TARGET_MODEL").ok()
-    }
-
-    /// Get path to MTP draft (heads-only) model from
-    /// TEST_MTP_DRAFT_MODEL env var, or `None` if unset. See
-    /// [`test_mtp_target_model_path`].
-    pub fn test_mtp_draft_model_path() -> Option<String> {
-        std::env::var("TEST_MTP_DRAFT_MODEL").ok()
-    }
-
     /// Load the test model with GPU acceleration if available
-    pub fn load_test_model() -> Arc<Model> {
-        let path = test_model_path();
+    pub(crate) fn load_test_model() -> Arc<Model> {
+        let path = std::env::var("TEST_MODEL").unwrap_or_else(|_| "model.gguf".to_string());
         Arc::new(
             get_model(&path, true, None, None, None)
-                .unwrap_or_else(|e| panic!("Failed to load test model from {}: {:?}", path, e)),
+                .unwrap_or_else(|e| panic!("failed to load test model from {path}: {e}")),
         )
     }
 
     /// Load the embeddings model with GPU acceleration if available
-    pub fn load_embeddings_model() -> Arc<Model> {
-        let path = test_embeddings_model_path();
+    pub(crate) fn load_embeddings_model() -> Arc<Model> {
+        let path = std::env::var("TEST_EMBEDDINGS_MODEL")
+            .unwrap_or_else(|_| "embeddings.gguf".to_string());
         // XXX: loading the embeddings model for unit tests without GPU offloading
         //      because it otherwise caused a segfault specifically with the llvmpipe vulkan driver.
         //      (which is used in the nix sandbox, since we don't have access to the host GPU)
@@ -122,20 +86,60 @@ pub mod test_utils {
         //      this segfault doesn't happen on nobodywho commit 94d51c5.
         //      it's most likely related to an upstream change in llama.cpp
         Arc::new(
-            get_model(&path, false, None, None, None).unwrap_or_else(|e| {
-                panic!("Failed to load embeddings model from {}: {:?}", path, e)
-            }),
+            get_model(&path, false, None, None, None)
+                .unwrap_or_else(|e| panic!("failed to load embeddings model from {path}: {e}")),
         )
     }
 
     /// Load the crossencoder model with GPU acceleration if available
-    pub fn load_crossencoder_model() -> Arc<Model> {
-        let path = test_crossencoder_model_path();
+    pub(crate) fn load_crossencoder_model() -> Arc<Model> {
+        let path = std::env::var("TEST_CROSSENCODER_MODEL")
+            .unwrap_or_else(|_| "crossencoder.gguf".to_string());
         // Same GPU offloading note as embeddings model
         Arc::new(
-            get_model(&path, false, None, None, None).unwrap_or_else(|e| {
-                panic!("Failed to load crossencoder model from {}: {:?}", path, e)
-            }),
+            get_model(&path, false, None, None, None)
+                .unwrap_or_else(|e| panic!("failed to load crossencoder model from {path}: {e}")),
         )
+    }
+
+    /// Load the MTP draft and target models.
+    pub(crate) fn load_mtp_models() -> Option<Arc<Model>> {
+        let target_path = std::env::var("TEST_MTP_TARGET_MODEL").ok()?;
+        let draft_path = std::env::var("TEST_MTP_DRAFT_MODEL")
+            .expect("should have TEST_MTP_DRAFT_MODEL if TEST_MTP_TARGET_MODEL is set");
+
+        Some(Arc::new(
+            get_model(&target_path, true, None, Some(&draft_path), None).unwrap_or_else(|e| {
+                panic!("failed to load MTP models from {target_path} and {draft_path}: {e}")
+            }),
+        ))
+    }
+
+    pub(crate) fn load_mtmd_models() -> Option<Arc<Model>> {
+        let vision_path = std::env::var("TEST_VISION_MODEL").ok()?;
+        let mmproj_path = std::env::var("TEST_MMPROJ_MODEL")
+            .expect("should have TEST_MMPROJ_MODEL if TEST_VISION_MODEL is set");
+
+        Some(Arc::new(
+            get_model(&vision_path, true, Some(&mmproj_path), None, None).unwrap_or_else(|e| {
+                panic!("failed to load vision models from {vision_path} and {mmproj_path}: {e}")
+            }),
+        ))
+    }
+
+    pub(crate) fn gemma4_model() -> Option<Arc<Model>> {
+        let path = std::env::var("GEMMA4_MODEL").ok()?;
+        Some(Arc::new(
+            get_model(&path, true, None, None, None)
+                .unwrap_or_else(|e| panic!("failed to load Gemma4 model from {path}: {e}")),
+        ))
+    }
+
+    pub(crate) fn qwen36_model() -> Option<Arc<Model>> {
+        let path = std::env::var("QWEN36_MODEL").ok()?;
+        Some(Arc::new(
+            get_model(&path, false, None, None, None)
+                .unwrap_or_else(|e| panic!("failed to load Qwen3.6 model from {path}: {e}")),
+        ))
     }
 }

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -58,7 +58,7 @@ pub(crate) mod test_utils {
             send_llamacpp_logs_to_tracing();
 
             tracing_subscriber::fmt()
-                .with_max_level(tracing::Level::INFO)
+                .with_max_level(tracing::Level::TRACE)
                 .with_timer(tracing_subscriber::fmt::time::uptime())
                 .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
                 .with_test_writer()

--- a/nobodywho/core/src/lib.rs
+++ b/nobodywho/core/src/lib.rs
@@ -68,6 +68,8 @@ pub(crate) mod test_utils {
 
     /// Load the test model with GPU acceleration if available
     pub(crate) fn load_test_model() -> Arc<Model> {
+        init_test_tracing();
+
         let path = std::env::var("TEST_MODEL").unwrap_or_else(|_| "model.gguf".to_string());
         Arc::new(
             get_model(&path, true, None, None, None)
@@ -77,6 +79,8 @@ pub(crate) mod test_utils {
 
     /// Load the embeddings model with GPU acceleration if available
     pub(crate) fn load_embeddings_model() -> Arc<Model> {
+        init_test_tracing();
+
         let path = std::env::var("TEST_EMBEDDINGS_MODEL")
             .unwrap_or_else(|_| "embeddings.gguf".to_string());
         // XXX: loading the embeddings model for unit tests without GPU offloading
@@ -93,6 +97,8 @@ pub(crate) mod test_utils {
 
     /// Load the crossencoder model with GPU acceleration if available
     pub(crate) fn load_crossencoder_model() -> Arc<Model> {
+        init_test_tracing();
+
         let path = std::env::var("TEST_CROSSENCODER_MODEL")
             .unwrap_or_else(|_| "crossencoder.gguf".to_string());
         // Same GPU offloading note as embeddings model
@@ -104,6 +110,8 @@ pub(crate) mod test_utils {
 
     /// Load the MTP draft and target models.
     pub(crate) fn load_mtp_models() -> Option<Arc<Model>> {
+        init_test_tracing();
+
         let target_path = std::env::var("TEST_MTP_TARGET_MODEL").ok()?;
         let draft_path = std::env::var("TEST_MTP_DRAFT_MODEL")
             .expect("should have TEST_MTP_DRAFT_MODEL if TEST_MTP_TARGET_MODEL is set");
@@ -116,6 +124,8 @@ pub(crate) mod test_utils {
     }
 
     pub(crate) fn load_mtmd_models() -> Option<Arc<Model>> {
+        init_test_tracing();
+
         let vision_path = std::env::var("TEST_VISION_MODEL").ok()?;
         let mmproj_path = std::env::var("TEST_MMPROJ_MODEL")
             .expect("should have TEST_MMPROJ_MODEL if TEST_VISION_MODEL is set");
@@ -128,6 +138,8 @@ pub(crate) mod test_utils {
     }
 
     pub(crate) fn gemma4_model() -> Option<Arc<Model>> {
+        init_test_tracing();
+
         let path = std::env::var("GEMMA4_MODEL").ok()?;
         Some(Arc::new(
             get_model(&path, true, None, None, None)
@@ -136,6 +148,8 @@ pub(crate) mod test_utils {
     }
 
     pub(crate) fn qwen36_model() -> Option<Arc<Model>> {
+        init_test_tracing();
+
         let path = std::env::var("QWEN36_MODEL").ok()?;
         Some(Arc::new(
             get_model(&path, false, None, None, None)

--- a/nobodywho/core/src/sampler.rs
+++ b/nobodywho/core/src/sampler.rs
@@ -710,6 +710,8 @@ pub(crate) fn read_sampler_from_metadata(model: &LlamaModel) -> Option<SamplerCo
 
 #[cfg(test)]
 mod tests {
+    use crate::test_utils;
+
     use super::*;
     use std::sync::Arc;
 
@@ -743,8 +745,7 @@ mod tests {
 
     #[test]
     fn test_json_preset_builds_sampler() {
-        let path = std::env::var("TEST_MODEL").expect("set TEST_MODEL to a gguf path");
-        let model = crate::llm::get_model(&path, false, None, None, None).expect("load model");
+        let model = test_utils::load_test_model();
 
         let res = SamplerPresets::json().build_sampler(&model.language_model);
         assert!(res.is_ok(), "json preset failed: {:?}", res.err());
@@ -757,10 +758,7 @@ mod tests {
     /// first the literal is emitted regardless of the model.
     #[test]
     fn test_ordering_grammar_first_with_unlikely_literal() {
-        let path = std::env::var("TEST_MODEL").expect("set TEST_MODEL to a gguf path");
-        let model = std::sync::Arc::new(
-            crate::llm::get_model(&path, false, None, None, None).expect("load model"),
-        );
+        let model = test_utils::load_test_model();
 
         let cfg = SamplerConfig::new(
             vec![
@@ -794,10 +792,7 @@ mod tests {
     /// the process during generation.
     #[test]
     fn test_json_preset_full_generation() {
-        let path = std::env::var("TEST_MODEL").expect("set TEST_MODEL to a gguf path");
-        let model = std::sync::Arc::new(
-            crate::llm::get_model(&path, false, None, None, None).expect("load model"),
-        );
+        let model = test_utils::load_test_model();
 
         let chat = crate::chat::ChatBuilder::new(model)
             .build()
@@ -849,10 +844,7 @@ mod tests {
     /// chaining the constraint last must not put it after the truncation step.
     #[test]
     fn test_builder_constraint_survives_top_k_one() {
-        let path = std::env::var("TEST_MODEL").expect("set TEST_MODEL to a gguf path");
-        let model = std::sync::Arc::new(
-            crate::llm::get_model(&path, false, None, None, None).expect("load model"),
-        );
+        let model = test_utils::load_test_model();
 
         let cfg = SamplerBuilder::new()
             .shift(ShiftStep::TopK { top_k: 1 })

--- a/nobodywho/core/src/tool_calling/mod.rs
+++ b/nobodywho/core/src/tool_calling/mod.rs
@@ -554,6 +554,8 @@ pub fn detect_tool_format(model: &LlamaModel) -> Result<ToolFormat, ToolFormatEr
 
 #[cfg(test)]
 mod tests {
+    use crate::test_utils;
+
     use super::*;
     use serde_json::json;
     use std::sync::Arc;
@@ -904,12 +906,10 @@ mod tests {
     /// Requires a Gemma4 GGUF — set `GEMMA4_MODEL`; skipped otherwise.
     #[test]
     fn gemma4_string_value_allows_left_angle_bracket() {
-        let Ok(path) = std::env::var("GEMMA4_MODEL") else {
+        let Some(model) = test_utils::gemma4_model() else {
             eprintln!("skipping: set GEMMA4_MODEL to a Gemma4 GGUF to run this test");
             return;
         };
-        let model = crate::llm::get_model(&path, true, None, None, None)
-            .unwrap_or_else(|e| panic!("failed to load Gemma4 model from {path}: {e:?}"));
         let grammar = ToolFormat::Gemma4(Gemma4Handler)
             .to_lark(&[weather_tool()], Some(&model.language_model))
             .unwrap();
@@ -1035,10 +1035,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires QWEN36_MODEL env var pointing at a Qwen3.6 GGUF"]
     fn diagnose_qwen36_detection() {
-        let path = std::env::var("QWEN36_MODEL").expect("set QWEN36_MODEL");
-        let model = crate::llm::get_model(&path, false, None, None, None).expect("load model");
+        let Some(model) = test_utils::qwen36_model() else {
+            eprintln!("skipping: set QWEN36_MODEL");
+            return;
+        };
 
         let name = model
             .language_model


### PR DESCRIPTION
Actually only loading the models once is blocked by https://github.com/ggml-org/llama.cpp/pull/28395.