### PR TITLE
godot: load the TTS worker on a plain thread instead of spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 - **React Native:** `STT` now takes a named options object. Replace `new STT(source, language, quantization)` with `new STT({ source, language, quantization })`.
 
+### Fixed
+
+- **Godot:** `NobodyWhoTts.synthesize()` no longer panics with "there is no reactor running" while loading the TTS worker. The model was loaded via `tokio::task::spawn_blocking`, which requires a Tokio runtime that gdext's executor does not provide; it now loads on a plain thread, like the STT node already did.
+
 ## [Python v1.6.0, Flutter v2.4.0, Godot v9.5.0, Kotlin v2.1.0, React Native v2.4.0, Swift v2.2.0] - 2026-07-13
 
 ### Added

--- a/nobodywho/godot/src/lib.rs
+++ b/nobodywho/godot/src/lib.rs
@@ -2287,11 +2287,17 @@ impl NobodyWhoTts {
             (config, device)
         };
 
-        let handle =
-            tokio::task::spawn_blocking(move || nobodywho::tts::Tts::with_device(config, device))
-                .await
-                .map_err(|e| GString::from(format!("TTS load task failed: {e}").as_str()))?
-                .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
+        // tokio::task::spawn_blocking requires an active Tokio runtime, but
+        // godot::task::spawn runs on gdext's own executor. Use a plain thread
+        // with a oneshot channel instead, like the STT node does.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(nobodywho::tts::Tts::with_device(config, device));
+        });
+        let handle = rx
+            .await
+            .map_err(|_| GString::from("TTS load thread panicked during model load"))?
+            .map_err(|e| GString::from(nobodywho::render_miette(&e).as_str()))?;
 
         let mut b = me.bind_mut();
         if let Some(existing) = &b.tts_handle {


### PR DESCRIPTION
Fixes #647

`NobodyWhoTts.synthesize()` runs on gdext's executor through `godot::task::spawn`, which has no Tokio runtime. Loading the TTS worker used `tokio::task::spawn_blocking`, which requires one, so calling `synthesize()` panicked with "there is no reactor running, must be called from the context of a Tokio 1.x runtime" and produced no audio. This is not hardware specific, despite the AMD report in the issue.

The STT node already hit this exact problem and solves it with a plain `std::thread` plus a oneshot channel, with a comment explaining why. This applies the same pattern to the TTS worker load path.

Reproduced and verified on Windows (Godot 4.7.2 headless, Intel GPU, so not AMD-specific):

- Before: `synthesize()` panics at `godot/src/lib.rs:2291` with "there is no reactor running ... Godot async task failed".
- After: no panic. With a valid model it loads and synthesizes; with an invalid path it returns a clean error through `worker_failed` instead of panicking.
