### PR TITLE
Fix `npmDepsHash`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
           pname = "react-native-jest";
           version = "0.0.0"; # nix derivation metadata only, does not need to match the npm package version
           src = ./nobodywho/react-native;
-          npmDepsHash = "sha256-+aiT6c9VJOqksavGCe3haY4MQ70Fc4gkQNlUeTl8H8c=";
+          npmDepsHash = "sha256-/i5YMkrIcpU+O5xrfe7a6UrMsTEG2Gnz2kujtyCGdgw=";
           dontNpmBuild = true;
           checkPhase = "npx jest";
           doCheck = true;


### PR DESCRIPTION
The Nix CI failed in https://github.com/nobodywho-ooo/nobodywho/pull/728, see [this failed run](https://github.com/nobodywho-ooo/nobodywho/actions/runs/34475870043/job/102866422442).

I didn't see that before I clicked the merge button (why is that possible? Grrr), so now our CI is borked. I think this fixes it.